### PR TITLE
Move BPM label inline with tap tempo button

### DIFF
--- a/src/__tests__/TempoController.test.tsx
+++ b/src/__tests__/TempoController.test.tsx
@@ -78,7 +78,7 @@ describe('TempoController tap tempo', () => {
     render(
       <TempoController bpm={120} setBpm={setBpm} />
     );
-    fireEvent.click(
+    fireEvent.mouseDown(
       screen.getByRole('button', { name: 'Tap tempo' })
     );
     expect(setBpm).not.toHaveBeenCalled();
@@ -95,8 +95,8 @@ describe('TempoController tap tempo', () => {
     perfSpy
       .mockReturnValueOnce(1000)
       .mockReturnValueOnce(1500);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenCalledWith(120);
   });
 
@@ -114,10 +114,10 @@ describe('TempoController tap tempo', () => {
       .mockReturnValueOnce(1400)
       .mockReturnValueOnce(1900)
       .mockReturnValueOnce(2500);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenLastCalledWith(120);
   });
 
@@ -133,8 +133,8 @@ describe('TempoController tap tempo', () => {
     perfSpy
       .mockReturnValueOnce(1000)
       .mockReturnValueOnce(1470);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenCalledWith(127.5);
   });
 
@@ -151,12 +151,12 @@ describe('TempoController tap tempo', () => {
       .mockReturnValueOnce(1500)
       // Third tap after 2s gap — buffer resets
       .mockReturnValueOnce(4000);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenCalledWith(120);
     setBpm.mockClear();
     // This tap resets the buffer — single entry, no setBpm
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).not.toHaveBeenCalled();
   });
 
@@ -172,8 +172,8 @@ describe('TempoController tap tempo', () => {
     const btn = screen.getByRole('button', {
       name: 'Tap tempo',
     });
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenCalledWith(300);
   });
 
@@ -189,8 +189,8 @@ describe('TempoController tap tempo', () => {
     perfSpy
       .mockReturnValueOnce(1000)
       .mockReturnValueOnce(2999);
-    fireEvent.click(btn);
-    fireEvent.click(btn);
+    fireEvent.mouseDown(btn);
+    fireEvent.mouseDown(btn);
     expect(setBpm).toHaveBeenCalledWith(30);
   });
 

--- a/src/app/TempoController.tsx
+++ b/src/app/TempoController.tsx
@@ -12,6 +12,7 @@ interface TempoControllerProps {
 
 export default function TempoController({ bpm, setBpm }: TempoControllerProps) {
   const tapBufferRef = useRef<number[]>([]);
+  const tapBtnRef = useRef<HTMLButtonElement>(null);
 
   const handleTap = useCallback(() => {
     const now = performance.now();
@@ -38,7 +39,16 @@ export default function TempoController({ bpm, setBpm }: TempoControllerProps) {
       const rounded = Math.round(clamped * 2) / 2;
       setBpm(rounded);
     }
+
   }, [setBpm]);
+
+  const flashTap = useCallback(() => {
+    const btn = tapBtnRef.current;
+    if (!btn) return;
+    btn.classList.remove('tap-flash');
+    void btn.offsetWidth;
+    btn.classList.add('tap-flash');
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -53,29 +63,31 @@ export default function TempoController({ bpm, setBpm }: TempoControllerProps) {
   }, [handleTap]);
 
   return (
-    <div className="flex items-center gap-1">
-      <div className="flex items-center gap-1 lg:flex-col lg:items-stretch">
-        <label htmlFor="bpm-input" className="text-[10px] uppercase tracking-widest text-neutral-500 lg:mb-1 font-bold">BPM</label>
-        <input
-          id="bpm-input"
-          name="bpm"
-          type="number"
-          inputMode="numeric"
-          autoComplete="off"
-          value={bpm}
-          min={MIN_BPM}
-          max={MAX_BPM}
-          onChange={(e) => setBpm(Math.max(MIN_BPM, Math.min(MAX_BPM, Number(e.target.value) || MIN_BPM)))}
-          className="bg-neutral-900 border border-neutral-800 rounded px-2 py-1 w-14 lg:w-20 text-orange-500 font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:border-orange-500 transition-colors"
-        />
-      </div>
+    <div className="relative flex items-center">
+      <label htmlFor="bpm-input" className="sr-only">BPM</label>
+      <input
+        id="bpm-input"
+        name="bpm"
+        type="number"
+        inputMode="numeric"
+        autoComplete="off"
+        value={bpm}
+        min={MIN_BPM}
+        max={MAX_BPM}
+        onChange={(e) => setBpm(Math.max(MIN_BPM, Math.min(MAX_BPM, Number(e.target.value) || MIN_BPM)))}
+        className="bg-neutral-900 border border-neutral-800 rounded pl-2 pr-10 py-1 w-28 text-orange-500 font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:border-orange-500 transition-colors"
+      />
       <button
+        ref={tapBtnRef}
         type="button"
         aria-label="Tap tempo"
-        onClick={handleTap}
-        className="self-end bg-neutral-900 border border-neutral-800 rounded px-2 py-1 text-[10px] font-bold uppercase tracking-widest text-neutral-400 active:text-orange-500 active:border-orange-500 transition-colors min-w-[32px] min-h-[32px]"
+        onMouseDown={() => { handleTap(); flashTap(); }}
+        onTouchStart={() => { handleTap(); flashTap(); }}
+        onClick={(e) => e.preventDefault()}
+        className="group/tap absolute inset-y-0 right-0 px-2 flex items-center text-[10px] uppercase tracking-widest font-bold cursor-pointer transition-colors"
       >
-        Tap
+        <span className="text-neutral-500 group-hover/tap:hidden">BPM</span>
+        <span className="text-neutral-400 hidden group-hover/tap:inline">TAP</span>
       </button>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,21 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   box-shadow: 0 0 0 3px #f97316;
 }
 
+@keyframes tap-pulse {
+  0% {
+    background-color: rgb(234 88 12 / 0.4);
+    color: #f97316;
+  }
+  100% {
+    background-color: transparent;
+    color: '';
+  }
+}
+
+.tap-flash {
+  animation: tap-pulse 200ms ease-out;
+}
+
 @supports (padding-top: env(safe-area-inset-top)) {
   .safe-area-top {
     padding-top: env(safe-area-inset-top);


### PR DESCRIPTION
## Summary

- Moved BPM label inline as a suffix inside the tempo input field
- "BPM" text swaps to "TAP" on hover and acts as the tap tempo button, replacing the separate Tap button
- Tap fires on mousedown/touchstart for immediate feedback
- Red-orange pulse animation on each tap press
- Widened input to fit decimal BPM values (e.g. 127.5)

Fixes #18

## Test plan

- [ ] Verify BPM label displays inline inside the input field
- [ ] Hover over the BPM label area — should swap to "TAP"
- [ ] Click/tap the TAP button — should pulse red-orange and update BPM
- [ ] Verify pulse fires on press (mousedown), not release
- [ ] Check layout on mobile and desktop widths
- [ ] `npm test` passes (126 tests)
- [ ] `npm run lint` passes
