### PR TITLE
Add Global controls section with swing, clear, and steps

### DIFF
--- a/src/__tests__/GlobalControls.test.tsx
+++ b/src/__tests__/GlobalControls.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import GlobalControls from '../app/GlobalControls';
+
+// Mock SequencerContext
+const mockSetPatternLength = vi.fn();
+const mockSetSwing = vi.fn();
+const mockClearAll = vi.fn();
+
+vi.mock('../app/SequencerContext', () => ({
+  useSequencer: () => ({
+    state: {
+      patternLength: 16,
+      swing: 0,
+    },
+    actions: {
+      setPatternLength: mockSetPatternLength,
+      setSwing: mockSetSwing,
+      clearAll: mockClearAll,
+    },
+  }),
+}));
+
+describe('GlobalControls', () => {
+  it('renders steps dropdown', () => {
+    render(<GlobalControls />);
+    const select = screen.getByRole('combobox');
+    expect(select).toBeDefined();
+    expect(
+      (select as HTMLSelectElement).value
+    ).toBe('16');
+  });
+
+  it('renders swing knob', () => {
+    render(<GlobalControls />);
+    const knob = screen.getByRole('slider');
+    expect(knob).toBeDefined();
+  });
+
+  it('renders clear button', () => {
+    render(<GlobalControls />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDefined();
+  });
+
+  it('steps change calls setPatternLength', () => {
+    render(<GlobalControls />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, {
+      target: { value: '8' },
+    });
+    expect(mockSetPatternLength).toHaveBeenCalledWith(8);
+  });
+
+  it('clear button calls clearAll', () => {
+    render(<GlobalControls />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    expect(mockClearAll).toHaveBeenCalled();
+  });
+
+  it('swing knob calls setSwing', () => {
+    render(<GlobalControls />);
+    const knob = screen.getByRole('slider');
+    // Simulate keyboard interaction (ArrowUp)
+    fireEvent.keyDown(knob, { key: 'ArrowUp' });
+    expect(mockSetSwing).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -264,6 +264,28 @@ describe('setPatternLength track lengths', () => {
     }
   });
 
+  it('shrinking preserves shorter track step strings', () => {
+    const { result } = renderSequencer();
+    // Set bd to custom length 6
+    act(() => {
+      result.current.actions.setTrackLength('bd', 6);
+    });
+    expect(
+      result.current.meta.config.steps.bd.length
+    ).toBe(6);
+    // Shrink pattern from 16 to 10
+    act(() => {
+      result.current.actions.setPatternLength(10);
+    });
+    // bd should still have length 6 and 6-char step string
+    expect(
+      result.current.meta.config.trackLengths.bd
+    ).toBe(6);
+    expect(
+      result.current.meta.config.steps.bd.length
+    ).toBe(6);
+  });
+
   it('growing expands tracks that were at old max', () => {
     const { result } = renderSequencer();
     // Shrink to 8 (all tracks follow to 8)

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -248,6 +248,108 @@ describe('pattern state machine', () => {
 });
 
 // -------------------------------------------------------
+// E. clearAll and setSwing actions
+// -------------------------------------------------------
+describe('clearAll', () => {
+  it('sets all track steps to zeros', () => {
+    const { result } = renderSequencer();
+    // First set some steps active
+    act(() => {
+      result.current.actions.toggleStep('bd', 0);
+      result.current.actions.toggleStep('sd', 4);
+    });
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    for (const id of TRACK_IDS) {
+      const steps = result.current.meta.config.steps[id];
+      expect(steps).toMatch(/^0+$/);
+    }
+  });
+
+  it('resets swing to 0', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setSwing(50);
+    });
+    expect(result.current.meta.config.swing).toBe(50);
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    expect(result.current.meta.config.swing).toBe(0);
+  });
+
+  it('resets all track lengths to patternLength', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setTrackLength('bd', 5);
+      result.current.actions.setTrackLength('sd', 8);
+    });
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    const pl = result.current.state.patternLength;
+    for (const id of TRACK_IDS) {
+      expect(
+        result.current.meta.config.trackLengths[id]
+      ).toBe(pl);
+    }
+  });
+
+  it('sets pattern to custom', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('custom');
+  });
+});
+
+describe('setSwing', () => {
+  it('updates swing value', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setSwing(75);
+    });
+    expect(result.current.meta.config.swing).toBe(75);
+  });
+
+  it('clamps below 0', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setSwing(-10);
+    });
+    expect(result.current.meta.config.swing).toBe(0);
+  });
+
+  it('clamps above 100', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setSwing(150);
+    });
+    expect(result.current.meta.config.swing).toBe(100);
+  });
+
+  it('setPattern does not reset swing', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setSwing(60);
+    });
+    const preset = patternsData.patterns[1];
+    act(() => {
+      result.current.actions.setPattern({
+        id: preset.id,
+        name: preset.name,
+        steps: preset.steps as Record<TrackId, string>,
+      });
+    });
+    expect(result.current.meta.config.swing).toBe(60);
+  });
+});
+
+// -------------------------------------------------------
 // D. URL hash import
 // -------------------------------------------------------
 describe('URL hash import', () => {

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -248,7 +248,51 @@ describe('pattern state machine', () => {
 });
 
 // -------------------------------------------------------
-// E. clearAll and setSwing actions
+// E. setPatternLength track length behavior
+// -------------------------------------------------------
+describe('setPatternLength track lengths', () => {
+  it('shrinking clamps tracks exceeding new length', () => {
+    const { result } = renderSequencer();
+    // Default: all tracks at 16
+    act(() => {
+      result.current.actions.setPatternLength(8);
+    });
+    for (const id of TRACK_IDS) {
+      expect(
+        result.current.meta.config.trackLengths[id]
+      ).toBe(8);
+    }
+  });
+
+  it('growing expands tracks that were at old max', () => {
+    const { result } = renderSequencer();
+    // Shrink to 8 (all tracks follow to 8)
+    act(() => {
+      result.current.actions.setPatternLength(8);
+    });
+    // Set bd to a custom shorter length
+    act(() => {
+      result.current.actions.setTrackLength('bd', 5);
+    });
+    // Grow back to 12 — tracks at 8 (old max) should
+    // expand to 12, but bd at 5 should stay at 5
+    act(() => {
+      result.current.actions.setPatternLength(12);
+    });
+    expect(
+      result.current.meta.config.trackLengths.bd
+    ).toBe(5);
+    expect(
+      result.current.meta.config.trackLengths.sd
+    ).toBe(12);
+    expect(
+      result.current.meta.config.trackLengths.ch
+    ).toBe(12);
+  });
+});
+
+// -------------------------------------------------------
+// F. clearAll and setSwing actions
 // -------------------------------------------------------
 describe('clearAll', () => {
   it('sets all track steps to zeros', () => {

--- a/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
+++ b/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
@@ -93,6 +93,7 @@ exports[`golden-file tests > defaultConfig() snapshot 1`] = `
     "rs": "0001001000001000",
     "sd": "0000000000000000",
   },
+  "swing": 0,
   "trackLengths": {
     "ac": 16,
     "bd": 16,

--- a/src/__tests__/configCodec.golden.test.ts
+++ b/src/__tests__/configCodec.golden.test.ts
@@ -43,6 +43,7 @@ function goldenConfigV1Decoded(): SequencerConfig {
     trackLengths,
     steps,
     mixer,
+    swing: 0,
   };
 }
 
@@ -77,6 +78,7 @@ function goldenConfigV2(): SequencerConfig {
     trackLengths,
     steps,
     mixer,
+    swing: 0,
   };
 }
 

--- a/src/__tests__/configCodec.test.ts
+++ b/src/__tests__/configCodec.test.ts
@@ -340,6 +340,44 @@ describe('validateSteps', () => {
   });
 });
 
+describe('swing serialization', () => {
+  it('config with swing round-trips', async () => {
+    const config = makeConfig({ swing: 50 });
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded).toEqual(config);
+    expect(decoded.swing).toBe(50);
+  });
+
+  it('missing swing defaults to 0', async () => {
+    const config = defaultConfig();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { swing: _swing, ...noSwing } = config;
+    const hash = await encodeRaw(noSwing);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.swing).toBe(0);
+  });
+
+  it('swing clamped to 0-100', async () => {
+    const below = await encodeRaw({
+      ...defaultConfig(), swing: -10,
+    });
+    expect((await decodeConfig(below)).swing).toBe(0);
+
+    const above = await encodeRaw({
+      ...defaultConfig(), swing: 200,
+    });
+    expect((await decodeConfig(above)).swing).toBe(100);
+  });
+
+  it('non-number swing defaults to 0', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(), swing: 'high',
+    });
+    expect((await decodeConfig(hash)).swing).toBe(0);
+  });
+});
+
 describe('validateMixer', () => {
   it('negative gain clamped to 0', async () => {
     const config = defaultConfig();

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -225,3 +225,240 @@ describe('handleStep', () => {
     expect(gainArg).toBeCloseTo(0.125);
   });
 });
+
+// -------------------------------------------------
+// handleStep swing timing
+// -------------------------------------------------
+describe('handleStep swing timing', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+    mockStop.mockClear();
+  });
+
+  it('odd step with swing: time is offset', async () => {
+    const { result } = renderSequencer();
+
+    // Set swing to 50 and activate bd at step 1
+    await act(async () => {
+      result.current.actions.setSwing(50);
+      // Clear step 0 for bd, set step 1
+      for (const id of TRACK_IDS) {
+        const cur =
+          result.current.meta.config.steps[id];
+        if (cur[0] === '1') {
+          result.current.actions.toggleStep(id, 0);
+        }
+      }
+    });
+
+    await act(async () => {
+      const cur =
+        result.current.meta.config.steps.bd;
+      if (cur[1] === '0') {
+        result.current.actions.toggleStep('bd', 1);
+      }
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    // Trigger odd step (step 1) at time 1.0
+    onStep(1, 1.0);
+
+    expect(mockPlaySound).toHaveBeenCalledTimes(1);
+    const scheduledTime = mockPlaySound.mock.calls[0][1];
+    // BPM 110 (default): halfStep = (60/110)*0.25/2 = 0.06818
+    // offset = (50/100) * 0.7 * 0.06818 = 0.02386
+    expect(scheduledTime).toBeGreaterThan(1.0);
+    expect(scheduledTime).toBeCloseTo(
+      1.0 + 0.5 * 0.7 * ((60 / 110) * 0.25 / 2),
+      4
+    );
+  });
+
+  it('even step with swing: no offset', async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.setSwing(80);
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    // Trigger even step (step 0) at time 1.0
+    onStep(0, 1.0);
+
+    // Check that time passed to playSound is exactly
+    // 1.0 (no offset for even steps)
+    for (const call of mockPlaySound.mock.calls) {
+      expect(call[1]).toBe(1.0);
+    }
+  });
+
+  it('max swing capped by 0.7 multiplier', async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.setSwing(100);
+      for (const id of TRACK_IDS) {
+        const cur =
+          result.current.meta.config.steps[id];
+        if (cur[0] === '1') {
+          result.current.actions.toggleStep(id, 0);
+        }
+      }
+    });
+
+    await act(async () => {
+      const cur =
+        result.current.meta.config.steps.bd;
+      if (cur[1] === '0') {
+        result.current.actions.toggleStep('bd', 1);
+      }
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    onStep(1, 1.0);
+
+    const scheduledTime = mockPlaySound.mock.calls[0][1];
+    // BPM 110: halfStep = (60/110)*0.25/2
+    // Max offset = 1.0 * 0.7 * halfStep
+    const halfStep = (60 / 110) * 0.25 / 2;
+    const maxOffset = 0.7 * halfStep;
+    expect(scheduledTime).toBeCloseTo(
+      1.0 + maxOffset, 4
+    );
+    // Verify it's less than a full halfStep
+    expect(scheduledTime - 1.0).toBeLessThan(halfStep);
+  });
+
+  it('swing offset scales with BPM', async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.setBpm(60);
+      result.current.actions.setSwing(50);
+      for (const id of TRACK_IDS) {
+        const cur =
+          result.current.meta.config.steps[id];
+        if (cur[0] === '1') {
+          result.current.actions.toggleStep(id, 0);
+        }
+      }
+    });
+
+    await act(async () => {
+      const cur =
+        result.current.meta.config.steps.bd;
+      if (cur[1] === '0') {
+        result.current.actions.toggleStep('bd', 1);
+      }
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    onStep(1, 1.0);
+
+    const scheduledTime = mockPlaySound.mock.calls[0][1];
+    // BPM 60: halfStep = (60/60)*0.25/2 = 0.125
+    // offset = 0.5 * 0.7 * 0.125 = 0.04375
+    const halfStep = (60 / 60) * 0.25 / 2;
+    expect(scheduledTime).toBeCloseTo(
+      1.0 + 0.5 * 0.7 * halfStep, 4
+    );
+  });
+
+  it('zero swing: no offset on any step', async () => {
+    const { result } = renderSequencer();
+    // swing defaults to 0
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    onStep(1, 1.0);
+
+    for (const call of mockPlaySound.mock.calls) {
+      expect(call[1]).toBe(1.0);
+    }
+  });
+});

--- a/src/app/GlobalControls.tsx
+++ b/src/app/GlobalControls.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { memo, useCallback } from 'react';
+import Knob from './Knob';
+import { useSequencer } from './SequencerContext';
+
+/**
+ * Global controls section: pattern length, swing, and
+ * clear all.
+ */
+function GlobalControlsInner() {
+  const { state, actions } = useSequencer();
+
+  const handlePatternLength = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      actions.setPatternLength(
+        parseInt(e.target.value, 10)
+      );
+    },
+    [actions]
+  );
+
+  const handleSwing = useCallback(
+    (v: number) => {
+      actions.setSwing(Math.round(v * 100));
+    },
+    [actions]
+  );
+
+  return (
+    <div className="bg-neutral-900/50 p-2 lg:p-4 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
+      <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 lg:mb-2 block font-bold">
+        Global
+      </span>
+      <div className="flex items-center gap-2 lg:gap-3">
+        {/* Steps dropdown */}
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[7px] lg:text-[8px] uppercase tracking-wider text-neutral-600">
+            Steps
+          </span>
+          <select
+            id="global-steps"
+            value={state.patternLength}
+            onChange={handlePatternLength}
+            className="bg-neutral-800 border border-neutral-700 rounded p-1 text-xs lg:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 hover:border-neutral-600 transition-colors w-12 lg:w-14"
+          >
+            {Array.from(
+              { length: 16 },
+              (_, i) => (
+                <option key={i + 1} value={i + 1}>
+                  {i + 1}
+                </option>
+              )
+            )}
+          </select>
+        </div>
+
+        {/* Swing knob */}
+        <div className="flex flex-col items-center gap-0.5">
+          <span className="text-[7px] lg:text-[8px] uppercase tracking-wider text-neutral-600">
+            Swing
+          </span>
+          <Knob
+            value={state.swing / 100}
+            onChange={handleSwing}
+            size={20}
+          />
+          <span className="text-[7px] lg:text-[8px] text-neutral-600">
+            {state.swing}%
+          </span>
+        </div>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Clear button */}
+        <button
+          onClick={actions.clearAll}
+          className="bg-neutral-800 border border-neutral-700 rounded px-1.5 lg:px-2 py-1 text-[9px] lg:text-[10px] uppercase tracking-wider font-bold text-neutral-400 hover:text-neutral-200 hover:border-neutral-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
+        >
+          <span className="hidden lg:inline">
+            Clr
+          </span>
+          <span className="lg:hidden">C</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const GlobalControls = memo(GlobalControlsInner);
+export default GlobalControls;

--- a/src/app/RunningLight.tsx
+++ b/src/app/RunningLight.tsx
@@ -19,7 +19,13 @@ function RunningLightInner({
   return (
     <div className="flex gap-4 items-center pt-2">
       <div className="hidden lg:block w-48" />
-      <div className="flex-1 grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5">
+      <div
+        className="flex-1 grid gap-[3px] lg:gap-1.5"
+        style={{
+          gridTemplateColumns:
+            `repeat(${patternLength}, minmax(0, 1fr))`,
+        }}
+      >
         {Array.from(
           { length: patternLength },
           (_, i) => (

--- a/src/app/RunningLight.tsx
+++ b/src/app/RunningLight.tsx
@@ -19,25 +19,21 @@ function RunningLightInner({
   return (
     <div className="flex gap-4 items-center pt-2">
       <div className="hidden lg:block w-48" />
-      <div
-        className="flex-1 grid gap-[3px] lg:gap-1.5"
-        style={{
-          gridTemplateColumns:
-            `repeat(${patternLength}, minmax(0, 1fr))`,
-        }}
-      >
+      <div className="flex-1 grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5">
         {Array.from(
-          { length: patternLength },
+          { length: 16 },
           (_, i) => (
             <div
               key={i}
               className={
                 'h-1.5 rounded-full'
                 + ' transition-colors duration-100 '
-                + (i === currentStep
-                  ? 'bg-orange-500'
-                    + ' shadow-[0_0_10px_rgba(249,115,22,0.8)]'
-                  : 'bg-neutral-900')
+                + (i >= patternLength
+                  ? 'bg-transparent'
+                  : i === currentStep
+                    ? 'bg-orange-500'
+                      + ' shadow-[0_0_10px_rgba(249,115,22,0.8)]'
+                    : 'bg-neutral-900')
               }
             />
           )

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -290,6 +290,15 @@ export function SequencerProvider({
       const states = trackStatesRef.current;
       const pattern = patternRef.current;
       const cfg = configRef.current;
+
+      // Swing: offset odd steps forward in time
+      const halfStep =
+        (60 / cfg.bpm) * 0.25 / 2;
+      const swingOffset = step % 2 === 1
+        ? (cfg.swing / 100) * 0.7 * halfStep
+        : 0;
+      const scheduledTime = time + swingOffset;
+
       const anySolo = Object.values(states).some(
         t => t.isSolo
       );
@@ -323,7 +332,7 @@ export function SequencerProvider({
           const gain =
             isAccented ? cubic * 1.5 : cubic;
           audioEngine.playSound(
-            track.id, time, gain
+            track.id, scheduledTime, gain
           );
         }
       });

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -466,6 +466,10 @@ export function SequencerProvider({
         for (const id of TRACK_IDS) {
           if (newTrackLengths[id] > clamped) {
             newTrackLengths[id] = clamped;
+          } else if (
+            newTrackLengths[id] === prev.patternLength
+          ) {
+            newTrackLengths[id] = clamped;
           }
           const cur = newSteps[id];
           if (cur.length < clamped) {

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -471,11 +471,12 @@ export function SequencerProvider({
           ) {
             newTrackLengths[id] = clamped;
           }
+          const len = newTrackLengths[id];
           const cur = newSteps[id];
-          if (cur.length < clamped) {
-            newSteps[id] = cur.padEnd(clamped, '0');
-          } else if (cur.length > clamped) {
-            newSteps[id] = cur.substring(0, clamped);
+          if (cur.length < len) {
+            newSteps[id] = cur.padEnd(len, '0');
+          } else if (cur.length > len) {
+            newSteps[id] = cur.substring(0, len);
           }
         }
         return {

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -67,6 +67,7 @@ interface SequencerState {
   currentPattern: Pattern;
   trackStates: Record<TrackId, TrackState>;
   isLoaded: boolean;
+  swing: number;
 }
 
 interface SequencerActions {
@@ -85,6 +86,8 @@ interface SequencerActions {
   setTrackLength: (
     trackId: TrackId, length: number
   ) => void;
+  clearAll: () => void;
+  setSwing: (value: number) => void;
 }
 
 interface SequencerMeta {
@@ -553,6 +556,37 @@ export function SequencerProvider({
     []
   );
 
+  const clearAll = useCallback(() => {
+    setConfig(prev => {
+      const newSteps = {} as Record<TrackId, string>;
+      const newTrackLengths = {} as Record<
+        TrackId, number
+      >;
+      for (const id of TRACK_IDS) {
+        newSteps[id] =
+          '0'.repeat(prev.patternLength);
+        newTrackLengths[id] = prev.patternLength;
+      }
+      return {
+        ...prev,
+        steps: newSteps,
+        trackLengths: newTrackLengths,
+        swing: 0,
+      };
+    });
+    setSelectedPatternId('custom');
+  }, []);
+
+  const setSwing = useCallback(
+    (value: number) => {
+      setConfig(prev => ({
+        ...prev,
+        swing: Math.max(0, Math.min(100, value)),
+      }));
+    },
+    []
+  );
+
   // ─── Context value ────────────────────────────────
 
   const value: SequencerContextValue = {
@@ -565,6 +599,7 @@ export function SequencerProvider({
       currentPattern,
       trackStates,
       isLoaded,
+      swing: config.swing,
     },
     actions: {
       togglePlay,
@@ -578,6 +613,8 @@ export function SequencerProvider({
       toggleFreeRun,
       setPatternLength,
       setTrackLength,
+      clearAll,
+      setSwing,
     },
     meta: { stepRef, totalStepsRef, config },
   };

--- a/src/app/SettingsPopover.tsx
+++ b/src/app/SettingsPopover.tsx
@@ -12,12 +12,12 @@ import { encodeConfig } from './configCodec';
 /**
  * Gear icon button with a dropdown popover for settings.
  *
- * Contains a pattern length selector and an Export action
- * that encodes the current config as a URL hash, copies
- * the full URL to clipboard, and updates the address bar.
+ * Contains an Export action that encodes the current config
+ * as a URL hash, copies the full URL to clipboard, and
+ * updates the address bar.
  */
 export default function SettingsPopover() {
-  const { state, actions, meta } = useSequencer();
+  const { meta } = useSequencer();
   const [isOpen, setIsOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -69,15 +69,6 @@ export default function SettingsPopover() {
     }
   }, [meta.config]);
 
-  const handlePatternLength = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      actions.setPatternLength(
-        parseInt(e.target.value, 10)
-      );
-    },
-    [actions]
-  );
-
   return (
     <div className="relative">
       <button
@@ -106,29 +97,6 @@ export default function SettingsPopover() {
           role="menu"
           className="absolute right-0 top-full mt-2 w-48 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl z-30 overflow-hidden"
         >
-          <div className="px-4 py-3 flex items-center justify-between border-b border-neutral-800">
-            <label
-              htmlFor="pattern-length"
-              className="text-sm text-neutral-300"
-            >
-              Steps
-            </label>
-            <select
-              id="pattern-length"
-              value={state.patternLength}
-              onChange={handlePatternLength}
-              className="bg-neutral-800 text-neutral-200 text-sm rounded px-2 py-1 w-14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500"
-            >
-              {Array.from(
-                { length: 16 },
-                (_, i) => (
-                  <option key={i + 1} value={i + 1}>
-                    {i + 1}
-                  </option>
-                )
-              )}
-            </select>
-          </div>
           <button
             role="menuitem"
             onClick={handleExport}

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -31,15 +31,19 @@ export default function StepGrid() {
 
   useEffect(() => {
     let raf: number;
-    let prev = -1;
+    let prevStep = -1;
+    let prevTotal = 0;
 
     const tick = () => {
-      const cur = stepRef.current;
-      if (cur !== prev) {
-        prev = cur;
-        setDisplayStep(cur);
+      const curStep = stepRef.current;
+      const curTotal = totalStepsRef.current;
+      if (curStep !== prevStep
+        || curTotal !== prevTotal) {
+        prevStep = curStep;
+        prevTotal = curTotal;
+        setDisplayStep(curStep);
         setDisplayTotal(
-          Math.max(0, totalStepsRef.current - 1)
+          Math.max(0, curTotal - 1)
         );
       }
       raf = requestAnimationFrame(tick);

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -270,7 +270,11 @@ function TrackRowInner({
         <div className="flex-1 relative">
           <div
             ref={gridRef}
-            className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
+            className="grid gap-[3px] lg:gap-1.5"
+            style={{
+              gridTemplateColumns:
+                `repeat(${patternLength}, minmax(0, 1fr))`,
+            }}
           >
             {Array.from(
               { length: patternLength },

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -210,7 +210,7 @@ function TrackRowInner({
   }, []);
 
   const handlePct =
-    (trackLength / patternLength) * 100;
+    (trackLength / 16) * 100;
 
   return (
     <div>
@@ -270,16 +270,13 @@ function TrackRowInner({
         <div className="flex-1 relative">
           <div
             ref={gridRef}
-            className="grid gap-[3px] lg:gap-1.5"
-            style={{
-              gridTemplateColumns:
-                `repeat(${patternLength}, minmax(0, 1fr))`,
-            }}
+            className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
           >
             {Array.from(
-              { length: patternLength },
+              { length: 16 },
               (_, i) => {
-                const disabled = i >= trackLength;
+                const disabled =
+                  i >= trackLength || i >= patternLength;
                 return (
                   <StepButton
                     key={i}

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -5,6 +5,7 @@ import kitsData from './data/kits.json';
 import patternsData from './data/patterns.json';
 import TempoController from './TempoController';
 import SettingsPopover from './SettingsPopover';
+import GlobalControls from './GlobalControls';
 import { useSequencer } from './SequencerContext';
 
 /**
@@ -44,7 +45,8 @@ function TransportControlsInner() {
         </div>
       </div>
       {/* Row 2: Kit + Pattern */}
-      <div className="grid grid-cols-2 gap-2 lg:gap-4 pt-2 lg:pt-0">
+      <div className="grid grid-cols-3 gap-2 lg:gap-4 pt-2 lg:pt-0">
+        <GlobalControls />
         <div className="bg-neutral-900/50 p-2 lg:p-4 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
           <label
             htmlFor="kit-select"

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -42,6 +42,7 @@ export function defaultConfig(): SequencerConfig {
     trackLengths,
     steps: firstPattern.steps as Record<TrackId, string>,
     mixer,
+    swing: 0,
   };
 }
 
@@ -158,6 +159,7 @@ function validateConfig(
   const mixer = validateMixer(
     obj.mixer, defaults.mixer
   );
+  const swing = validateSwing(obj.swing);
 
   return {
     version: CONFIG_VERSION,
@@ -167,6 +169,7 @@ function validateConfig(
     trackLengths,
     steps,
     mixer,
+    swing,
   };
 }
 
@@ -194,6 +197,20 @@ function validatePatternLength(value: unknown): number {
   return Math.max(
     PATTERN_LENGTH_MIN,
     Math.min(PATTERN_LENGTH_MAX, Math.round(value))
+  );
+}
+
+const SWING_MIN = 0;
+const SWING_MAX = 100;
+const DEFAULT_SWING = 0;
+
+function validateSwing(value: unknown): number {
+  if (typeof value !== 'number' || !isFinite(value)) {
+    return DEFAULT_SWING;
+  }
+  return Math.max(
+    SWING_MIN,
+    Math.min(SWING_MAX, Math.round(value))
   );
 }
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -67,4 +67,5 @@ export interface SequencerConfig {
   trackLengths: Record<TrackId, number>;
   steps: Record<TrackId, string>;
   mixer: Record<TrackId, TrackMixerState>;
+  swing: number;
 }


### PR DESCRIPTION
## Summary

- Add a **Global** section to the header (left of Kit and Pattern) with three controls: Steps dropdown, Swing knob, and Clear button
- **Swing** delays off-beat 16th notes via a per-sound timing offset in handleStep (0.7 cap, configRef-based)
- **Clear** zeros all track steps, resets track lengths and swing to defaults
- Pattern length moved from SettingsPopover to Global section
- Fix: track lengths that follow the master length now expand/contract correctly
- Fix: step grid always renders 16 columns with steps beyond pattern length greyed out
- Fix: free-run tracks' running light uses total step count instead of global step (fixes #19)

## Test Plan

- [ ] Verify Global | Kit | Pattern three-column layout on desktop and mobile
- [ ] Steps dropdown changes pattern length; cells beyond are greyed and non-clickable
- [ ] Swing knob audibly shifts off-beat timing
- [ ] Clear button zeros all steps, resets swing and track lengths
- [ ] URL export/import preserves swing value
- [ ] Old URLs without swing default to 0%
- [ ] Loading a preset pattern preserves swing
- [ ] Free-run track running light cycles independently of global pattern
- [ ] Track length handles align correctly at any pattern length
- [ ] SettingsPopover no longer shows Steps selector