### PR TITLE
Add trig conditions engine (probability + cycle A:B)

### DIFF
--- a/docs/superpowers/plans/2026-03-16-trig-conditions-tier1.md
+++ b/docs/superpowers/plans/2026-03-16-trig-conditions-tier1.md
@@ -1,0 +1,1800 @@
+# Trig Conditions Tier 1: Probability & Cycle A:B
+
+> **For agentic workers:** REQUIRED: Use
+> superpowers:subagent-driven-development (if subagents
+> available) or superpowers:executing-plans to implement
+> this plan. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Add probability (X%) and cycle (A:B) trig
+conditions so individual steps can fire conditionally,
+creating evolving patterns without long sequences.
+
+**Architecture:** A new `TrigCondition` union type and
+`trigConditions` sparse map are added to `SequencerConfig`
+(version 3). A pure `evaluateCondition()` function is
+extracted into its own module and called from `handleStep`.
+`cycleCount` transient state tracks per-track loop
+iterations. configCodec is bumped to v3 with backward
+compat for v1/v2 URLs.
+
+**Tech Stack:** TypeScript, React, Vitest, Next.js
+
+**Issues:** [#5](https://github.com/memestreak/xox/issues/5)
+(engine, partial), [#6](https://github.com/memestreak/xox/issues/6)
+(UI, not in scope — Tier 1 is engine only)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/app/types.ts` | Modify | Add `TrigCondition` type, `trigConditions` to `SequencerConfig`, optional `trigConditions?` to `Pattern` |
+| `src/app/trigConditions.ts` | Create | Pure `evaluateCondition()` function |
+| `src/app/configCodec.ts` | Modify | Bump to v3, add `validateTrigConditions()`, update `defaultConfig()` |
+| `src/app/SequencerContext.tsx` | Modify | Add `cycleCount` ref, wire `evaluateCondition` into `handleStep`, add `setTrigCondition`/`clearTrigCondition` actions, prune on track/pattern length change, reset `trigConditions` in `clearAll`, clear and load conditions in `setPattern` |
+| `src/__tests__/trigConditions.test.ts` | Create | Unit tests for `evaluateCondition` |
+| `src/__tests__/handleStep.test.ts` | Modify | Integration tests for conditions in `handleStep` |
+| `src/__tests__/configCodec.test.ts` | Modify | Validation tests for `trigConditions` field |
+| `src/__tests__/configCodec.golden.test.ts` | Modify | v3 golden hash, v1/v2 backward compat tests |
+
+---
+
+## Task 1: Types, configCodec v3, and golden tests
+
+Types and configCodec must land together — adding
+`trigConditions` to `SequencerConfig` without updating
+`defaultConfig()` and `validateConfig()` would break
+compilation.
+
+**Files:**
+- Modify: `src/app/types.ts`
+- Modify: `src/app/configCodec.ts`
+- Modify: `src/__tests__/configCodec.test.ts`
+- Modify: `src/__tests__/configCodec.golden.test.ts`
+
+- [ ] **Step 1: Write failing tests for trigConditions validation**
+
+In `src/__tests__/configCodec.test.ts`, add a new
+describe block:
+
+```typescript
+describe('trigConditions validation', () => {
+  it('missing trigConditions defaults to empty',
+    async () => {
+      const config = makeConfig();
+      delete (config as Record<string, unknown>)
+        .trigConditions;
+      const hash = await encodeRaw(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({});
+    }
+  );
+
+  it('valid probability condition round-trips',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          bd: {
+            0: { type: 'probability', value: 50 },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({
+        bd: {
+          0: { type: 'probability', value: 50 },
+        },
+      });
+    }
+  );
+
+  it('valid cycle condition round-trips',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          sd: {
+            3: { type: 'cycle', a: 1, b: 4 },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({
+        sd: {
+          3: { type: 'cycle', a: 1, b: 4 },
+        },
+      });
+    }
+  );
+
+  it('invalid condition type is dropped',
+    async () => {
+      const config = {
+        ...makeConfig(),
+        trigConditions: {
+          bd: { 0: { type: 'bogus' } },
+        },
+      };
+      const hash = await encodeRaw(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({});
+    }
+  );
+
+  it('probability value clamped to 1-99',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          bd: {
+            0: {
+              type: 'probability', value: 150,
+            },
+            1: {
+              type: 'probability', value: -5,
+            },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      const bd = decoded.trigConditions.bd!;
+      expect(bd[0]).toEqual(
+        { type: 'probability', value: 99 }
+      );
+      expect(bd[1]).toEqual(
+        { type: 'probability', value: 1 }
+      );
+    }
+  );
+
+  it('cycle b clamped to 2-8', async () => {
+    const config = makeConfig({
+      trigConditions: {
+        bd: {
+          0: { type: 'cycle', a: 0, b: 200 },
+        },
+      },
+    });
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions.bd![0]).toEqual(
+      { type: 'cycle', a: 1, b: 8 }
+    );
+  });
+
+  it('cycle b=1 is dropped (minimum is 2)',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          bd: {
+            0: { type: 'cycle', a: 1, b: 1 },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({});
+    }
+  );
+
+  it('cycle a > b is clamped to a = b',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          bd: {
+            0: { type: 'cycle', a: 5, b: 3 },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions.bd![0]).toEqual(
+        { type: 'cycle', a: 3, b: 3 }
+      );
+    }
+  );
+
+  it('step index beyond track length is dropped',
+    async () => {
+      const config = makeConfig({
+        trigConditions: {
+          bd: {
+            99: {
+              type: 'probability', value: 50,
+            },
+          },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({});
+    }
+  );
+
+  it('non-object trigConditions defaults to empty',
+    async () => {
+      const config = {
+        ...makeConfig(),
+        trigConditions: 'garbage',
+      };
+      const hash = await encodeRaw(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.trigConditions).toEqual({});
+    }
+  );
+});
+```
+
+Also update the existing `'wrong version number is
+overwritten'` test — change the expected version from
+`toBe(2)` to `toBe(3)`.
+
+- [ ] **Step 2: Add TrigCondition type to types.ts**
+
+At the end of `src/app/types.ts`, add:
+
+```typescript
+/**
+ * A trig condition that gates whether a step fires.
+ * One condition per step. Absent = always fire.
+ */
+export type TrigCondition =
+  | { type: 'probability'; value: number }
+  | { type: 'cycle'; a: number; b: number };
+```
+
+Add `trigConditions` to `SequencerConfig` (after
+`swing`):
+
+```typescript
+export interface SequencerConfig {
+  version: number;
+  kitId: string;
+  bpm: number;
+  patternLength: number;
+  trackLengths: Record<TrackId, number>;
+  steps: Record<TrackId, string>;
+  mixer: Record<TrackId, TrackMixerState>;
+  swing: number;
+  trigConditions: Partial<
+    Record<TrackId, Record<number, TrigCondition>>
+  >;
+}
+```
+
+The outer `Partial` means tracks with no conditions are
+simply absent. The inner `Record<number, TrigCondition>`
+is sparse — only step indices with conditions have
+entries.
+
+Also add optional `trigConditions` to the `Pattern`
+interface so patterns can carry conditions:
+
+```typescript
+export interface Pattern {
+  id: string;
+  name: string;
+  steps: Record<TrackId, string>;
+  trigConditions?: Partial<
+    Record<
+      TrackId, Record<number, TrigCondition>
+    >
+  >;
+}
+```
+
+The `?` makes the field optional. Existing
+`patterns.json` is **not modified** — preset patterns
+simply lack the field, which defaults to `{}`.
+
+- [ ] **Step 3: Bump CONFIG_VERSION and update defaultConfig**
+
+In `src/app/configCodec.ts`:
+
+Change line 12:
+```typescript
+const CONFIG_VERSION = 3;
+```
+
+Add `TrigCondition` to the import from `./types`
+(line 5-9):
+
+```typescript
+import type {
+  SequencerConfig,
+  TrackId,
+  TrackMixerState,
+  TrigCondition,
+} from './types';
+```
+
+In `defaultConfig()` (line 37-46), add `trigConditions`
+to the return object:
+
+```typescript
+  return {
+    version: CONFIG_VERSION,
+    kitId: kitsData.kits[0].id,
+    bpm: DEFAULT_BPM,
+    patternLength: DEFAULT_PATTERN_LENGTH,
+    trackLengths,
+    steps: firstPattern.steps as
+      Record<TrackId, string>,
+    mixer,
+    swing: 0,
+    trigConditions: {},
+  };
+```
+
+- [ ] **Step 4: Add validateTrigConditions function**
+
+Add after `validateSwing()` (after line 215):
+
+```typescript
+/**
+ * Validate trig conditions. Returns a sparse map
+ * containing only valid conditions on valid step
+ * indices.
+ */
+function validateTrigConditions(
+  value: unknown,
+  trackLengths: Record<TrackId, number>
+): Partial<
+  Record<TrackId, Record<number, TrigCondition>>
+> {
+  if (value === null || typeof value !== 'object') {
+    return {};
+  }
+  const obj = value as Record<string, unknown>;
+  const result: Partial<
+    Record<TrackId, Record<number, TrigCondition>>
+  > = {};
+
+  for (const id of TRACK_IDS) {
+    const trackConds = obj[id];
+    if (
+      trackConds === null ||
+      typeof trackConds !== 'object'
+    ) {
+      continue;
+    }
+    const tc =
+      trackConds as Record<string, unknown>;
+    const validated:
+      Record<number, TrigCondition> = {};
+    for (const [key, cond] of Object.entries(tc)) {
+      const stepIdx = Number(key);
+      if (
+        !Number.isInteger(stepIdx) ||
+        stepIdx < 0 ||
+        stepIdx >= trackLengths[id]
+      ) {
+        continue;
+      }
+      const parsed =
+        validateSingleCondition(cond);
+      if (parsed !== null) {
+        validated[stepIdx] = parsed;
+      }
+    }
+    if (Object.keys(validated).length > 0) {
+      result[id] = validated;
+    }
+  }
+  return result;
+}
+
+function validateSingleCondition(
+  value: unknown
+): TrigCondition | null {
+  if (
+    value === null || typeof value !== 'object'
+  ) {
+    return null;
+  }
+  const obj = value as Record<string, unknown>;
+
+  if (obj.type === 'probability') {
+    if (
+      typeof obj.value !== 'number' ||
+      !isFinite(obj.value)
+    ) {
+      return null;
+    }
+    return {
+      type: 'probability',
+      value: Math.max(
+        1, Math.min(99, Math.round(obj.value))
+      ),
+    };
+  }
+
+  if (obj.type === 'cycle') {
+    if (
+      typeof obj.a !== 'number' ||
+      !isFinite(obj.a) ||
+      typeof obj.b !== 'number' ||
+      !isFinite(obj.b)
+    ) {
+      return null;
+    }
+    const rawB = Math.round(obj.b);
+    if (rawB < 2) return null;
+    const b = Math.min(8, rawB);
+    const a = Math.max(
+      1, Math.min(b, Math.round(obj.a))
+    );
+    return { type: 'cycle', a, b };
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 5: Wire validateTrigConditions into validateConfig**
+
+In `validateConfig()` (lines 138-174), add after
+`validateSwing`:
+
+```typescript
+  const trigConditions = validateTrigConditions(
+    obj.trigConditions, trackLengths
+  );
+```
+
+And include it in the return object:
+
+```typescript
+  return {
+    version: CONFIG_VERSION,
+    kitId,
+    bpm,
+    patternLength,
+    trackLengths,
+    steps,
+    mixer,
+    swing,
+    trigConditions,
+  };
+```
+
+- [ ] **Step 6: Update golden tests for v3**
+
+In `src/__tests__/configCodec.golden.test.ts`:
+
+Update `goldenConfigV1Decoded()` — change `version: 2`
+to `version: 3` and add `trigConditions: {}`:
+
+```typescript
+function goldenConfigV1Decoded(): SequencerConfig {
+  // ... existing setup code unchanged ...
+  return {
+    version: 3,
+    kitId: 'electro',
+    bpm: 140,
+    patternLength: 16,
+    trackLengths,
+    steps,
+    mixer,
+    swing: 0,
+    trigConditions: {},
+  };
+}
+```
+
+Update `goldenConfigV2()` — add `trigConditions: {}`:
+
+```typescript
+function goldenConfigV2(): SequencerConfig {
+  // ... existing setup code unchanged ...
+  return {
+    version: 2,
+    kitId: 'electro',
+    bpm: 140,
+    patternLength: 12,
+    trackLengths,
+    steps,
+    mixer,
+    swing: 0,
+    trigConditions: {},
+  };
+}
+```
+
+Update the v2 round-trip test — `decodeConfig` stamps
+v3, so the decoded version won't match the input:
+
+```typescript
+it('v2 config round-trips identically',
+  async () => {
+    const config = goldenConfigV2();
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded).toEqual({
+      ...config,
+      version: 3,
+    });
+  }
+);
+```
+
+Add `encodeRaw` helper (duplicate the 10-line helper
+from `configCodec.test.ts` at the top of the golden
+test file):
+
+```typescript
+async function encodeRaw(
+  obj: unknown
+): Promise<string> {
+  const json = JSON.stringify(obj);
+  const stream = new Blob([json]).stream()
+    .pipeThrough(
+      new CompressionStream('deflate-raw')
+    );
+  const bytes = new Uint8Array(
+    await new Response(stream).arrayBuffer()
+  );
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+```
+
+Add a new v2 backward compat test:
+
+```typescript
+function goldenConfigV2Decoded(): SequencerConfig {
+  return {
+    ...goldenConfigV2(),
+    version: 3,
+  };
+}
+
+it('v2 hash decodes with trigConditions defaulted',
+  async () => {
+    const v2Config = goldenConfigV2();
+    const v2Only = { ...v2Config };
+    delete (v2Only as Record<string, unknown>)
+      .trigConditions;
+    const hash = await encodeRaw(v2Only);
+    const decoded = await decodeConfig(hash);
+    expect(decoded).toEqual(
+      goldenConfigV2Decoded()
+    );
+  }
+);
+```
+
+- [ ] **Step 7: Run tests and update snapshots**
+
+Run: `npm test -- --update-snapshots`
+Expected: snapshot updates to include
+`trigConditions: {}`, all tests pass.
+
+Note: SequencerContext.tsx will have type errors at
+this point because it constructs `SequencerConfig`
+objects without `trigConditions` in some actions. Those
+are fixed in Task 3. Verify that the configCodec and
+golden tests pass in isolation:
+
+Run: `npm test -- src/__tests__/configCodec`
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/app/types.ts src/app/configCodec.ts \
+  src/__tests__/configCodec.test.ts \
+  src/__tests__/configCodec.golden.test.ts
+git commit -m "Add TrigCondition type and configCodec v3"
+```
+
+---
+
+## Task 2: Create evaluateCondition module
+
+**Files:**
+- Create: `src/app/trigConditions.ts`
+- Create: `src/__tests__/trigConditions.test.ts`
+
+- [ ] **Step 1: Write tests for evaluateCondition**
+
+Create `src/__tests__/trigConditions.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+import {
+  evaluateCondition,
+} from '../app/trigConditions';
+import type { TrigCondition } from '../app/types';
+
+describe('evaluateCondition', () => {
+  describe('no condition (undefined)', () => {
+    it('always fires', () => {
+      expect(evaluateCondition(undefined, {
+        cycleCount: 0,
+      })).toBe(true);
+    });
+  });
+
+  describe('probability', () => {
+    const cond: TrigCondition = {
+      type: 'probability', value: 50,
+    };
+
+    it('fires when random < threshold', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValue(0.49);
+      expect(evaluateCondition(cond, {
+        cycleCount: 0,
+      })).toBe(true);
+      vi.restoreAllMocks();
+    });
+
+    it('does not fire when random >= threshold',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.50);
+        expect(evaluateCondition(cond, {
+          cycleCount: 0,
+        })).toBe(false);
+        vi.restoreAllMocks();
+      }
+    );
+
+    it('1% fires when random < 0.01', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValue(0.009);
+      const c: TrigCondition = {
+        type: 'probability', value: 1,
+      };
+      expect(evaluateCondition(c, {
+        cycleCount: 0,
+      })).toBe(true);
+      vi.restoreAllMocks();
+    });
+
+    it('99% does not fire when random >= 0.99',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.99);
+        const c: TrigCondition = {
+          type: 'probability', value: 99,
+        };
+        expect(evaluateCondition(c, {
+          cycleCount: 0,
+        })).toBe(false);
+        vi.restoreAllMocks();
+      }
+    );
+  });
+
+  describe('cycle A:B', () => {
+    it('1:4 fires on cycle 0 (1st of every 4)',
+      () => {
+        const cond: TrigCondition = {
+          type: 'cycle', a: 1, b: 4,
+        };
+        expect(evaluateCondition(cond, {
+          cycleCount: 0,
+        })).toBe(true);
+      }
+    );
+
+    it('1:4 does not fire on cycles 1-3', () => {
+      const cond: TrigCondition = {
+        type: 'cycle', a: 1, b: 4,
+      };
+      expect(evaluateCondition(cond, {
+        cycleCount: 1,
+      })).toBe(false);
+      expect(evaluateCondition(cond, {
+        cycleCount: 2,
+      })).toBe(false);
+      expect(evaluateCondition(cond, {
+        cycleCount: 3,
+      })).toBe(false);
+    });
+
+    it('3:4 fires on cycle 2 (3rd of every 4)',
+      () => {
+        const cond: TrigCondition = {
+          type: 'cycle', a: 3, b: 4,
+        };
+        expect(evaluateCondition(cond, {
+          cycleCount: 2,
+        })).toBe(true);
+      }
+    );
+
+    it('2:2 fires on odd cycles (0-indexed)',
+      () => {
+        const cond: TrigCondition = {
+          type: 'cycle', a: 2, b: 2,
+        };
+        expect(evaluateCondition(cond, {
+          cycleCount: 0,
+        })).toBe(false);
+        expect(evaluateCondition(cond, {
+          cycleCount: 1,
+        })).toBe(true);
+        expect(evaluateCondition(cond, {
+          cycleCount: 2,
+        })).toBe(false);
+        expect(evaluateCondition(cond, {
+          cycleCount: 3,
+        })).toBe(true);
+      }
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/__tests__/trigConditions.test.ts`
+Expected: FAIL — module `trigConditions` does not exist
+
+- [ ] **Step 3: Implement evaluateCondition**
+
+Create `src/app/trigConditions.ts`:
+
+```typescript
+import type { TrigCondition } from './types';
+
+/**
+ * Context needed to evaluate a trig condition.
+ */
+export interface ConditionContext {
+  /**
+   * Current cycle count for this track
+   * (0-indexed).
+   */
+  cycleCount: number;
+}
+
+/**
+ * Evaluate whether a step should fire given its
+ * condition and the current context.
+ *
+ * Returns true if:
+ * - No condition (undefined) -- always fire
+ * - Probability: Math.random() < value/100
+ * - Cycle A:B: (cycleCount % b) === (a - 1)
+ *
+ * Args:
+ *   condition: The trig condition, or undefined
+ *     for unconditional steps.
+ *   ctx: Current evaluation context.
+ *
+ * Returns:
+ *   Whether the step should fire.
+ */
+export function evaluateCondition(
+  condition: TrigCondition | undefined,
+  ctx: ConditionContext
+): boolean {
+  if (condition === undefined) return true;
+
+  switch (condition.type) {
+    case 'probability':
+      return Math.random() <
+        condition.value / 100;
+    case 'cycle':
+      return (
+        ctx.cycleCount % condition.b ===
+        condition.a - 1
+      );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/trigConditions.test.ts`
+Expected: all pass
+
+- [ ] **Step 5: Run lint**
+
+Run: `npm run lint`
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/app/trigConditions.ts \
+  src/__tests__/trigConditions.test.ts
+git commit -m "Add evaluateCondition for probability and cycle"
+```
+
+---
+
+## Task 3: Wire evaluateCondition into handleStep
+
+**Files:**
+- Modify: `src/app/SequencerContext.tsx`
+- Modify: `src/__tests__/handleStep.test.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+In `src/__tests__/handleStep.test.ts`, add a new
+describe block. These tests verify that conditions are
+consulted during step evaluation. The `clearAll` action
+is used to get a clean slate with only the tracks we
+care about active.
+
+```typescript
+describe('trig conditions in handleStep', () => {
+  it('step with probability condition can be '
+    + 'suppressed', async () => {
+    vi.spyOn(Math, 'random')
+      .mockReturnValue(0.99);
+
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.clearAll();
+    });
+    await act(async () => {
+      result.current.actions
+        .toggleStep('bd', 0);
+    });
+    await act(async () => {
+      result.current.actions.setTrigCondition(
+        'bd', 0,
+        { type: 'probability', value: 50 }
+      );
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep =
+      mockStart.mock.calls[0][1] as (
+        step: number, time: number
+      ) => void;
+    await waitFor(() => {
+      expect(result.current.state.isPlaying)
+        .toBe(true);
+    });
+    mockPlaySound.mockClear();
+
+    onStep(0, 0.0);
+
+    expect(mockPlaySound)
+      .not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('step without condition always fires',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.clearAll();
+      });
+      await act(async () => {
+        result.current.actions
+          .toggleStep('bd', 0);
+      });
+
+      mockPlaySound.mockClear();
+      mockStart.mockClear();
+
+      await act(async () => {
+        result.current.actions.togglePlay();
+      });
+
+      const onStep =
+        mockStart.mock.calls[0][1] as (
+          step: number, time: number
+        ) => void;
+      await waitFor(() => {
+        expect(result.current.state.isPlaying)
+          .toBe(true);
+      });
+      mockPlaySound.mockClear();
+
+      onStep(0, 0.0);
+
+      expect(mockPlaySound)
+        .toHaveBeenCalledTimes(1);
+      expect(mockPlaySound.mock.calls[0][0])
+        .toBe('bd');
+    }
+  );
+
+  it('clearTrigCondition removes condition',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0,
+          { type: 'probability', value: 50 }
+        );
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toBeDefined();
+
+      await act(async () => {
+        result.current.actions
+          .clearTrigCondition('bd', 0);
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toBeUndefined();
+    }
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/__tests__/handleStep.test.ts`
+Expected: FAIL — `setTrigCondition` and
+`clearTrigCondition` don't exist yet
+
+- [ ] **Step 3: Add imports and cycleCount ref**
+
+In `src/app/SequencerContext.tsx`:
+
+Add imports at top:
+
+```typescript
+import {
+  evaluateCondition,
+} from './trigConditions';
+import type { TrigCondition } from './types';
+```
+
+Add `cycleCountRef` near the other refs (around
+line 240, after `configRef`):
+
+```typescript
+const cycleCountRef = useRef<
+  Record<TrackId, number>
+>({} as Record<TrackId, number>);
+```
+
+- [ ] **Step 4: Wire condition evaluation into handleStep**
+
+In `handleStep` (line 284), make these changes:
+
+**Add cycle count increment** after the `anySolo`
+check (line 304) and before the accent evaluation:
+
+```typescript
+      // Increment cycle count for tracks at
+      // their cycle boundary
+      for (const id of TRACK_IDS) {
+        const len = cfg.trackLengths[id];
+        if (total > 0 && total % len === 0) {
+          cycleCountRef.current[id] =
+            (cycleCountRef.current[id] ?? 0)
+            + 1;
+        }
+      }
+```
+
+**Replace the `isAccented` const** (lines 315-318)
+with condition-aware version. This goes AFTER the
+cycle increment so accent sees the updated count:
+
+```typescript
+      const accentStep = trackStep('ac');
+      const accentActive =
+        pattern.steps.ac[accentStep] === '1';
+      let isAccented = false;
+      if (accentActive) {
+        const accentCond =
+          cfg.trigConditions?.ac?.[accentStep];
+        isAccented = evaluateCondition(
+          accentCond, {
+            cycleCount:
+              cycleCountRef.current.ac ?? 0,
+          }
+        );
+      }
+```
+
+**Add condition check** inside the `TRACKS.forEach`
+loop. After `pattern.steps[track.id][effectiveStep]
+=== '1'`, add before the gain/playSound code:
+
+```typescript
+          const cond =
+            cfg.trigConditions?.[track.id]?.[
+              effectiveStep
+            ];
+          const shouldFire = evaluateCondition(
+            cond, {
+              cycleCount:
+                cycleCountRef.current[track.id]
+                ?? 0,
+            }
+          );
+          if (!shouldFire) return;
+```
+
+The full inner loop becomes:
+
+```typescript
+      TRACKS.forEach(track => {
+        const st = states[track.id];
+        const audible = anySolo
+          ? st.isSolo
+          : !st.isMuted;
+        if (!audible) return;
+
+        const effectiveStep =
+          trackStep(track.id);
+        if (
+          pattern.steps[track.id][effectiveStep]
+            === '1'
+        ) {
+          const cond =
+            cfg.trigConditions?.[track.id]?.[
+              effectiveStep
+            ];
+          const shouldFire = evaluateCondition(
+            cond, {
+              cycleCount:
+                cycleCountRef.current[track.id]
+                ?? 0,
+            }
+          );
+          if (!shouldFire) return;
+
+          const cubic = st.gain ** 3;
+          const gain =
+            isAccented ? cubic * 1.5 : cubic;
+          audioEngine.playSound(
+            track.id, scheduledTime, gain
+          );
+        }
+      });
+```
+
+- [ ] **Step 5: Initialize and reset cycleCount in togglePlay**
+
+In `togglePlay` (line 351):
+
+**Start branch** (after `totalStepsRef.current = 0`
+on line 358):
+
+```typescript
+      const counts =
+        {} as Record<TrackId, number>;
+      for (const id of TRACK_IDS) {
+        counts[id] = 0;
+      }
+      cycleCountRef.current = counts;
+```
+
+**Stop branch** (after `totalStepsRef.current = 0`
+on line 356):
+
+```typescript
+      const counts =
+        {} as Record<TrackId, number>;
+      for (const id of TRACK_IDS) {
+        counts[id] = 0;
+      }
+      cycleCountRef.current = counts;
+```
+
+- [ ] **Step 6: Add setTrigCondition and clearTrigCondition actions**
+
+Add to the `SequencerActions` interface (around
+line 90):
+
+```typescript
+  setTrigCondition: (
+    trackId: TrackId,
+    stepIndex: number,
+    condition: TrigCondition
+  ) => void;
+  clearTrigCondition: (
+    trackId: TrackId,
+    stepIndex: number
+  ) => void;
+```
+
+Add implementations after the existing actions
+(before the `useMemo` that assembles the return
+value):
+
+```typescript
+  const setTrigCondition = useCallback(
+    (
+      trackId: TrackId,
+      stepIndex: number,
+      condition: TrigCondition
+    ) => {
+      setConfig(prev => {
+        const trackConds = {
+          ...prev.trigConditions[trackId],
+        };
+        trackConds[stepIndex] = condition;
+        return {
+          ...prev,
+          trigConditions: {
+            ...prev.trigConditions,
+            [trackId]: trackConds,
+          },
+        };
+      });
+    },
+    []
+  );
+
+  const clearTrigCondition = useCallback(
+    (trackId: TrackId, stepIndex: number) => {
+      setConfig(prev => {
+        const trackConds = {
+          ...prev.trigConditions[trackId],
+        };
+        delete trackConds[stepIndex];
+        const newConditions = {
+          ...prev.trigConditions,
+        };
+        if (
+          Object.keys(trackConds).length === 0
+        ) {
+          delete newConditions[trackId];
+        } else {
+          newConditions[trackId] = trackConds;
+        }
+        return {
+          ...prev,
+          trigConditions: newConditions,
+        };
+      });
+    },
+    []
+  );
+```
+
+Add both to the `useMemo` actions return object.
+
+- [ ] **Step 7: Reset trigConditions in clearAll**
+
+In the `clearAll` action (around line 573), add
+`trigConditions: {}` to the returned config object
+so clearing all state also removes all conditions:
+
+```typescript
+  const clearAll = useCallback(() => {
+    setConfig(prev => {
+      // ... existing steps/trackLengths/swing
+      // reset code ...
+      return {
+        ...prev,
+        steps: newSteps,
+        trackLengths: newTrackLengths,
+        swing: 0,
+        trigConditions: {},
+      };
+    });
+    setSelectedPatternId('custom');
+  }, []);
+```
+
+- [ ] **Step 8: Reset cycle count on mute/solo toggle**
+
+In the `toggleMute` action (around line 525), add
+cycle count reset for the toggled track:
+
+```typescript
+  const toggleMute = useCallback(
+    (trackId: TrackId) => {
+      setConfig(prev => ({
+        ...prev,
+        mixer: {
+          ...prev.mixer,
+          [trackId]: {
+            ...prev.mixer[trackId],
+            isMuted:
+              !prev.mixer[trackId].isMuted,
+          },
+        },
+      }));
+      // Reset cycle count for this track
+      cycleCountRef.current[trackId] = 0;
+    },
+    []
+  );
+```
+
+Apply the same pattern to `toggleSolo` (around
+line 541):
+
+```typescript
+  const toggleSolo = useCallback(
+    (trackId: TrackId) => {
+      setConfig(prev => ({
+        ...prev,
+        mixer: {
+          ...prev.mixer,
+          [trackId]: {
+            ...prev.mixer[trackId],
+            isSolo:
+              !prev.mixer[trackId].isSolo,
+          },
+        },
+      }));
+      // Reset cycle count for this track
+      cycleCountRef.current[trackId] = 0;
+    },
+    []
+  );
+```
+
+- [ ] **Step 9: Clear and load conditions in setPattern**
+
+In the `setPattern` action (around line 399), modify
+it to replace `trigConditions` with the pattern's
+conditions (defaulting to `{}` if absent):
+
+```typescript
+  const setPattern = useCallback(
+    (pattern: Pattern) => {
+      setConfig(prev => {
+        const newSteps = { ...pattern.steps };
+        for (const id of TRACK_IDS) {
+          const cur = newSteps[id] ?? '';
+          const len = prev.trackLengths[id];
+          if (cur.length < len) {
+            newSteps[id] =
+              cur.padEnd(len, '0');
+          } else if (cur.length > len) {
+            newSteps[id] =
+              cur.substring(0, len);
+          }
+        }
+        return {
+          ...prev,
+          steps: newSteps,
+          trigConditions:
+            pattern.trigConditions ?? {},
+        };
+      });
+      setSelectedPatternId(pattern.id);
+    },
+    []
+  );
+```
+
+- [ ] **Step 10: Prune conditions on track length change**
+
+In the existing `setTrackLength` action (line 494), add
+condition pruning after step string truncation:
+
+```typescript
+  const setTrackLength = useCallback(
+    (trackId: TrackId, length: number) => {
+      setConfig(prev => {
+        const clamped = Math.max(
+          1,
+          Math.min(prev.patternLength, length)
+        );
+        const cur = prev.steps[trackId];
+        let newSteps: string;
+        if (cur.length < clamped) {
+          newSteps = cur.padEnd(clamped, '0');
+        } else {
+          newSteps =
+            cur.substring(0, clamped);
+        }
+
+        // Prune conditions beyond new length
+        const trackConds =
+          prev.trigConditions[trackId];
+        let newConditions =
+          prev.trigConditions;
+        if (trackConds) {
+          const pruned: Record<
+            number, TrigCondition
+          > = {};
+          for (
+            const [k, v] of
+            Object.entries(trackConds)
+          ) {
+            const idx = Number(k);
+            if (idx < clamped) {
+              pruned[idx] = v;
+            }
+          }
+          newConditions = {
+            ...prev.trigConditions,
+          };
+          if (
+            Object.keys(pruned).length === 0
+          ) {
+            delete newConditions[trackId];
+          } else {
+            newConditions[trackId] = pruned;
+          }
+        }
+
+        return {
+          ...prev,
+          steps: {
+            ...prev.steps,
+            [trackId]: newSteps,
+          },
+          trackLengths: {
+            ...prev.trackLengths,
+            [trackId]: clamped,
+          },
+          trigConditions: newConditions,
+        };
+      });
+      setSelectedPatternId('custom');
+    },
+    []
+  );
+```
+
+- [ ] **Step 11: Prune conditions on pattern length change**
+
+In the `setPatternLength` action (around line 457),
+add condition pruning. `setPatternLength` shortens
+all tracks to the new pattern length, so conditions
+on steps beyond each track's new length must be
+pruned:
+
+```typescript
+  const setPatternLength = useCallback(
+    (length: number) => {
+      setConfig(prev => {
+        const clamped = Math.max(
+          1, Math.min(64, length)
+        );
+        // ... existing step/trackLength logic ...
+
+        // Prune conditions beyond new lengths
+        const newConditions: Partial<
+          Record<
+            TrackId,
+            Record<number, TrigCondition>
+          >
+        > = {};
+        for (const id of TRACK_IDS) {
+          const trackConds =
+            prev.trigConditions[id];
+          if (!trackConds) continue;
+          const newLen = newTrackLengths[id];
+          const pruned: Record<
+            number, TrigCondition
+          > = {};
+          for (
+            const [k, v] of
+            Object.entries(trackConds)
+          ) {
+            const idx = Number(k);
+            if (idx < newLen) {
+              pruned[idx] = v;
+            }
+          }
+          if (
+            Object.keys(pruned).length > 0
+          ) {
+            newConditions[id] = pruned;
+          }
+        }
+
+        return {
+          ...prev,
+          patternLength: clamped,
+          trackLengths: newTrackLengths,
+          steps: newSteps,
+          trigConditions: newConditions,
+        };
+      });
+      setSelectedPatternId('custom');
+    },
+    []
+  );
+```
+
+- [ ] **Step 12: Run tests**
+
+Run: `npm test`
+Expected: all pass
+
+- [ ] **Step 13: Run lint**
+
+Run: `npm run lint`
+Expected: clean
+
+- [ ] **Step 14: Commit**
+
+```
+git add src/app/SequencerContext.tsx \
+  src/__tests__/handleStep.test.ts
+git commit -m "Wire trig conditions into handleStep"
+```
+
+---
+
+## Task 4: Add condition pruning tests
+
+**Files:**
+- Modify: `src/__tests__/handleStep.test.ts`
+
+- [ ] **Step 1: Write pruning tests**
+
+First, add these imports at the top of
+`handleStep.test.ts` (alongside existing imports):
+
+```typescript
+import patternsData
+  from '../app/data/patterns.json';
+import type { Pattern } from '../app/types';
+```
+
+Then add to the `trig conditions in handleStep`
+describe block:
+
+```typescript
+it('shortening track prunes conditions '
+  + 'beyond length', async () => {
+  const { result } = renderSequencer();
+
+  await act(async () => {
+    result.current.actions.setTrigCondition(
+      'bd', 15,
+      { type: 'probability', value: 50 }
+    );
+  });
+
+  expect(
+    result.current.meta.config
+      .trigConditions.bd?.[15]
+  ).toBeDefined();
+
+  await act(async () => {
+    result.current.actions
+      .setTrackLength('bd', 8);
+  });
+
+  expect(
+    result.current.meta.config
+      .trigConditions.bd?.[15]
+  ).toBeUndefined();
+});
+
+it('shortening track preserves conditions '
+  + 'within length', async () => {
+  const { result } = renderSequencer();
+
+  await act(async () => {
+    result.current.actions.setTrigCondition(
+      'bd', 3,
+      { type: 'probability', value: 50 }
+    );
+  });
+
+  await act(async () => {
+    result.current.actions
+      .setTrackLength('bd', 8);
+  });
+
+  expect(
+    result.current.meta.config
+      .trigConditions.bd?.[3]
+  ).toEqual(
+    { type: 'probability', value: 50 }
+  );
+});
+
+it('shortening pattern length prunes '
+  + 'conditions', async () => {
+  const { result } = renderSequencer();
+
+  await act(async () => {
+    result.current.actions.setTrigCondition(
+      'bd', 15,
+      { type: 'probability', value: 50 }
+    );
+  });
+
+  await act(async () => {
+    result.current.actions
+      .setPatternLength(8);
+  });
+
+  expect(
+    result.current.meta.config
+      .trigConditions.bd?.[15]
+  ).toBeUndefined();
+});
+
+it('clearAll resets trigConditions',
+  async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.setTrigCondition(
+        'bd', 0,
+        { type: 'probability', value: 50 }
+      );
+    });
+
+    expect(
+      result.current.meta.config
+        .trigConditions.bd?.[0]
+    ).toBeDefined();
+
+    await act(async () => {
+      result.current.actions.clearAll();
+    });
+
+    expect(
+      result.current.meta.config
+        .trigConditions
+    ).toEqual({});
+  }
+);
+
+it('loading preset clears conditions',
+  async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.setTrigCondition(
+        'bd', 0,
+        { type: 'probability', value: 50 }
+      );
+    });
+
+    expect(
+      result.current.meta.config
+        .trigConditions.bd?.[0]
+    ).toBeDefined();
+
+    // Load a preset pattern (no trigConditions)
+    const preset = patternsData.patterns[0];
+
+    await act(async () => {
+      result.current.actions.setPattern(
+        preset as Pattern
+      );
+    });
+
+    expect(
+      result.current.meta.config
+        .trigConditions
+    ).toEqual({});
+  }
+);
+
+it('toggling step off preserves condition',
+  async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions
+        .toggleStep('bd', 0);
+    });
+    await act(async () => {
+      result.current.actions.setTrigCondition(
+        'bd', 0,
+        { type: 'probability', value: 50 }
+      );
+    });
+
+    // Toggle step off
+    await act(async () => {
+      result.current.actions
+        .toggleStep('bd', 0);
+    });
+
+    // Condition persists on inactive step
+    expect(
+      result.current.meta.config
+        .trigConditions.bd?.[0]
+    ).toEqual(
+      { type: 'probability', value: 50 }
+    );
+
+    // Toggle step back on
+    await act(async () => {
+      result.current.actions
+        .toggleStep('bd', 0);
+    });
+
+    // Condition still there
+    expect(
+      result.current.meta.config
+        .trigConditions.bd?.[0]
+    ).toEqual(
+      { type: 'probability', value: 50 }
+    );
+  }
+);
+
+it('mute resets cycle count for that track',
+  async () => {
+    const { result } = renderSequencer();
+
+    await act(async () => {
+      result.current.actions.clearAll();
+    });
+    await act(async () => {
+      result.current.actions
+        .toggleStep('bd', 0);
+    });
+    await act(async () => {
+      result.current.actions.setTrigCondition(
+        'bd', 0,
+        { type: 'cycle', a: 2, b: 2 }
+      );
+    });
+
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+
+    const onStep =
+      mockStart.mock.calls[0][1] as (
+        step: number, time: number
+      ) => void;
+    await waitFor(() => {
+      expect(result.current.state.isPlaying)
+        .toBe(true);
+    });
+
+    // Play 16 steps (one cycle), then 16 more
+    // (second cycle where 2:2 fires)
+    for (let i = 0; i < 32; i++) {
+      onStep(i % 16, i * 0.125);
+    }
+
+    // Mute bd — should reset its cycle count
+    await act(async () => {
+      result.current.actions.toggleMute('bd');
+    });
+
+    // Unmute bd
+    await act(async () => {
+      result.current.actions.toggleMute('bd');
+    });
+
+    // After unmute, cycle count is back to 0.
+    // Next step 0 should NOT fire (2:2 fires
+    // on cycle 1, not cycle 0)
+    mockPlaySound.mockClear();
+    onStep(0, 100.0);
+
+    const playedIds =
+      mockPlaySound.mock.calls.map(
+        (c: unknown[]) => c[0]
+      );
+    expect(playedIds).not.toContain('bd');
+
+    vi.restoreAllMocks();
+  }
+);
+```
+
+- [ ] **Step 2: Add E2E URL hash import test**
+
+In `src/__tests__/SequencerContext.test.tsx`, add to
+the existing `'URL hash import'` describe block:
+
+```typescript
+it('v3 hash with trigConditions sets '
+  + 'conditions in state', async () => {
+  const config = defaultConfig();
+  config.trigConditions = {
+    bd: {
+      0: { type: 'probability', value: 50 },
+    },
+    sd: {
+      3: { type: 'cycle', a: 1, b: 4 },
+    },
+  };
+  const hash = await encodeConfig(config);
+  window.location.hash = hash;
+
+  const { result } = renderSequencer();
+  await waitFor(() => {
+    expect(
+      result.current.meta.config
+        .trigConditions.bd?.[0]
+    ).toBeDefined();
+  });
+  expect(
+    result.current.meta.config
+      .trigConditions.bd![0]
+  ).toEqual(
+    { type: 'probability', value: 50 }
+  );
+  expect(
+    result.current.meta.config
+      .trigConditions.sd![3]
+  ).toEqual(
+    { type: 'cycle', a: 1, b: 4 }
+  );
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test`
+Expected: all pass
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/__tests__/handleStep.test.ts \
+  src/__tests__/SequencerContext.test.tsx
+git commit -m "Add pruning, lifecycle, and E2E tests for trig conditions"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: all pass
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: clean
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build`
+Expected: clean static export
+
+- [ ] **Step 4: Manual smoke test**
+
+Start dev server (`npm run dev`), open in browser:
+1. Verify normal playback is unchanged (no
+   conditions set)
+2. This is engine-only (no UI yet), so manual
+   verification is limited to confirming no runtime
+   errors during playback
+
+- [ ] **Step 5: Stop the dev server**
+
+- [ ] **Step 6: Commit any remaining changes and
+create PR**
+
+**Spec:**
+`docs/superpowers/specs/2026-03-17-trig-conditions-tier1-spec.md`
+
+**Design decisions:**
+- Cycle B range: 2-8 (matches Elektron)
+- Probability: integer 1-99
+- Per-track cycle counter (Elektron-style)
+- `setPattern` clears and loads conditions
+- Pattern type has optional `trigConditions?`
+- Accent supports conditions (evaluated globally)
+- Negated cycle (NOT A:B) noted for future tier

--- a/docs/superpowers/specs/2026-03-17-trig-conditions-tier1-spec.md
+++ b/docs/superpowers/specs/2026-03-17-trig-conditions-tier1-spec.md
@@ -1,0 +1,422 @@
+# Trig Conditions Tier 1: Probability & Cycle A:B — Spec
+
+Refines the engine portion of the
+[trig conditions design](2026-03-15-trig-conditions-design.md)
+based on Elektron device research and design review.
+
+**Scope:** Probability (X%) and Cycle (A:B) conditions
+only. Engine + serialization. No UI.
+
+**Issue:** [#5](https://github.com/memestreak/xox/issues/5)
+(partial)
+
+---
+
+## 1. Condition Types (Tier 1)
+
+| Type | Abbrev | Behavior | Parameters |
+|------|--------|----------|------------|
+| Probability | `%` | X% chance each visit | `value`: integer 1-99 |
+| Cycle | `A:B` | Fires on the Ath of every B track loops | `a`: 1-B, `b`: 2-8 |
+
+**One condition per step.** Missing = always fire.
+
+### Parameter Constraints
+
+- **Probability value:** Integer, clamped 1-99. Values
+  outside this range are clamped during validation.
+- **Cycle B:** Integer, clamped 2-8 (matches Elektron).
+  B=1 is not valid — that's equivalent to "always fire."
+- **Cycle A:** Integer, clamped 1-B. A > B is clamped
+  to A = B.
+
+---
+
+## 2. Data Model
+
+### TrigCondition Type
+
+```typescript
+export type TrigCondition =
+  | { type: 'probability'; value: number }
+  | { type: 'cycle'; a: number; b: number };
+```
+
+### SequencerConfig (version 3)
+
+```typescript
+export interface SequencerConfig {
+  version: number;
+  kitId: string;
+  bpm: number;
+  patternLength: number;
+  trackLengths: Record<TrackId, number>;
+  steps: Record<TrackId, string>;
+  mixer: Record<TrackId, TrackMixerState>;
+  swing: number;
+  trigConditions: Partial<
+    Record<
+      TrackId, Record<number, TrigCondition>
+    >
+  >;
+}
+```
+
+- Outer `Partial`: tracks with no conditions are absent
+- Inner `Record<number, TrigCondition>`: sparse by step
+  index
+- Only steps with conditions are stored
+
+### Pattern Type
+
+```typescript
+export interface Pattern {
+  id: string;
+  name: string;
+  steps: Record<TrackId, string>;
+  trigConditions?: Partial<
+    Record<
+      TrackId, Record<number, TrigCondition>
+    >
+  >;
+}
+```
+
+- `trigConditions` is **optional** (`?`). When absent,
+  defaults to `{}` (no conditions).
+- Existing `patterns.json` is **not modified** — preset
+  patterns have no conditions.
+- Loading a preset pattern **clears** existing conditions
+  and loads the pattern's conditions (empty for presets).
+
+---
+
+## 3. Cycle Counting
+
+### Counter Scope
+
+**Per-track.** All steps on a track share the same cycle
+count. This matches Elektron behavior. Steps with
+different A:B values on the same track reference the
+same underlying counter — they just select different
+slices.
+
+### Increment Trigger
+
+The cycle counter for a track increments **at the
+track-length boundary**, when the track's pattern loops.
+Specifically: `total > 0 && total % trackLength === 0`,
+where `total` is `totalStepsRef.current` (the
+pre-increment value in handleStep).
+
+This applies to both freeRun and non-freeRun tracks.
+`total` always increments by 1 per scheduler tick
+regardless of mode.
+
+### Timing Within handleStep
+
+1. Read `total` from `totalStepsRef.current`
+2. Increment `totalStepsRef`
+3. **Increment cycle counts** for tracks at boundaries
+4. Evaluate accent (with condition, if any)
+5. Evaluate each track's steps (with conditions)
+
+Accent is evaluated **after** cycle increment so that
+accent and tracks see the same cycle count on boundary
+steps.
+
+This means:
+- First step ever (`total=0`): cycleCount = 0 for all
+  tracks (increment check is `total > 0`, so no
+  increment)
+- Second track loop start (`total=trackLength`):
+  cycleCount increments to 1
+
+### Evaluation Formula
+
+For condition `A:B`:
+```
+fires = (cycleCount % B) === (A - 1)
+```
+
+- Cycle 0 → 1:B fires (1-1=0)
+- Cycle 1 → 2:B fires
+- Cycle B-1 → B:B fires
+- Cycle B → wraps, 1:B fires again
+
+### Reset
+
+- **Stop:** All cycle counts reset to 0
+- **Start:** All cycle counts initialized to 0
+- **Mute/unmute:** Reset cycle count for the affected
+  track only. Matches Elektron behavior where changing
+  a track's audibility resets its cycle position.
+- **Solo/unsolo:** Reset cycle count for the affected
+  track only.
+
+### FreeRun Interaction
+
+FreeRun tracks use `total % trackLength` for their
+effective step (instead of `step % trackLength`). The
+cycle counter uses the same `total`-based boundary
+detection for all tracks, so freeRun and non-freeRun
+tracks count cycles consistently.
+
+### Length-1 Tracks
+
+For a track with length 1, `total % 1 === 0` is true
+on every step (for total > 0). The cycle count
+increments every step. This is mathematically correct:
+a 1-step track repeats its single step every step, so
+each repetition is a new cycle. Cycle 1:2 on a
+length-1 track fires every other step.
+
+### Test Conventions
+
+Tests in `handleStep.test.ts` use static imports:
+
+```typescript
+import patternsData from '../app/data/patterns.json';
+import type { Pattern } from '../app/types';
+```
+
+This matches existing test patterns in
+`SequencerContext.test.tsx`. Do not use dynamic imports
+for pattern data.
+
+An E2E URL hash import test should be added to the
+existing `'URL hash import'` describe block in
+`SequencerContext.test.tsx` to verify trigConditions
+survive the full mount → decode → state flow.
+
+---
+
+## 4. Probability
+
+- Uses `Math.random()` (truly random)
+- Each visit: `Math.random() < value / 100`
+- Two users with the same shared URL hear different
+  outcomes
+- Matches Elektron behavior
+
+---
+
+## 5. Accent
+
+Accent (`ac`) **supports trig conditions** in Tier 1.
+
+- Accent is evaluated **once per step**, after cycle
+  count increment but before the per-track loop
+- Accent condition is **independent** of individual
+  track conditions
+- If accent fires, ALL audible tracks at that step get
+  the 1.5x gain boost
+- If a track's own condition suppresses it, the track
+  doesn't play (accent boost is irrelevant for that
+  track, but other tracks still get it)
+
+---
+
+## 6. Condition Lifecycle
+
+### Loading a Preset Pattern
+
+`setPattern` **clears** existing `trigConditions` and
+loads the pattern's conditions:
+
+```typescript
+return {
+  ...prev,
+  steps: newSteps,
+  trigConditions:
+    pattern.trigConditions ?? {},
+};
+```
+
+Since preset patterns have no `trigConditions` field,
+this effectively clears all conditions on preset load.
+
+### Clear All
+
+`clearAll` resets `trigConditions` to `{}`.
+
+### Track Length Change
+
+When `setTrackLength` shortens a track, conditions on
+steps beyond the new length are **pruned** (deleted).
+Conditions within the new length are preserved.
+
+### Pattern Length Change
+
+When `setPatternLength` shortens the pattern, all
+tracks whose length decreases have their conditions
+pruned accordingly.
+
+### Toggle Step Off
+
+Toggling a step off does **not** remove its condition.
+The condition is metadata that persists even when the
+step is inactive. If the step is toggled back on, the
+condition still applies. (Matches Elektron: parameter
+locks persist on inactive trigs.)
+
+---
+
+## 7. Serialization
+
+### configCodec v3
+
+- `CONFIG_VERSION` bumps from 2 to 3
+- `defaultConfig()` includes `trigConditions: {}`
+- `validateConfig()` calls `validateTrigConditions()`
+  which:
+  - Returns `{}` for missing/non-object values
+  - Iterates only known `TRACK_IDS`
+  - Drops conditions on step indices beyond track length
+  - Validates each condition: known type, clamped params
+  - Drops empty track entries (sparse)
+- `validateSingleCondition()`:
+  - `probability`: value must be finite number, clamp
+    1-99
+  - `cycle`: a and b must be finite numbers. B<2 is
+    dropped (null). B clamped to max 8. A clamped
+    to 1-B.
+  - Unknown types return `null` (dropped)
+
+### Backward Compatibility
+
+- **v1 URLs** (no patternLength, no trackLengths, no
+  trigConditions): decode with all fields defaulted.
+  `trigConditions` defaults to `{}`.
+- **v2 URLs** (no trigConditions): decode with
+  `trigConditions` defaulted to `{}`.
+- **v3 URLs**: full round-trip with conditions.
+- Version field is always stamped to `CONFIG_VERSION`
+  (3) on decode.
+
+### Golden Tests
+
+- Existing v1 golden hash still decodes correctly
+  (with `version: 3`, `trigConditions: {}`)
+- Existing v2 golden config round-trips (version
+  stamped to 3)
+- New v2 backward compat test: encode v2 config
+  without trigConditions, decode, verify
+  `trigConditions: {}`
+
+---
+
+## 8. Transient State
+
+```typescript
+// In SequencerProvider
+const cycleCountRef = useRef<
+  Record<TrackId, number>
+>({} as Record<TrackId, number>);
+```
+
+- Initialized to all-zeros on start
+- Reset to all-zeros on stop
+- Incremented per-track in handleStep at track-length
+  boundaries
+- Not serialized (transient — resets each playback)
+
+---
+
+## 9. Actions
+
+### New Actions
+
+```typescript
+setTrigCondition: (
+  trackId: TrackId,
+  stepIndex: number,
+  condition: TrigCondition
+) => void;
+
+clearTrigCondition: (
+  trackId: TrackId,
+  stepIndex: number
+) => void;
+```
+
+### Modified Actions
+
+- `setPattern`: clears and loads `trigConditions`
+- `clearAll`: resets `trigConditions` to `{}`
+- `setTrackLength`: prunes conditions beyond new length
+- `setPatternLength`: prunes conditions for all
+  affected tracks
+- `toggleMute`: resets cycle count for the toggled
+  track
+- `toggleSolo`: resets cycle count for the toggled
+  track
+
+---
+
+## 10. evaluateCondition Module
+
+Pure function in `src/app/trigConditions.ts`:
+
+```typescript
+export interface ConditionContext {
+  cycleCount: number;
+}
+
+export function evaluateCondition(
+  condition: TrigCondition | undefined,
+  ctx: ConditionContext
+): boolean;
+```
+
+- `undefined` → `true` (always fire)
+- `probability` → `Math.random() < value / 100`
+- `cycle` → `(ctx.cycleCount % b) === (a - 1)`
+
+Designed for extension: future tiers add fields to
+`ConditionContext` (e.g., `lastFired`, `stepResults`,
+`fillActive`) and new `case` branches.
+
+---
+
+## 11. Future Considerations
+
+- **Negated cycle (NOT A:B):** Elektron supports this
+  (fires on every loop *except* the Ath of every B).
+  Not in Tier 1 scope. Consider adding as a separate
+  condition type (e.g., `{ type: '!cycle', a, b }`)
+  in a future tier.
+- **Pattern save/load slots:** When XOX gains saveable
+  pattern slots, conditions should be part of the saved
+  data (already architected via the Pattern type).
+
+---
+
+## 12. Verification Criteria
+
+- [ ] 50% probability fires ~half the time (mock
+      Math.random for deterministic tests)
+- [ ] Cycle 1:4 fires on 1st of every 4 track loops
+- [ ] Cycle 3:4 fires on 3rd of every 4 track loops
+- [ ] Cycle counter is per-track, shared by all steps
+- [ ] B clamped to 2-8, A clamped to 1-B
+- [ ] Probability clamped to integer 1-99
+- [ ] Accent supports conditions (evaluated
+      independently)
+- [ ] Loading preset clears conditions
+- [ ] clearAll resets conditions
+- [ ] Shortening track prunes conditions
+- [ ] Shortening pattern length prunes conditions
+- [ ] v1 URL decodes with `trigConditions: {}`
+- [ ] v2 URL decodes with `trigConditions: {}`
+- [ ] v3 URL round-trips all conditions
+- [ ] Invalid condition types dropped on decode
+- [ ] Stop/start resets cycle counts
+- [ ] Mute/unmute resets cycle count for that track
+- [ ] Solo/unsolo resets cycle count for that track
+- [ ] Toggling a step off preserves its condition
+- [ ] Toggling a step back on re-applies its condition
+- [ ] E2E: URL with trigConditions → mount → conditions
+      in state
+- [ ] Length-1 tracks: cycle increments every step
+- [ ] `npm test` and `npm run lint` pass

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -494,4 +494,34 @@ describe('URL hash import', () => {
     expect(result.current.meta.config.kitId).toBe('808');
     expect(result.current.meta.config.bpm).toBe(300);
   });
+
+  it('v3 hash with trigConditions sets conditions in state',
+    async () => {
+      const config = defaultConfig();
+      config.trigConditions = {
+        bd: { 0: { type: 'probability', value: 50 } },
+        sd: { 3: { type: 'cycle', a: 1, b: 4 } },
+      };
+      const hash = await encodeConfig(config);
+      window.location.hash = hash;
+
+      const { result } = renderSequencer();
+      await waitFor(() => {
+        expect(
+          result.current.meta.config
+            .trigConditions.bd?.[0]
+        ).toBeDefined();
+      });
+      expect(
+        result.current.meta.config.trigConditions.bd![0]
+      ).toEqual(
+        { type: 'probability', value: 50 }
+      );
+      expect(
+        result.current.meta.config.trigConditions.sd![3]
+      ).toEqual(
+        { type: 'cycle', a: 1, b: 4 }
+      );
+    }
+  );
 });

--- a/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
+++ b/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
@@ -108,6 +108,7 @@ exports[`golden-file tests > defaultConfig() snapshot 1`] = `
     "rs": 16,
     "sd": 16,
   },
-  "version": 2,
+  "trigConditions": {},
+  "version": 3,
 }
 `;

--- a/src/__tests__/configCodec.golden.test.ts
+++ b/src/__tests__/configCodec.golden.test.ts
@@ -10,6 +10,27 @@ import type {
 import { TRACK_IDS } from '../app/types';
 
 /**
+ * Helper: encode a raw object bypassing validation,
+ * for testing backward-compat decoding of old formats.
+ */
+async function encodeRaw(obj: unknown): Promise<string> {
+  const json = JSON.stringify(obj);
+  const stream = new Blob([json]).stream()
+    .pipeThrough(new CompressionStream('deflate-raw'));
+  const bytes = new Uint8Array(
+    await new Response(stream).arrayBuffer()
+  );
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/**
  * Golden-file tests protect against silent changes to the
  * serialization format. If any of these fail, existing
  * shared URLs in the wild would break.
@@ -36,7 +57,7 @@ function goldenConfigV1Decoded(): SequencerConfig {
     trackLengths[id] = 16;
   }
   return {
-    version: 2,
+    version: 3,
     kitId: 'electro',
     bpm: 140,
     patternLength: 16,
@@ -44,6 +65,44 @@ function goldenConfigV1Decoded(): SequencerConfig {
     steps,
     mixer,
     swing: 0,
+    trigConditions: {},
+  };
+}
+
+/**
+ * What a v2 golden config decodes to in the v3 app:
+ * same fields plus trigConditions: {}, version=3.
+ */
+function goldenConfigV2Decoded(): SequencerConfig {
+  const steps = {} as Record<TrackId, string>;
+  const mixer = {} as Record<TrackId, {
+    gain: number; isMuted: boolean; isSolo: boolean;
+    freeRun: boolean;
+  }>;
+  const trackLengths = {} as Record<TrackId, number>;
+  for (const id of TRACK_IDS) {
+    steps[id] = '101010101010';
+    mixer[id] = {
+      gain: 0.8, isMuted: false, isSolo: false,
+      freeRun: false,
+    };
+    trackLengths[id] = 12;
+  }
+  trackLengths.bd = 8;
+  steps.bd = '10101010';
+  trackLengths.sd = 5;
+  steps.sd = '10100';
+  mixer.bd.freeRun = true;
+  return {
+    version: 3,
+    kitId: 'electro',
+    bpm: 140,
+    patternLength: 12,
+    trackLengths,
+    steps,
+    mixer,
+    swing: 0,
+    trigConditions: {},
   };
 }
 
@@ -71,7 +130,7 @@ function goldenConfigV2(): SequencerConfig {
   steps.sd = '10100';
   mixer.bd.freeRun = true;
   return {
-    version: 2,
+    version: 3,
     kitId: 'electro',
     bpm: 140,
     patternLength: 12,
@@ -79,6 +138,7 @@ function goldenConfigV2(): SequencerConfig {
     steps,
     mixer,
     swing: 0,
+    trigConditions: {},
   };
 }
 
@@ -100,6 +160,28 @@ describe('golden-file tests', () => {
   it('v1 hash decodes with defaults filled in', async () => {
     const decoded = await decodeConfig(GOLDEN_HASH_V1);
     expect(decoded).toEqual(goldenConfigV1Decoded());
+  });
+
+  it('v2 hash decodes with trigConditions defaulted', async () => {
+    // Encode a v2-era config (no trigConditions field) and
+    // verify it decodes cleanly with trigConditions: {}
+    // and version bumped to 3.
+    const v2Config = {
+      version: 2,
+      kitId: 'electro',
+      bpm: 140,
+      patternLength: 12,
+      trackLengths: goldenConfigV2Decoded().trackLengths,
+      steps: goldenConfigV2Decoded().steps,
+      mixer: goldenConfigV2Decoded().mixer,
+      swing: 0,
+      // no trigConditions field
+    };
+    const hash = await encodeRaw(v2Config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded).toEqual(goldenConfigV2Decoded());
+    expect(decoded.version).toBe(3);
+    expect(decoded.trigConditions).toEqual({});
   });
 
   it('v2 config round-trips identically', async () => {

--- a/src/__tests__/configCodec.test.ts
+++ b/src/__tests__/configCodec.test.ts
@@ -168,7 +168,7 @@ describe('defensive decoding', () => {
     const raw = { ...config, version: 999 };
     const hash = await encodeRaw(raw);
     const decoded = await decodeConfig(hash);
-    expect(decoded.version).toBe(2);
+    expect(decoded.version).toBe(3);
   });
 
   it('partial config (only kitId) fills defaults', async () => {
@@ -375,6 +375,146 @@ describe('swing serialization', () => {
       ...defaultConfig(), swing: 'high',
     });
     expect((await decodeConfig(hash)).swing).toBe(0);
+  });
+});
+
+// -------------------------------------------------------
+// D. TrigCondition validation
+// -------------------------------------------------------
+describe('validateTrigConditions', () => {
+  it('missing trigConditions defaults to empty', async () => {
+    const config = defaultConfig();
+    const { trigConditions, ...noTc } = config;
+    void trigConditions; // intentionally omitted
+    const hash = await encodeRaw(noTc);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
+  });
+
+  it('valid probability condition round-trips', async () => {
+    const config = defaultConfig();
+    config.trigConditions = {
+      bd: { 0: { type: 'probability', value: 50 } },
+    };
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({
+      bd: { 0: { type: 'probability', value: 50 } },
+    });
+  });
+
+  it('valid cycle condition round-trips', async () => {
+    const config = defaultConfig();
+    config.trigConditions = {
+      sd: { 2: { type: 'cycle', a: 1, b: 4 } },
+    };
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({
+      sd: { 2: { type: 'cycle', a: 1, b: 4 } },
+    });
+  });
+
+  it('invalid type is dropped', async () => {
+    const config = defaultConfig();
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: { 0: { type: 'random', value: 50 } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
+  });
+
+  it('probability value clamped to 1-99', async () => {
+    const config = defaultConfig();
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: {
+          0: { type: 'probability', value: 0 },
+          1: { type: 'probability', value: 100 },
+          2: { type: 'probability', value: 50 },
+        },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions.bd?.[0]).toEqual(
+      { type: 'probability', value: 1 }
+    );
+    expect(decoded.trigConditions.bd?.[1]).toEqual(
+      { type: 'probability', value: 99 }
+    );
+    expect(decoded.trigConditions.bd?.[2]).toEqual(
+      { type: 'probability', value: 50 }
+    );
+  });
+
+  it('cycle b clamped to max 8', async () => {
+    const config = defaultConfig();
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: { 0: { type: 'cycle', a: 1, b: 16 } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions.bd?.[0]).toEqual(
+      { type: 'cycle', a: 1, b: 8 }
+    );
+  });
+
+  it('cycle b=1 is dropped', async () => {
+    const config = defaultConfig();
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: { 0: { type: 'cycle', a: 1, b: 1 } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
+  });
+
+  it('cycle a>b is clamped to a=b', async () => {
+    const config = defaultConfig();
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: { 0: { type: 'cycle', a: 5, b: 3 } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions.bd?.[0]).toEqual(
+      { type: 'cycle', a: 3, b: 3 }
+    );
+  });
+
+  it('step index beyond track length is dropped', async () => {
+    const config = defaultConfig();
+    // Default track length is 16, step 16 is out of bounds
+    const raw = {
+      ...config,
+      trigConditions: {
+        bd: { 16: { type: 'probability', value: 50 } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
+  });
+
+  it('non-object trigConditions defaults to empty', async () => {
+    const raw = { ...defaultConfig(), trigConditions: 'bad' };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
   });
 });
 

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useSequencer } from '../app/SequencerContext';
 import { TRACK_IDS } from '../app/types';
 import type { TrackId } from '../app/types';
+import patternsData from '../app/data/patterns.json';
+import type { Pattern } from '../app/types';
 import { TestWrapper } from './helpers/sequencer-wrapper';
 
 // Mock AudioEngine -- capture the onStep callback via start()
@@ -582,6 +584,217 @@ describe('trig conditions in handleStep', () => {
         result.current.meta.config
           .trigConditions.bd?.[0]
       ).toBeUndefined();
+    }
+  );
+
+  it('shortening track prunes conditions beyond length',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 15, { type: 'probability', value: 75 }
+        );
+      });
+      await act(async () => {
+        result.current.actions.setTrackLength('bd', 8);
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[15]
+      ).toBeUndefined();
+    }
+  );
+
+  it('shortening track preserves conditions within length',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 3, { type: 'probability', value: 75 }
+        );
+      });
+      await act(async () => {
+        result.current.actions.setTrackLength('bd', 8);
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[3]
+      ).toEqual({ type: 'probability', value: 75 });
+    }
+  );
+
+  it('shortening pattern length prunes conditions',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 15, { type: 'probability', value: 75 }
+        );
+      });
+      await act(async () => {
+        result.current.actions.setPatternLength(8);
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[15]
+      ).toBeUndefined();
+    }
+  );
+
+  it('clearAll resets trigConditions',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0, { type: 'probability', value: 50 }
+        );
+      });
+      await act(async () => {
+        result.current.actions.clearAll();
+      });
+
+      expect(
+        result.current.meta.config.trigConditions
+      ).toEqual({});
+    }
+  );
+
+  it('loading preset clears conditions',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0, { type: 'probability', value: 50 }
+        );
+      });
+      await act(async () => {
+        result.current.actions.setPattern(
+          patternsData.patterns[0] as Pattern
+        );
+      });
+
+      expect(
+        result.current.meta.config.trigConditions
+      ).toEqual({});
+    }
+  );
+
+  it('toggling step off preserves condition',
+    async () => {
+      const { result } = renderSequencer();
+
+      // Turn step 0 of bd on
+      await act(async () => {
+        const cur =
+          result.current.meta.config.steps.bd;
+        if (cur[0] === '0') {
+          result.current.actions.toggleStep('bd', 0);
+        }
+      });
+
+      // Set a condition
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0,
+          { type: 'probability', value: 50 }
+        );
+      });
+
+      // Toggle step off
+      await act(async () => {
+        result.current.actions.toggleStep('bd', 0);
+      });
+
+      // Condition should persist
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toEqual({ type: 'probability', value: 50 });
+
+      // Toggle step back on
+      await act(async () => {
+        result.current.actions.toggleStep('bd', 0);
+      });
+
+      // Condition should still be there
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toEqual({ type: 'probability', value: 50 });
+    }
+  );
+
+  it('mute resets cycle count for that track',
+    async () => {
+      const { result } = renderSequencer();
+
+      // Start clean, activate bd step 0
+      await act(async () => {
+        result.current.actions.clearAll();
+      });
+      await act(async () => {
+        result.current.actions.toggleStep('bd', 0);
+      });
+
+      // Set cycle 2:2: fires when cycleCount % 2 === 1
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0,
+          { type: 'cycle', a: 2, b: 2 }
+        );
+      });
+
+      mockPlaySound.mockClear();
+      mockStart.mockClear();
+
+      await act(async () => {
+        result.current.actions.togglePlay();
+      });
+
+      const onStep = mockStart.mock.calls[0][1] as (
+        step: number, time: number
+      ) => void;
+
+      await waitFor(() => {
+        expect(
+          result.current.state.isPlaying
+        ).toBe(true);
+      });
+      mockPlaySound.mockClear();
+
+      // Play 17 steps: cycle increments at total=16,
+      // so cycleCount=1 after 17 calls.
+      // total=17 after these calls (not a multiple of 16).
+      for (let s = 0; s < 17; s++) {
+        onStep(s % 16, 0.0);
+      }
+
+      // Mute then unmute bd — each call resets
+      // cycleCountRef[bd] to 0
+      await act(async () => {
+        result.current.actions.toggleMute('bd');
+      });
+      await act(async () => {
+        result.current.actions.toggleMute('bd');
+      });
+
+      mockPlaySound.mockClear();
+
+      // totalStepsRef is now 17; 17 % 16 !== 0, so no
+      // cycle increment fires. cycleCount stays at 0.
+      // cycle 2:2 requires cycleCount % 2 === 1, so
+      // bd step 0 should NOT fire.
+      onStep(0, 0.0);
+
+      expect(mockPlaySound).not.toHaveBeenCalled();
     }
   );
 });

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -462,3 +462,126 @@ describe('handleStep swing timing', () => {
     }
   });
 });
+
+// -------------------------------------------------
+// trig conditions in handleStep
+// -------------------------------------------------
+describe('trig conditions in handleStep', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+    mockStop.mockClear();
+  });
+
+  it('step with probability condition can be suppressed',
+    async () => {
+      const { result } = renderSequencer();
+
+      // Clear all, then activate bd step 0
+      await act(async () => {
+        result.current.actions.clearAll();
+      });
+      await act(async () => {
+        result.current.actions.toggleStep('bd', 0);
+      });
+
+      // Set probability 50 on bd step 0
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0, { type: 'probability', value: 50 }
+        );
+      });
+
+      // Mock Math.random to return 0.99 (> 0.50)
+      const randomSpy = vi.spyOn(Math, 'random')
+        .mockReturnValue(0.99);
+
+      mockPlaySound.mockClear();
+      mockStart.mockClear();
+
+      await act(async () => {
+        result.current.actions.togglePlay();
+      });
+
+      const onStep = mockStart.mock.calls[0][1] as (
+        step: number, time: number
+      ) => void;
+
+      await waitFor(() => {
+        expect(
+          result.current.state.isPlaying
+        ).toBe(true);
+      });
+      mockPlaySound.mockClear();
+
+      onStep(0, 0.0);
+
+      expect(mockPlaySound).not.toHaveBeenCalled();
+      randomSpy.mockRestore();
+    }
+  );
+
+  it('step without condition always fires',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.clearAll();
+      });
+      await act(async () => {
+        result.current.actions.toggleStep('bd', 0);
+      });
+
+      mockPlaySound.mockClear();
+      mockStart.mockClear();
+
+      await act(async () => {
+        result.current.actions.togglePlay();
+      });
+
+      const onStep = mockStart.mock.calls[0][1] as (
+        step: number, time: number
+      ) => void;
+
+      await waitFor(() => {
+        expect(
+          result.current.state.isPlaying
+        ).toBe(true);
+      });
+      mockPlaySound.mockClear();
+
+      onStep(0, 0.0);
+
+      expect(mockPlaySound).toHaveBeenCalledTimes(1);
+      expect(mockPlaySound.mock.calls[0][0]).toBe('bd');
+    }
+  );
+
+  it('clearTrigCondition removes condition',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setTrigCondition(
+          'bd', 0, { type: 'probability', value: 50 }
+        );
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toEqual({ type: 'probability', value: 50 });
+
+      await act(async () => {
+        result.current.actions.clearTrigCondition(
+          'bd', 0
+        );
+      });
+
+      expect(
+        result.current.meta.config
+          .trigConditions.bd?.[0]
+      ).toBeUndefined();
+    }
+  );
+});

--- a/src/__tests__/trigConditions.test.ts
+++ b/src/__tests__/trigConditions.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  evaluateCondition,
+} from '../app/trigConditions';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('evaluateCondition', () => {
+  describe('undefined condition', () => {
+    it('always fires when condition is undefined', () => {
+      expect(evaluateCondition(undefined, { cycleCount: 0 })).toBe(true);
+      expect(evaluateCondition(undefined, { cycleCount: 99 })).toBe(true);
+    });
+  });
+
+  describe('probability condition', () => {
+    it('fires when Math.random returns 0.49 with 50% probability', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.49);
+      expect(
+        evaluateCondition(
+          { type: 'probability', value: 50 },
+          { cycleCount: 0 }
+        )
+      ).toBe(true);
+    });
+
+    it('does not fire when Math.random returns 0.50 with 50% prob', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.50);
+      expect(
+        evaluateCondition(
+          { type: 'probability', value: 50 },
+          { cycleCount: 0 }
+        )
+      ).toBe(false);
+    });
+
+    it('fires when random < 0.01 with 1% probability', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.009);
+      expect(
+        evaluateCondition(
+          { type: 'probability', value: 1 },
+          { cycleCount: 0 }
+        )
+      ).toBe(true);
+    });
+
+    it('does not fire when random >= 0.99 with 99% probability', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.99);
+      expect(
+        evaluateCondition(
+          { type: 'probability', value: 99 },
+          { cycleCount: 0 }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('cycle condition', () => {
+    it('cycle 1:4 fires on cycle 0', () => {
+      expect(
+        evaluateCondition(
+          { type: 'cycle', a: 1, b: 4 },
+          { cycleCount: 0 }
+        )
+      ).toBe(true);
+    });
+
+    it('cycle 1:4 does not fire on cycles 1, 2, 3', () => {
+      const cond = { type: 'cycle' as const, a: 1, b: 4 };
+      expect(evaluateCondition(cond, { cycleCount: 1 })).toBe(false);
+      expect(evaluateCondition(cond, { cycleCount: 2 })).toBe(false);
+      expect(evaluateCondition(cond, { cycleCount: 3 })).toBe(false);
+    });
+
+    it('cycle 3:4 fires on cycle 2', () => {
+      expect(
+        evaluateCondition(
+          { type: 'cycle', a: 3, b: 4 },
+          { cycleCount: 2 }
+        )
+      ).toBe(true);
+    });
+
+    it('cycle 2:2 fires on odd 0-indexed cycles', () => {
+      const cond = { type: 'cycle' as const, a: 2, b: 2 };
+      expect(evaluateCondition(cond, { cycleCount: 0 })).toBe(false);
+      expect(evaluateCondition(cond, { cycleCount: 1 })).toBe(true);
+      expect(evaluateCondition(cond, { cycleCount: 2 })).toBe(false);
+      expect(evaluateCondition(cond, { cycleCount: 3 })).toBe(true);
+    });
+  });
+});

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -14,11 +14,13 @@ import kitsData from './data/kits.json';
 import patternsData from './data/patterns.json';
 import { audioEngine } from './AudioEngine';
 import { defaultConfig, decodeConfig } from './configCodec';
+import { evaluateCondition } from './trigConditions';
 import { TRACK_IDS } from './types';
 import type {
   Kit,
   Pattern,
   SequencerConfig,
+  TrigCondition,
   TrackId,
   TrackState,
 } from './types';
@@ -88,6 +90,15 @@ interface SequencerActions {
   ) => void;
   clearAll: () => void;
   setSwing: (value: number) => void;
+  setTrigCondition: (
+    trackId: TrackId,
+    stepIndex: number,
+    condition: TrigCondition
+  ) => void;
+  clearTrigCondition: (
+    trackId: TrackId,
+    stepIndex: number
+  ) => void;
 }
 
 interface SequencerMeta {
@@ -241,6 +252,9 @@ export function SequencerProvider({
   const trackStatesRef = useRef(trackStates);
   const patternRef = useRef(currentPattern);
   const configRef = useRef(config);
+  const cycleCountRef = useRef<Record<TrackId, number>>(
+    {} as Record<TrackId, number>
+  );
 
   useEffect(() => {
     trackStatesRef.current = trackStates;
@@ -303,6 +317,15 @@ export function SequencerProvider({
         t => t.isSolo
       );
 
+      // Increment cycle count at cycle boundaries
+      for (const id of TRACK_IDS) {
+        const len = cfg.trackLengths[id];
+        if (total > 0 && total % len === 0) {
+          cycleCountRef.current[id] =
+            (cycleCountRef.current[id] ?? 0) + 1;
+        }
+      }
+
       const trackStep = (
         id: TrackId
       ): number => {
@@ -312,10 +335,18 @@ export function SequencerProvider({
           : step % len;
       };
 
-      const isAccented =
-        pattern.steps.ac[
-          trackStep('ac')
-        ] === '1';
+      const accentStep = trackStep('ac');
+      const accentActive =
+        pattern.steps.ac[accentStep] === '1';
+      let isAccented = false;
+      if (accentActive) {
+        const accentCond =
+          cfg.trigConditions?.ac?.[accentStep];
+        isAccented = evaluateCondition(accentCond, {
+          cycleCount:
+            cycleCountRef.current.ac ?? 0,
+        });
+      }
 
       TRACKS.forEach(track => {
         const st = states[track.id];
@@ -326,8 +357,22 @@ export function SequencerProvider({
 
         const effectiveStep = trackStep(track.id);
         if (
-          pattern.steps[track.id][effectiveStep] === '1'
+          pattern.steps[track.id][effectiveStep]
+            === '1'
         ) {
+          const cond =
+            cfg.trigConditions
+              ?.[track.id]?.[effectiveStep];
+          const shouldFire = evaluateCondition(
+            cond,
+            {
+              cycleCount:
+                cycleCountRef.current[track.id]
+                  ?? 0,
+            }
+          );
+          if (!shouldFire) return;
+
           const cubic = st.gain ** 3;
           const gain =
             isAccented ? cubic * 1.5 : cubic;
@@ -348,14 +393,22 @@ export function SequencerProvider({
 
   // ─── Actions ──────────────────────────────────────
 
+  const initCycleCounts = useCallback(() => {
+    const counts = {} as Record<TrackId, number>;
+    for (const id of TRACK_IDS) { counts[id] = 0; }
+    cycleCountRef.current = counts;
+  }, []);
+
   const togglePlay = useCallback(() => {
     if (isPlaying) {
       audioEngine.stop();
       setIsPlaying(false);
       stepRef.current = -1;
       totalStepsRef.current = 0;
+      initCycleCounts();
     } else {
       totalStepsRef.current = 0;
+      initCycleCounts();
       audioEngine.start(
         config.bpm,
         handleStep,
@@ -364,7 +417,7 @@ export function SequencerProvider({
       setIsPlaying(true);
     }
   }, [isPlaying, config.bpm, config.patternLength,
-    handleStep]);
+    handleStep, initCycleCounts]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -408,7 +461,12 @@ export function SequencerProvider({
           newSteps[id] = cur.substring(0, len);
         }
       }
-      return { ...prev, steps: newSteps };
+      return {
+        ...prev,
+        steps: newSteps,
+        trigConditions:
+          pattern.trigConditions ?? {},
+      };
     });
     setSelectedPatternId(pattern.id);
   }, []);
@@ -463,6 +521,9 @@ export function SequencerProvider({
           ...prev.trackLengths,
         };
         const newSteps = { ...prev.steps };
+        const newTrigConds = {
+          ...prev.trigConditions,
+        };
         for (const id of TRACK_IDS) {
           if (newTrackLengths[id] > clamped) {
             newTrackLengths[id] = clamped;
@@ -478,12 +539,27 @@ export function SequencerProvider({
           } else if (cur.length > len) {
             newSteps[id] = cur.substring(0, len);
           }
+          // Prune conditions beyond new length
+          const trackConds = newTrigConds[id];
+          if (trackConds) {
+            const pruned: Record<
+              number, TrigCondition
+            > = {};
+            for (const [k, v] of
+              Object.entries(trackConds)) {
+              if (Number(k) < len) {
+                pruned[Number(k)] = v;
+              }
+            }
+            newTrigConds[id] = pruned;
+          }
         }
         return {
           ...prev,
           patternLength: clamped,
           trackLengths: newTrackLengths,
           steps: newSteps,
+          trigConditions: newTrigConds,
         };
       });
       setSelectedPatternId('custom');
@@ -505,6 +581,26 @@ export function SequencerProvider({
         } else {
           newSteps = cur.substring(0, clamped);
         }
+        // Prune conditions beyond new length
+        const trackConds =
+          prev.trigConditions[trackId];
+        let newTrigConditions =
+          prev.trigConditions;
+        if (trackConds) {
+          const pruned: Record<
+            number, TrigCondition
+          > = {};
+          for (const [k, v] of
+            Object.entries(trackConds)) {
+            if (Number(k) < clamped) {
+              pruned[Number(k)] = v;
+            }
+          }
+          newTrigConditions = {
+            ...prev.trigConditions,
+            [trackId]: pruned,
+          };
+        }
         return {
           ...prev,
           trackLengths: {
@@ -515,6 +611,7 @@ export function SequencerProvider({
             ...prev.steps,
             [trackId]: newSteps,
           },
+          trigConditions: newTrigConditions,
         };
       });
       setSelectedPatternId('custom');
@@ -534,6 +631,7 @@ export function SequencerProvider({
           },
         },
       }));
+      cycleCountRef.current[trackId] = 0;
     },
     []
   );
@@ -550,6 +648,7 @@ export function SequencerProvider({
           },
         },
       }));
+      cycleCountRef.current[trackId] = 0;
     },
     []
   );
@@ -586,6 +685,7 @@ export function SequencerProvider({
         steps: newSteps,
         trackLengths: newTrackLengths,
         swing: 0,
+        trigConditions: {},
       };
     });
     setSelectedPatternId('custom');
@@ -597,6 +697,45 @@ export function SequencerProvider({
         ...prev,
         swing: Math.max(0, Math.min(100, value)),
       }));
+    },
+    []
+  );
+
+  const setTrigCondition = useCallback(
+    (
+      trackId: TrackId,
+      stepIndex: number,
+      condition: TrigCondition
+    ) => {
+      setConfig(prev => ({
+        ...prev,
+        trigConditions: {
+          ...prev.trigConditions,
+          [trackId]: {
+            ...prev.trigConditions[trackId],
+            [stepIndex]: condition,
+          },
+        },
+      }));
+    },
+    []
+  );
+
+  const clearTrigCondition = useCallback(
+    (trackId: TrackId, stepIndex: number) => {
+      setConfig(prev => {
+        const trackConds = {
+          ...prev.trigConditions[trackId],
+        };
+        delete trackConds[stepIndex];
+        return {
+          ...prev,
+          trigConditions: {
+            ...prev.trigConditions,
+            [trackId]: trackConds,
+          },
+        };
+      });
     },
     []
   );
@@ -629,6 +768,8 @@ export function SequencerProvider({
       setTrackLength,
       clearAll,
       setSwing,
+      setTrigCondition,
+      clearTrigCondition,
     },
     meta: { stepRef, totalStepsRef, config },
   };

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -6,10 +6,11 @@ import type {
   SequencerConfig,
   TrackId,
   TrackMixerState,
+  TrigCondition,
 } from './types';
 import { TRACK_IDS } from './types';
 
-const CONFIG_VERSION = 2;
+const CONFIG_VERSION = 3;
 const DEFAULT_KIT_ID = '808';
 const BPM_MIN = 20;
 const BPM_MAX = 300;
@@ -43,6 +44,7 @@ export function defaultConfig(): SequencerConfig {
     steps: firstPattern.steps as Record<TrackId, string>,
     mixer,
     swing: 0,
+    trigConditions: {},
   };
 }
 
@@ -160,6 +162,9 @@ function validateConfig(
     obj.mixer, defaults.mixer
   );
   const swing = validateSwing(obj.swing);
+  const trigConditions = validateTrigConditions(
+    obj.trigConditions, trackLengths
+  );
 
   return {
     version: CONFIG_VERSION,
@@ -170,6 +175,7 @@ function validateConfig(
     steps,
     mixer,
     swing,
+    trigConditions,
   };
 }
 
@@ -284,6 +290,93 @@ function normalizeSteps(
       result[id] = cur.substring(0, len);
     }
   }
+  return result;
+}
+
+const PROB_MIN = 1;
+const PROB_MAX = 99;
+const CYCLE_B_MIN = 2;
+const CYCLE_B_MAX = 8;
+
+/**
+ * Validate a single trig condition object.
+ * Returns null if the condition is invalid and should be dropped.
+ */
+function validateSingleCondition(
+  raw: unknown
+): TrigCondition | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  if (obj.type === 'probability') {
+    if (
+      typeof obj.value !== 'number' ||
+      !isFinite(obj.value)
+    ) return null;
+    return {
+      type: 'probability',
+      value: Math.max(
+        PROB_MIN, Math.min(PROB_MAX, Math.round(obj.value))
+      ),
+    };
+  }
+
+  if (obj.type === 'cycle') {
+    if (
+      typeof obj.a !== 'number' || !isFinite(obj.a) ||
+      typeof obj.b !== 'number' || !isFinite(obj.b)
+    ) return null;
+    const rawB = Math.round(obj.b);
+    if (rawB < CYCLE_B_MIN) return null;
+    const b = Math.min(CYCLE_B_MAX, rawB);
+    const a = Math.max(1, Math.min(b, Math.round(obj.a)));
+    return { type: 'cycle', a, b };
+  }
+
+  return null;
+}
+
+/**
+ * Validate trigConditions map. Drops entries with invalid
+ * step indices (>= trackLength) or invalid condition objects.
+ */
+function validateTrigConditions(
+  value: unknown,
+  trackLengths: Record<TrackId, number>
+): SequencerConfig['trigConditions'] {
+  if (value === null || typeof value !== 'object') return {};
+  const obj = value as Record<string, unknown>;
+  const result: SequencerConfig['trigConditions'] = {};
+
+  for (const id of TRACK_IDS) {
+    const trackEntry = obj[id];
+    if (
+      trackEntry === null ||
+      typeof trackEntry !== 'object'
+    ) continue;
+
+    const trackLength = trackLengths[id];
+    const stepMap = trackEntry as Record<string, unknown>;
+    const validSteps: Record<number, TrigCondition> = {};
+
+    for (const key of Object.keys(stepMap)) {
+      const stepIndex = Number(key);
+      if (
+        !Number.isInteger(stepIndex) ||
+        stepIndex < 0 ||
+        stepIndex >= trackLength
+      ) continue;
+      const cond = validateSingleCondition(stepMap[key]);
+      if (cond !== null) {
+        validSteps[stepIndex] = cond;
+      }
+    }
+
+    if (Object.keys(validSteps).length > 0) {
+      result[id] = validSteps;
+    }
+  }
+
   return result;
 }
 

--- a/src/app/trigConditions.ts
+++ b/src/app/trigConditions.ts
@@ -1,0 +1,40 @@
+import type { TrigCondition } from './types';
+
+/**
+ * Context needed to evaluate a trig condition.
+ */
+export interface ConditionContext {
+  /** Current cycle count for this track (0-indexed). */
+  cycleCount: number;
+}
+
+/**
+ * Evaluate whether a step should fire given its
+ * condition and the current context.
+ *
+ * Returns true if:
+ * - No condition (undefined) -- always fire
+ * - Probability: Math.random() < value/100
+ * - Cycle A:B: (cycleCount % b) === (a - 1)
+ *
+ * Args:
+ *   condition: The trig condition, or undefined
+ *     for unconditional steps.
+ *   ctx: Current evaluation context.
+ *
+ * Returns:
+ *   Whether the step should fire.
+ */
+export function evaluateCondition(
+  condition: TrigCondition | undefined,
+  ctx: ConditionContext
+): boolean {
+  if (condition === undefined) return true;
+
+  switch (condition.type) {
+    case 'probability':
+      return Math.random() < condition.value / 100;
+    case 'cycle':
+      return ctx.cycleCount % condition.b === condition.a - 1;
+  }
+}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -13,12 +13,25 @@ export interface Kit {
 }
 
 /**
+ * A trig condition controlling when a step fires.
+ *
+ * - probability: fires randomly with the given percentage (1-99)
+ * - cycle: fires on step `a` of every `b` repetitions (1/b to b/b)
+ */
+export type TrigCondition =
+  | { type: 'probability'; value: number }
+  | { type: 'cycle'; a: number; b: number };
+
+/**
  * Represents a pattern with variable-length step strings.
  */
 export interface Pattern {
   id: string;
   name: string;
   steps: Record<TrackId, string>;
+  trigConditions?: Partial<
+    Record<TrackId, Record<number, TrigCondition>>
+  >;
 }
 
 /**
@@ -68,4 +81,7 @@ export interface SequencerConfig {
   steps: Record<TrackId, string>;
   mixer: Record<TrackId, TrackMixerState>;
   swing: number;
+  trigConditions: Partial<
+    Record<TrackId, Record<number, TrigCondition>>
+  >;
 }


### PR DESCRIPTION
## Summary

- Add `TrigCondition` type (probability + cycle A:B) and
  `trigConditions` sparse map to `SequencerConfig` (v3)
- Add optional `trigConditions?` to `Pattern` type
- Bump configCodec to v3 with validation and backward compat
  for v1/v2 URLs
- Add pure `evaluateCondition()` module for condition evaluation
- Wire condition evaluation into `handleStep` with per-track
  cycle counting (Elektron-style)
- Add `setTrigCondition`/`clearTrigCondition` actions
- Conditions cleared on preset load, clearAll; pruned on
  track/pattern length change
- Mute/solo resets cycle count for affected track
- Accent supports conditions (evaluated globally)

Engine only — no UI. Tier 1 of the trig conditions feature
(probability and cycle A:B). Future tiers add PRE, NEI, FILL,
1st, and the condition popover UI.

Part of #5

## Test plan

- [x] 157 tests pass (11 test files)
- [x] Zero lint errors
- [x] Production build succeeds
- [x] Probability: mocked Math.random verifies fire/suppress
- [x] Cycle A:B: unit tests for 1:4, 3:4, 2:2
- [x] configCodec v3: round-trip, clamping, B<2 dropped,
  invalid types dropped, step out of range dropped
- [x] Golden tests: v1 and v2 URLs decode with trigConditions
  defaulted to {}
- [x] E2E: URL hash with trigConditions -> mount -> conditions
  in state
- [x] Pruning: track length, pattern length
- [x] Lifecycle: clearAll, preset load, toggle-off preserves
- [x] Mute resets cycle count
- [x] Manual smoke test: playback works normally

