### PR TITLE
Add trig conditions UI (per-step popover)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "16.1.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "use-long-press": "^3.3.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
@@ -7738,6 +7739,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-long-press": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-3.3.0.tgz",
+      "integrity": "sha512-Yedz46ILxsb1BTS6kUzpV/wyEZPUlJDq+8Oat0LP1eOZQHbS887baJHJbIGENqCo8wTKNxmoTHLdY8lU/e+wvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "use-long-press": "^3.3.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/src/__tests__/ProbabilitySlider.test.tsx
+++ b/src/__tests__/ProbabilitySlider.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent }
+  from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ProbabilitySlider
+  from '../app/ProbabilitySlider';
+
+describe('ProbabilitySlider', () => {
+  it('renders with aria-valuenow', () => {
+    render(
+      <ProbabilitySlider
+        value={75}
+        onChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('slider')
+        .getAttribute('aria-valuenow')
+    ).toBe('75');
+  });
+
+  it('displays percentage text', () => {
+    const { container } = render(
+      <ProbabilitySlider
+        value={42}
+        onChange={vi.fn()}
+      />
+    );
+    expect(container.textContent).toContain('42%');
+  });
+
+  it('ArrowRight +1', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={50} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'),
+      { key: 'ArrowRight' }
+    );
+    expect(fn).toHaveBeenCalledWith(51);
+  });
+
+  it('Shift+ArrowRight +10', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={50} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'),
+      { key: 'ArrowRight', shiftKey: true }
+    );
+    expect(fn).toHaveBeenCalledWith(60);
+  });
+
+  it('Home = 1', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={50} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'), { key: 'Home' }
+    );
+    expect(fn).toHaveBeenCalledWith(1);
+  });
+
+  it('End = 100', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={50} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'), { key: 'End' }
+    );
+    expect(fn).toHaveBeenCalledWith(100);
+  });
+
+  it('clamps at 1 min', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={1} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'),
+      { key: 'ArrowLeft' }
+    );
+    expect(fn).toHaveBeenCalledWith(1);
+  });
+
+  it('clamps at 100 max', () => {
+    const fn = vi.fn();
+    render(
+      <ProbabilitySlider value={100} onChange={fn} />
+    );
+    fireEvent.keyDown(
+      screen.getByRole('slider'),
+      { key: 'ArrowRight' }
+    );
+    expect(fn).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -499,8 +499,8 @@ describe('URL hash import', () => {
     async () => {
       const config = defaultConfig();
       config.trigConditions = {
-        bd: { 0: { type: 'probability', value: 50 } },
-        sd: { 3: { type: 'cycle', a: 1, b: 4 } },
+        bd: { 0: { probability: 50 } },
+        sd: { 3: { cycle: { a: 1, b: 4 } } },
       };
       const hash = await encodeConfig(config);
       window.location.hash = hash;
@@ -515,12 +515,12 @@ describe('URL hash import', () => {
       expect(
         result.current.meta.config.trigConditions.bd![0]
       ).toEqual(
-        { type: 'probability', value: 50 }
+        { probability: 50 }
       );
       expect(
         result.current.meta.config.trigConditions.sd![3]
       ).toEqual(
-        { type: 'cycle', a: 1, b: 4 }
+        { cycle: { a: 1, b: 4 } }
       );
     }
   );

--- a/src/__tests__/StepButton.test.tsx
+++ b/src/__tests__/StepButton.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent }
+  from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StepButton from '../app/StepButton';
+
+const base = {
+  trackName: 'Kick',
+  stepIndex: 0,
+  isActive: true,
+  isCurrent: false,
+  isBeat: false,
+  isDisabled: false,
+  onToggle: vi.fn(),
+};
+
+describe('StepButton indicators', () => {
+  it('prob bar when < 100', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        conditions={{ probability: 50 }}
+      />
+    );
+    const bar = container.querySelector(
+      '[data-testid="prob-bar"]'
+    );
+    expect(bar).toBeTruthy();
+    expect(
+      bar?.getAttribute('style')
+    ).toContain('width: 50%');
+  });
+
+  it('no prob bar when undefined', () => {
+    const { container } = render(
+      <StepButton {...base} />
+    );
+    expect(container.querySelector(
+      '[data-testid="prob-bar"]'
+    )).toBeNull();
+  });
+
+  it('cycle text when set', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        conditions={{ cycle: { a: 2, b: 4 } }}
+      />
+    );
+    expect(container.textContent).toContain('2:4');
+  });
+
+  it('both indicators coexist', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        conditions={{
+          probability: 75,
+          cycle: { a: 1, b: 3 },
+        }}
+      />
+    );
+    expect(container.querySelector(
+      '[data-testid="prob-bar"]'
+    )).toBeTruthy();
+    expect(container.textContent).toContain('1:3');
+  });
+
+  it('no indicators on inactive step', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        isActive={false}
+        conditions={{ probability: 50 }}
+      />
+    );
+    expect(container.querySelector(
+      '[data-testid="prob-bar"]'
+    )).toBeNull();
+  });
+});
+
+describe('StepButton interactions', () => {
+  it('right-click on active calls onOpenPopover',
+    () => {
+      const onOpen = vi.fn();
+      render(
+        <StepButton
+          {...base}
+          onOpenPopover={onOpen}
+        />
+      );
+      fireEvent.contextMenu(
+        screen.getByRole('button')
+      );
+      expect(onOpen).toHaveBeenCalled();
+    }
+  );
+
+  it('right-click on inactive: no popover', () => {
+    const onOpen = vi.fn();
+    render(
+      <StepButton
+        {...base}
+        isActive={false}
+        onOpenPopover={onOpen}
+      />
+    );
+    fireEvent.contextMenu(
+      screen.getByRole('button')
+    );
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('click still toggles', () => {
+    const toggle = vi.fn();
+    render(
+      <StepButton
+        {...base}
+        onToggle={toggle}
+        onOpenPopover={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/TrigConditionPopover.test.tsx
+++ b/src/__tests__/TrigConditionPopover.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent }
+  from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach }
+  from 'vitest';
+import TrigConditionPopover
+  from '../app/TrigConditionPopover';
+
+const mockSet = vi.fn();
+const mockClear = vi.fn();
+
+vi.mock('../app/SequencerContext', () => ({
+  useSequencer: () => ({
+    actions: {
+      setTrigCondition: mockSet,
+      clearTrigCondition: mockClear,
+    },
+  }),
+}));
+
+const base = {
+  trackId: 'bd' as const,
+  stepIndex: 3,
+  conditions: undefined as undefined,
+  onClose: vi.fn(),
+};
+
+describe('TrigConditionPopover', () => {
+  beforeEach(() => {
+    mockSet.mockClear();
+    mockClear.mockClear();
+    base.onClose.mockClear();
+  });
+
+  it('header shows step number + track abbrev',
+    () => {
+      render(<TrigConditionPopover {...base} />);
+      expect(
+        screen.getByText(/Step 4/)
+      ).toBeTruthy();
+      expect(
+        screen.getByText(/BD/)
+      ).toBeTruthy();
+    }
+  );
+
+  it('slider defaults to 100', () => {
+    render(<TrigConditionPopover {...base} />);
+    expect(
+      screen.getByRole('slider')
+        .getAttribute('aria-valuenow')
+    ).toBe('100');
+  });
+
+  it('cycle defaults to 1:1', () => {
+    render(<TrigConditionPopover {...base} />);
+    const sel = screen.getByRole(
+      'combobox'
+    ) as HTMLSelectElement;
+    expect(sel.value).toBe('1:1');
+  });
+
+  it('changing cycle calls setTrigCondition',
+    () => {
+      render(<TrigConditionPopover {...base} />);
+      fireEvent.change(
+        screen.getByRole('combobox'),
+        { target: { value: '2:4' } }
+      );
+      expect(mockSet).toHaveBeenCalledWith(
+        'bd', 3, { cycle: { a: 2, b: 4 } }
+      );
+    }
+  );
+
+  it('all defaults calls clearTrigCondition',
+    () => {
+      render(
+        <TrigConditionPopover
+          {...base}
+          conditions={{ probability: 50 }}
+        />
+      );
+      fireEvent.keyDown(
+        screen.getByRole('slider'), { key: 'End' }
+      );
+      expect(mockClear).toHaveBeenCalledWith(
+        'bd', 3
+      );
+    }
+  );
+
+  it('Escape calls onClose', () => {
+    render(<TrigConditionPopover {...base} />);
+    fireEvent.keyDown(
+      document, { key: 'Escape' }
+    );
+    expect(base.onClose).toHaveBeenCalled();
+  });
+
+  it('click outside calls onClose', () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <TrigConditionPopover
+          {...base}
+          onClose={onClose}
+        />
+      </div>
+    );
+    vi.advanceTimersByTime(1);
+    fireEvent.mouseDown(
+      screen.getByTestId('outside')
+    );
+    expect(onClose).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('pre-populates from existing conditions',
+    () => {
+      render(
+        <TrigConditionPopover
+          {...base}
+          conditions={{
+            probability: 75,
+            cycle: { a: 1, b: 3 },
+          }}
+        />
+      );
+      expect(
+        screen.getByRole('slider')
+          .getAttribute('aria-valuenow')
+      ).toBe('75');
+      const sel2 = screen.getByRole(
+        'combobox'
+      ) as HTMLSelectElement;
+      expect(sel2.value).toBe('1:3');
+    }
+  );
+});

--- a/src/__tests__/configCodec.test.ts
+++ b/src/__tests__/configCodec.test.ts
@@ -394,24 +394,24 @@ describe('validateTrigConditions', () => {
   it('valid probability condition round-trips', async () => {
     const config = defaultConfig();
     config.trigConditions = {
-      bd: { 0: { type: 'probability', value: 50 } },
+      bd: { 0: { probability: 50 } },
     };
     const hash = await encodeConfig(config);
     const decoded = await decodeConfig(hash);
     expect(decoded.trigConditions).toEqual({
-      bd: { 0: { type: 'probability', value: 50 } },
+      bd: { 0: { probability: 50 } },
     });
   });
 
   it('valid cycle condition round-trips', async () => {
     const config = defaultConfig();
     config.trigConditions = {
-      sd: { 2: { type: 'cycle', a: 1, b: 4 } },
+      sd: { 2: { cycle: { a: 1, b: 4 } } },
     };
     const hash = await encodeConfig(config);
     const decoded = await decodeConfig(hash);
     expect(decoded.trigConditions).toEqual({
-      sd: { 2: { type: 'cycle', a: 1, b: 4 } },
+      sd: { 2: { cycle: { a: 1, b: 4 } } },
     });
   });
 
@@ -436,20 +436,20 @@ describe('validateTrigConditions', () => {
         bd: {
           0: { type: 'probability', value: 0 },
           1: { type: 'probability', value: 100 },
-          2: { type: 'probability', value: 50 },
+          2: { probability: 50 },
         },
       },
     };
     const hash = await encodeRaw(raw);
     const decoded = await decodeConfig(hash);
     expect(decoded.trigConditions.bd?.[0]).toEqual(
-      { type: 'probability', value: 1 }
+      { probability: 1 }
     );
     expect(decoded.trigConditions.bd?.[1]).toEqual(
-      { type: 'probability', value: 99 }
+      { probability: 99 }
     );
     expect(decoded.trigConditions.bd?.[2]).toEqual(
-      { type: 'probability', value: 50 }
+      { probability: 50 }
     );
   });
 
@@ -464,7 +464,7 @@ describe('validateTrigConditions', () => {
     const hash = await encodeRaw(raw);
     const decoded = await decodeConfig(hash);
     expect(decoded.trigConditions.bd?.[0]).toEqual(
-      { type: 'cycle', a: 1, b: 8 }
+      { cycle: { a: 1, b: 8 } }
     );
   });
 
@@ -492,7 +492,7 @@ describe('validateTrigConditions', () => {
     const hash = await encodeRaw(raw);
     const decoded = await decodeConfig(hash);
     expect(decoded.trigConditions.bd?.[0]).toEqual(
-      { type: 'cycle', a: 3, b: 3 }
+      { cycle: { a: 3, b: 3 } }
     );
   });
 
@@ -502,7 +502,7 @@ describe('validateTrigConditions', () => {
     const raw = {
       ...config,
       trigConditions: {
-        bd: { 16: { type: 'probability', value: 50 } },
+        bd: { 16: { probability: 50 } },
       },
     };
     const hash = await encodeRaw(raw);

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -490,7 +490,7 @@ describe('trig conditions in handleStep', () => {
       // Set probability 50 on bd step 0
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 0, { type: 'probability', value: 50 }
+          'bd', 0, { probability: 50 }
         );
       });
 
@@ -565,14 +565,14 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 0, { type: 'probability', value: 50 }
+          'bd', 0, { probability: 50 }
         );
       });
 
       expect(
         result.current.meta.config
           .trigConditions.bd?.[0]
-      ).toEqual({ type: 'probability', value: 50 });
+      ).toEqual({ probability: 50 });
 
       await act(async () => {
         result.current.actions.clearTrigCondition(
@@ -593,7 +593,7 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 15, { type: 'probability', value: 75 }
+          'bd', 15, { probability: 75 }
         );
       });
       await act(async () => {
@@ -613,7 +613,7 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 3, { type: 'probability', value: 75 }
+          'bd', 3, { probability: 75 }
         );
       });
       await act(async () => {
@@ -623,7 +623,7 @@ describe('trig conditions in handleStep', () => {
       expect(
         result.current.meta.config
           .trigConditions.bd?.[3]
-      ).toEqual({ type: 'probability', value: 75 });
+      ).toEqual({ probability: 75 });
     }
   );
 
@@ -633,7 +633,7 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 15, { type: 'probability', value: 75 }
+          'bd', 15, { probability: 75 }
         );
       });
       await act(async () => {
@@ -653,7 +653,7 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 0, { type: 'probability', value: 50 }
+          'bd', 0, { probability: 50 }
         );
       });
       await act(async () => {
@@ -672,7 +672,7 @@ describe('trig conditions in handleStep', () => {
 
       await act(async () => {
         result.current.actions.setTrigCondition(
-          'bd', 0, { type: 'probability', value: 50 }
+          'bd', 0, { probability: 50 }
         );
       });
       await act(async () => {
@@ -704,7 +704,7 @@ describe('trig conditions in handleStep', () => {
       await act(async () => {
         result.current.actions.setTrigCondition(
           'bd', 0,
-          { type: 'probability', value: 50 }
+          { probability: 50 }
         );
       });
 
@@ -717,7 +717,7 @@ describe('trig conditions in handleStep', () => {
       expect(
         result.current.meta.config
           .trigConditions.bd?.[0]
-      ).toEqual({ type: 'probability', value: 50 });
+      ).toEqual({ probability: 50 });
 
       // Toggle step back on
       await act(async () => {
@@ -728,7 +728,7 @@ describe('trig conditions in handleStep', () => {
       expect(
         result.current.meta.config
           .trigConditions.bd?.[0]
-      ).toEqual({ type: 'probability', value: 50 });
+      ).toEqual({ probability: 50 });
     }
   );
 
@@ -748,7 +748,7 @@ describe('trig conditions in handleStep', () => {
       await act(async () => {
         result.current.actions.setTrigCondition(
           'bd', 0,
-          { type: 'cycle', a: 2, b: 2 }
+          { cycle: { a: 2, b: 2 } }
         );
       });
 

--- a/src/__tests__/trigConditions.test.ts
+++ b/src/__tests__/trigConditions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   evaluateCondition,
+  CYCLE_OPTIONS,
 } from '../app/trigConditions';
 
 afterEach(() => {
@@ -9,86 +10,176 @@ afterEach(() => {
 
 describe('evaluateCondition', () => {
   describe('undefined condition', () => {
-    it('always fires when condition is undefined', () => {
-      expect(evaluateCondition(undefined, { cycleCount: 0 })).toBe(true);
-      expect(evaluateCondition(undefined, { cycleCount: 99 })).toBe(true);
-    });
+    it('always fires when condition is undefined',
+      () => {
+        expect(evaluateCondition(
+          undefined, { cycleCount: 0 }
+        )).toBe(true);
+        expect(evaluateCondition(
+          undefined, { cycleCount: 99 }
+        )).toBe(true);
+      }
+    );
   });
 
   describe('probability condition', () => {
-    it('fires when Math.random returns 0.49 with 50% probability', () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0.49);
-      expect(
-        evaluateCondition(
-          { type: 'probability', value: 50 },
-          { cycleCount: 0 }
-        )
-      ).toBe(true);
-    });
+    it('fires when random < probability/100',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.49);
+        expect(evaluateCondition(
+          { probability: 50 }, { cycleCount: 0 }
+        )).toBe(true);
+      }
+    );
 
-    it('does not fire when Math.random returns 0.50 with 50% prob', () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0.50);
-      expect(
-        evaluateCondition(
-          { type: 'probability', value: 50 },
-          { cycleCount: 0 }
-        )
-      ).toBe(false);
-    });
+    it('does not fire when random >= prob/100',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.50);
+        expect(evaluateCondition(
+          { probability: 50 }, { cycleCount: 0 }
+        )).toBe(false);
+      }
+    );
 
-    it('fires when random < 0.01 with 1% probability', () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0.009);
-      expect(
-        evaluateCondition(
-          { type: 'probability', value: 1 },
-          { cycleCount: 0 }
-        )
-      ).toBe(true);
-    });
+    it('fires when random < 0.01 with 1% prob',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.009);
+        expect(evaluateCondition(
+          { probability: 1 }, { cycleCount: 0 }
+        )).toBe(true);
+      }
+    );
 
-    it('does not fire when random >= 0.99 with 99% probability', () => {
-      vi.spyOn(Math, 'random').mockReturnValue(0.99);
-      expect(
-        evaluateCondition(
-          { type: 'probability', value: 99 },
-          { cycleCount: 0 }
-        )
-      ).toBe(false);
-    });
+    it('does not fire when random >= 0.99 with 99%',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.99);
+        expect(evaluateCondition(
+          { probability: 99 }, { cycleCount: 0 }
+        )).toBe(false);
+      }
+    );
   });
 
   describe('cycle condition', () => {
     it('cycle 1:4 fires on cycle 0', () => {
-      expect(
-        evaluateCondition(
-          { type: 'cycle', a: 1, b: 4 },
-          { cycleCount: 0 }
-        )
-      ).toBe(true);
+      expect(evaluateCondition(
+        { cycle: { a: 1, b: 4 } },
+        { cycleCount: 0 }
+      )).toBe(true);
     });
 
-    it('cycle 1:4 does not fire on cycles 1, 2, 3', () => {
-      const cond = { type: 'cycle' as const, a: 1, b: 4 };
-      expect(evaluateCondition(cond, { cycleCount: 1 })).toBe(false);
-      expect(evaluateCondition(cond, { cycleCount: 2 })).toBe(false);
-      expect(evaluateCondition(cond, { cycleCount: 3 })).toBe(false);
-    });
+    it('cycle 1:4 does not fire on 1, 2, 3',
+      () => {
+        const cond = { cycle: { a: 1, b: 4 } };
+        expect(evaluateCondition(
+          cond, { cycleCount: 1 }
+        )).toBe(false);
+        expect(evaluateCondition(
+          cond, { cycleCount: 2 }
+        )).toBe(false);
+        expect(evaluateCondition(
+          cond, { cycleCount: 3 }
+        )).toBe(false);
+      }
+    );
 
     it('cycle 3:4 fires on cycle 2', () => {
-      expect(
-        evaluateCondition(
-          { type: 'cycle', a: 3, b: 4 },
-          { cycleCount: 2 }
-        )
-      ).toBe(true);
+      expect(evaluateCondition(
+        { cycle: { a: 3, b: 4 } },
+        { cycleCount: 2 }
+      )).toBe(true);
     });
 
-    it('cycle 2:2 fires on odd 0-indexed cycles', () => {
-      const cond = { type: 'cycle' as const, a: 2, b: 2 };
-      expect(evaluateCondition(cond, { cycleCount: 0 })).toBe(false);
-      expect(evaluateCondition(cond, { cycleCount: 1 })).toBe(true);
-      expect(evaluateCondition(cond, { cycleCount: 2 })).toBe(false);
-      expect(evaluateCondition(cond, { cycleCount: 3 })).toBe(true);
+    it('cycle 2:2 fires on odd 0-indexed cycles',
+      () => {
+        const cond = { cycle: { a: 2, b: 2 } };
+        expect(evaluateCondition(
+          cond, { cycleCount: 0 }
+        )).toBe(false);
+        expect(evaluateCondition(
+          cond, { cycleCount: 1 }
+        )).toBe(true);
+        expect(evaluateCondition(
+          cond, { cycleCount: 2 }
+        )).toBe(false);
+        expect(evaluateCondition(
+          cond, { cycleCount: 3 }
+        )).toBe(true);
+      }
+    );
+  });
+
+  describe('AND semantics', () => {
+    it('both must pass for step to fire', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValue(0.49);
+      // prob passes (50% > 49%), cycle 1:2 on
+      // cycle 0 => (0%2)+1=1 === a=1 => true
+      expect(evaluateCondition(
+        { probability: 50, cycle: { a: 1, b: 2 } },
+        { cycleCount: 0 }
+      )).toBe(true);
     });
+
+    it('prob passes but cycle fails => false',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.01);
+        // cycle 1:2 on cycle 1: (1%2)+1=2 !== 1
+        expect(evaluateCondition(
+          {
+            probability: 50,
+            cycle: { a: 1, b: 2 },
+          },
+          { cycleCount: 1 }
+        )).toBe(false);
+      }
+    );
+
+    it('cycle passes but prob fails => false',
+      () => {
+        vi.spyOn(Math, 'random')
+          .mockReturnValue(0.99);
+        expect(evaluateCondition(
+          {
+            probability: 50,
+            cycle: { a: 1, b: 2 },
+          },
+          { cycleCount: 0 }
+        )).toBe(false);
+      }
+    );
+  });
+});
+
+describe('CYCLE_OPTIONS', () => {
+  it('starts with 1:1', () => {
+    expect(CYCLE_OPTIONS[0]).toEqual(
+      { label: '1:1', a: 1, b: 1 }
+    );
+  });
+
+  it('contains all a:b for b 2-8', () => {
+    // Total: 1 + sum(2..8) = 1 + 2+3+4+5+6+7+8
+    //      = 1 + 35 = 36
+    expect(CYCLE_OPTIONS).toHaveLength(36);
+  });
+
+  it('last option is 8:8', () => {
+    const last =
+      CYCLE_OPTIONS[CYCLE_OPTIONS.length - 1];
+    expect(last).toEqual(
+      { label: '8:8', a: 8, b: 8 }
+    );
+  });
+
+  it('labels match a:b format', () => {
+    for (const opt of CYCLE_OPTIONS) {
+      expect(opt.label).toBe(`${opt.a}:${opt.b}`);
+    }
   });
 });

--- a/src/app/ProbabilitySlider.tsx
+++ b/src/app/ProbabilitySlider.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useRef, useCallback, useEffect } from 'react';
+
+interface ProbabilitySliderProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+/**
+ * Horizontal probability slider (1-100) with
+ * pointer-capture drag and keyboard controls.
+ *
+ * Args:
+ *   value: Current probability (1-100)
+ *   onChange: Callback with new value
+ */
+export default function ProbabilitySlider({
+  value,
+  onChange,
+}: ProbabilitySliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    startX: number;
+    startValue: number;
+  } | null>(null);
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const clamp = (v: number) =>
+    Math.max(1, Math.min(100, Math.round(v)));
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as Element).setPointerCapture(
+        e.pointerId
+      );
+      dragRef.current = {
+        startX: e.clientX,
+        startValue: valueRef.current,
+      };
+    },
+    []
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current || !trackRef.current) {
+        return;
+      }
+      const width = trackRef.current.offsetWidth;
+      if (width === 0) return;
+      const delta =
+        ((e.clientX - dragRef.current.startX)
+          / width) * 99;
+      onChange(
+        clamp(dragRef.current.startValue + delta)
+      );
+    },
+    [onChange]
+  );
+
+  const release = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const v = valueRef.current;
+      let next = v;
+      const step = e.shiftKey ? 10 : 1;
+      if (
+        e.key === 'ArrowRight'
+        || e.key === 'ArrowUp'
+      ) {
+        next = clamp(v + step);
+      } else if (
+        e.key === 'ArrowLeft'
+        || e.key === 'ArrowDown'
+      ) {
+        next = clamp(v - step);
+      } else if (e.key === 'Home') {
+        next = 1;
+      } else if (e.key === 'End') {
+        next = 100;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      onChange(next);
+    },
+    [onChange]
+  );
+
+  const pct = ((value - 1) / 99) * 100;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={0}
+        aria-valuemin={1}
+        aria-valuemax={100}
+        aria-valuenow={value}
+        aria-label="Probability"
+        className={
+          'relative h-6 flex-1 rounded'
+          + ' bg-neutral-700 cursor-ew-resize'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500'
+        }
+        style={{ touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={release}
+        onLostPointerCapture={release}
+        onKeyDown={onKeyDown}
+      >
+        <div
+          className={
+            'absolute inset-y-0 left-0 rounded'
+            + ' bg-orange-600'
+          }
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className={
+        'text-xs font-mono text-neutral-300'
+        + ' w-10 text-right tabular-nums'
+      }>
+        {value}%
+      </span>
+    </div>
+  );
+}

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -20,7 +20,7 @@ import type {
   Kit,
   Pattern,
   SequencerConfig,
-  TrigCondition,
+  StepConditions,
   TrackId,
   TrackState,
 } from './types';
@@ -93,7 +93,7 @@ interface SequencerActions {
   setTrigCondition: (
     trackId: TrackId,
     stepIndex: number,
-    condition: TrigCondition
+    conditions: StepConditions
   ) => void;
   clearTrigCondition: (
     trackId: TrackId,
@@ -543,7 +543,7 @@ export function SequencerProvider({
           const trackConds = newTrigConds[id];
           if (trackConds) {
             const pruned: Record<
-              number, TrigCondition
+              number, StepConditions
             > = {};
             for (const [k, v] of
               Object.entries(trackConds)) {
@@ -588,7 +588,7 @@ export function SequencerProvider({
           prev.trigConditions;
         if (trackConds) {
           const pruned: Record<
-            number, TrigCondition
+            number, StepConditions
           > = {};
           for (const [k, v] of
             Object.entries(trackConds)) {
@@ -705,7 +705,7 @@ export function SequencerProvider({
     (
       trackId: TrackId,
       stepIndex: number,
-      condition: TrigCondition
+      conditions: StepConditions
     ) => {
       setConfig(prev => ({
         ...prev,
@@ -713,7 +713,7 @@ export function SequencerProvider({
           ...prev.trigConditions,
           [trackId]: {
             ...prev.trigConditions[trackId],
-            [stepIndex]: condition,
+            [stepIndex]: conditions,
           },
         },
       }));
@@ -728,12 +728,17 @@ export function SequencerProvider({
           ...prev.trigConditions[trackId],
         };
         delete trackConds[stepIndex];
+        const newTrigConditions = {
+          ...prev.trigConditions,
+        };
+        if (Object.keys(trackConds).length === 0) {
+          delete newTrigConditions[trackId];
+        } else {
+          newTrigConditions[trackId] = trackConds;
+        }
         return {
           ...prev,
-          trigConditions: {
-            ...prev.trigConditions,
-            [trackId]: trackConds,
-          },
+          trigConditions: newTrigConditions,
         };
       });
     },

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { memo } from 'react';
+import { memo, useRef } from 'react';
+import { useLongPress } from 'use-long-press';
+import type { StepConditions } from './types';
 
 interface StepButtonProps {
   trackName: string;
@@ -10,6 +12,10 @@ interface StepButtonProps {
   isBeat: boolean;
   isDisabled: boolean;
   onToggle: () => void;
+  conditions?: StepConditions;
+  onOpenPopover?: (
+    rect: { top: number; left: number }
+  ) => void;
 }
 
 /**
@@ -26,12 +32,35 @@ function StepButtonInner({
   isBeat,
   isDisabled,
   onToggle,
+  conditions,
+  onOpenPopover,
 }: StepButtonProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const longPress = useLongPress(
+    () => {
+      if (isActive && onOpenPopover) {
+        navigator.vibrate?.(10);
+        const el = buttonRef.current;
+        const r = el?.getBoundingClientRect();
+        onOpenPopover({
+          top: (r?.bottom ?? 0) + 4,
+          left: r?.left ?? 0,
+        });
+      }
+    },
+    {
+      threshold: 500,
+      cancelOnMovement: 25,
+    }
+  );
+
   if (isDisabled) {
     return (
       <div
         aria-label={
-          `${trackName} step ${stepIndex + 1} (inactive)`
+          `${trackName} step ${stepIndex + 1}`
+          + ' (inactive)'
         }
         className={
           'h-8 lg:h-12 rounded-sm'
@@ -59,12 +88,28 @@ function StepButtonInner({
 
   return (
     <button
+      ref={buttonRef}
+      {...longPress()}
       onClick={onToggle}
-      aria-label={`${trackName} step ${stepIndex + 1}`}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        if (isActive && onOpenPopover) {
+          const el = buttonRef.current;
+          const r = el?.getBoundingClientRect();
+          onOpenPopover({
+            top: (r?.bottom ?? e.clientY) + 4,
+            left: r?.left ?? e.clientX,
+          });
+        }
+      }}
+      aria-label={
+        `${trackName} step ${stepIndex + 1}`
+      }
       aria-pressed={isActive}
       style={{ touchAction: 'manipulation' }}
       className={
-        'h-8 lg:h-12 rounded-sm'
+        'relative overflow-hidden'
+        + ' h-8 lg:h-12 rounded-sm'
         + ' transition-colors duration-100'
         + ' motion-safe:transition-transform'
         + ' focus-visible:outline-none'
@@ -75,7 +120,44 @@ function StepButtonInner({
           ? ' border-l-2 border-neutral-700'
           : '')
       }
-    />
+    >
+      {isActive
+        && conditions?.probability !== undefined
+        ? (
+          <span
+            data-testid="prob-bar"
+            className={
+              'absolute bottom-0 left-0 h-[2px]'
+            }
+            style={{
+              width: `${conditions.probability}%`,
+              background: 'rgba(255,255,255,0.85)',
+            }}
+          />
+        ) : null}
+      {isActive && conditions?.cycle != null
+        && conditions.cycle.b >= 2
+        ? (
+          <span
+            className={
+              'absolute inset-0 flex items-center'
+              + ' justify-center text-[13px]'
+              + ' font-bold leading-none'
+              + ' pointer-events-none'
+            }
+            style={{
+              fontFamily: 'var(--font-orbitron)',
+              color: 'rgba(255,255,255,0.9)',
+              textShadow:
+                '0 1px 2px rgba(0,0,0,0.8)',
+              letterSpacing: '0.05em',
+            }}
+          >
+            {conditions.cycle.a}
+            :{conditions.cycle.b}
+          </span>
+        ) : null}
+    </button>
   );
 }
 

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react';
 import { TRACKS, useSequencer } from './SequencerContext';
 import TrackRow from './TrackRow';
 import RunningLight from './RunningLight';
+import TrigConditionPopover
+  from './TrigConditionPopover';
+import type { TrackId } from './types';
 
 /**
  * The main sequencer grid section containing all track
@@ -21,11 +24,17 @@ export default function StepGrid() {
     toggleStep, toggleMute, toggleSolo,
     setGain, setTrackLength, toggleFreeRun,
   } = actions;
-  const { stepRef, totalStepsRef } = meta;
+  const { stepRef, totalStepsRef, config } = meta;
 
-  // Local state driven by rAF, isolated from the context
-  // provider so only StepGrid and its children re-render
-  // on step ticks.
+  const [openPopover, setOpenPopover] = useState<{
+    trackId: TrackId;
+    stepIndex: number;
+    anchorRect: { top: number; left: number };
+  } | null>(null);
+
+  // Local state driven by rAF, isolated from the
+  // context provider so only StepGrid and its children
+  // re-render on step ticks.
   const [displayStep, setDisplayStep] = useState(-1);
   const [displayTotal, setDisplayTotal] = useState(0);
 
@@ -37,8 +46,10 @@ export default function StepGrid() {
     const tick = () => {
       const curStep = stepRef.current;
       const curTotal = totalStepsRef.current;
-      if (curStep !== prevStep
-        || curTotal !== prevTotal) {
+      if (
+        curStep !== prevStep
+        || curTotal !== prevTotal
+      ) {
         prevStep = curStep;
         prevTotal = curTotal;
         setDisplayStep(curStep);
@@ -77,8 +88,31 @@ export default function StepGrid() {
           onSetGain={setGain}
           onSetTrackLength={setTrackLength}
           onToggleFreeRun={toggleFreeRun}
+          trigConditions={
+            config.trigConditions[track.id]
+          }
+          onOpenPopover={(
+            trackId: TrackId,
+            stepIndex: number,
+            rect: { top: number; left: number }
+          ) => setOpenPopover({
+            trackId, stepIndex, anchorRect: rect,
+          })}
         />
       ))}
+      {openPopover !== null ? (
+        <TrigConditionPopover
+          trackId={openPopover.trackId}
+          stepIndex={openPopover.stepIndex}
+          conditions={
+            config.trigConditions[
+              openPopover.trackId
+            ]?.[openPopover.stepIndex]
+          }
+          anchorRect={openPopover.anchorRect}
+          onClose={() => setOpenPopover(null)}
+        />
+      ) : null}
       <RunningLight
         currentStep={displayStep}
         patternLength={patternLength}

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -3,7 +3,7 @@
 import {
   memo, useCallback, useEffect, useRef, useState,
 } from 'react';
-import { TrackId } from './types';
+import type { StepConditions, TrackId } from './types';
 import TrackToggle from './TrackToggle';
 import StepButton from './StepButton';
 import Knob from './Knob';
@@ -32,6 +32,12 @@ interface TrackRowProps {
     trackId: TrackId, length: number
   ) => void;
   onToggleFreeRun: (trackId: TrackId) => void;
+  trigConditions?: Record<number, StepConditions>;
+  onOpenPopover?: (
+    trackId: TrackId,
+    stepIndex: number,
+    rect: { top: number; left: number }
+  ) => void;
 }
 
 /**
@@ -60,6 +66,8 @@ function TrackRowInner({
   onSetGain,
   onSetTrackLength,
   onToggleFreeRun,
+  trigConditions,
+  onOpenPopover,
 }: TrackRowProps) {
   const handleMute = useCallback(
     () => onToggleMute(trackId),
@@ -93,12 +101,12 @@ function TrackRowInner({
     if (!menuOpen) return;
     const handleClick = (e: MouseEvent) => {
       if (
-        menuRef.current &&
-        !menuRef.current.contains(
+        menuRef.current
+        && !menuRef.current.contains(
           e.target as Node
-        ) &&
-        nameRef.current &&
-        !nameRef.current.contains(
+        )
+        && nameRef.current
+        && !nameRef.current.contains(
           e.target as Node
         )
       ) {
@@ -276,14 +284,16 @@ function TrackRowInner({
               { length: 16 },
               (_, i) => {
                 const disabled =
-                  i >= trackLength || i >= patternLength;
+                  i >= trackLength
+                  || i >= patternLength;
                 return (
                   <StepButton
                     key={i}
                     trackName={trackName}
                     stepIndex={i}
                     isActive={
-                      !disabled && steps[i] === '1'
+                      !disabled
+                      && steps[i] === '1'
                     }
                     isCurrent={
                       !disabled
@@ -293,6 +303,19 @@ function TrackRowInner({
                     isDisabled={disabled}
                     onToggle={
                       () => onToggleStep(trackId, i)
+                    }
+                    conditions={
+                      trigConditions?.[i]
+                    }
+                    onOpenPopover={
+                      onOpenPopover
+                        ? (rect: {
+                            top: number;
+                            left: number;
+                          }) => onOpenPopover(
+                            trackId, i, rect
+                          )
+                        : undefined
                     }
                   />
                 );

--- a/src/app/TrigConditionPopover.tsx
+++ b/src/app/TrigConditionPopover.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import {
+  useState, useRef, useEffect, useCallback,
+} from 'react';
+import { useSequencer } from './SequencerContext';
+import { CYCLE_OPTIONS } from './trigConditions';
+import ProbabilitySlider from './ProbabilitySlider';
+import type { StepConditions, TrackId } from './types';
+
+interface TrigConditionPopoverProps {
+  trackId: TrackId;
+  stepIndex: number;
+  conditions?: StepConditions;
+  anchorRect?: { top: number; left: number };
+  onClose: () => void;
+}
+
+/**
+ * Popover for editing per-step trig conditions.
+ * Shows probability slider and cycle dropdown.
+ *
+ * Args:
+ *   trackId: Track this condition belongs to
+ *   stepIndex: Step index (0-based)
+ *   conditions: Current conditions
+ *   anchorRect: Position anchor
+ *   onClose: Called when popover should close
+ */
+export default function TrigConditionPopover({
+  trackId,
+  stepIndex,
+  conditions,
+  anchorRect,
+  onClose,
+}: TrigConditionPopoverProps) {
+  const { actions } = useSequencer();
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const [probability, setProbability] = useState(
+    conditions?.probability ?? 100
+  );
+  const [cycleValue, setCycleValue] = useState(
+    conditions?.cycle
+      ? `${conditions.cycle.a}:${conditions.cycle.b}`
+      : '1:1'
+  );
+
+  const updateConditions = useCallback(
+    (prob: number, cycle: string) => {
+      const sc: StepConditions = {};
+      if (prob < 100) {
+        sc.probability = prob;
+      }
+      const option = CYCLE_OPTIONS.find(
+        o => o.label === cycle
+      );
+      if (option && option.b >= 2) {
+        sc.cycle = { a: option.a, b: option.b };
+      }
+      if (Object.keys(sc).length === 0) {
+        actions.clearTrigCondition(
+          trackId, stepIndex
+        );
+      } else {
+        actions.setTrigCondition(
+          trackId, stepIndex, sc
+        );
+      }
+    },
+    [actions, trackId, stepIndex]
+  );
+
+  const handleProbChange = useCallback(
+    (v: number) => {
+      setProbability(v);
+      updateConditions(v, cycleValue);
+    },
+    [updateConditions, cycleValue]
+  );
+
+  const handleCycleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const v = e.target.value;
+      setCycleValue(v);
+      updateConditions(probability, v);
+    },
+    [updateConditions, probability]
+  );
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        popoverRef.current
+        && !popoverRef.current.contains(
+          e.target as Node
+        )
+      ) {
+        onClose();
+      }
+    };
+    let active = true;
+    setTimeout(() => {
+      if (active) {
+        document.addEventListener(
+          'mousedown', handleMouseDown
+        );
+      }
+    }, 0);
+    return () => {
+      active = false;
+      document.removeEventListener(
+        'mousedown', handleMouseDown
+      );
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener(
+      'keydown', handleKeyDown
+    );
+    return () =>
+      document.removeEventListener(
+        'keydown', handleKeyDown
+      );
+  }, [onClose]);
+
+  return (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label="Trig conditions"
+      className={
+        'fixed z-30'
+        + ' w-56 bg-neutral-900 border'
+        + ' border-neutral-700 rounded-lg'
+        + ' shadow-xl p-3 space-y-3'
+      }
+      style={anchorRect ? {
+        top: `${anchorRect.top}px`,
+        left: `${anchorRect.left}px`,
+      } : undefined}
+    >
+      <div className={
+        'flex items-center justify-between'
+      }>
+        <div className={
+          'text-xs font-bold uppercase'
+          + ' tracking-wider text-neutral-400'
+        }>
+          Step {stepIndex + 1}{' '}
+          <span className="text-neutral-500">
+            {'\u00B7'} {trackId.toUpperCase()}
+          </span>
+        </div>
+        <button
+          onClick={() => {
+            actions.clearTrigCondition(
+              trackId, stepIndex
+            );
+            onClose();
+          }}
+          disabled={conditions === undefined}
+          className={
+            'text-[11px] px-1.5 py-0.5 rounded'
+            + ' border transition-colors'
+            + (conditions !== undefined
+              ? ' text-neutral-400'
+                + ' hover:text-neutral-200'
+                + ' border-neutral-700'
+                + ' hover:bg-neutral-800'
+              : ' text-neutral-700'
+                + ' border-neutral-800'
+                + ' cursor-default')
+          }
+        >
+          Reset trig cond.
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Probability
+        </div>
+        <ProbabilitySlider
+          value={probability}
+          onChange={handleProbChange}
+        />
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Cycle
+        </div>
+        <select
+          value={cycleValue}
+          onChange={handleCycleChange}
+          className={
+            'w-full bg-neutral-800'
+            + ' text-neutral-200'
+            + ' text-sm rounded px-2 py-1.5'
+            + ' border border-neutral-700'
+            + ' focus-visible:outline-none'
+            + ' focus-visible:ring-2'
+            + ' focus-visible:ring-orange-500'
+          }
+        >
+          {CYCLE_OPTIONS.map(opt => (
+            <option key={opt.label} value={opt.label}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+    </div>
+  );
+}

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -4,9 +4,9 @@ import kitsData from './data/kits.json';
 import patternsData from './data/patterns.json';
 import type {
   SequencerConfig,
+  StepConditions,
   TrackId,
   TrackMixerState,
-  TrigCondition,
 } from './types';
 import { TRACK_IDS } from './types';
 
@@ -299,74 +299,121 @@ const CYCLE_B_MIN = 2;
 const CYCLE_B_MAX = 8;
 
 /**
- * Validate a single trig condition object.
- * Returns null if the condition is invalid and should be dropped.
+ * Validate a single StepConditions object.
+ * Returns null if the entry has no valid fields.
  */
 function validateSingleCondition(
   raw: unknown
-): TrigCondition | null {
-  if (raw === null || typeof raw !== 'object') return null;
+): StepConditions | null {
+  if (raw === null || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
+  const sc: StepConditions = {};
 
+  // Legacy discriminated-union format (type field)
   if (obj.type === 'probability') {
     if (
-      typeof obj.value !== 'number' ||
-      !isFinite(obj.value)
-    ) return null;
-    return {
-      type: 'probability',
-      value: Math.max(
-        PROB_MIN, Math.min(PROB_MAX, Math.round(obj.value))
-      ),
-    };
-  }
-
-  if (obj.type === 'cycle') {
+      typeof obj.value === 'number'
+      && isFinite(obj.value)
+    ) {
+      sc.probability = Math.max(
+        PROB_MIN,
+        Math.min(PROB_MAX, Math.round(obj.value))
+      );
+    }
+  } else if (obj.type === 'cycle') {
     if (
-      typeof obj.a !== 'number' || !isFinite(obj.a) ||
-      typeof obj.b !== 'number' || !isFinite(obj.b)
-    ) return null;
-    const rawB = Math.round(obj.b);
-    if (rawB < CYCLE_B_MIN) return null;
-    const b = Math.min(CYCLE_B_MAX, rawB);
-    const a = Math.max(1, Math.min(b, Math.round(obj.a)));
-    return { type: 'cycle', a, b };
+      typeof obj.a === 'number' && isFinite(obj.a)
+      && typeof obj.b === 'number' && isFinite(obj.b)
+    ) {
+      const rawB = Math.round(obj.b);
+      if (rawB >= CYCLE_B_MIN) {
+        const b = Math.min(CYCLE_B_MAX, rawB);
+        const a = Math.max(
+          1, Math.min(b, Math.round(obj.a))
+        );
+        sc.cycle = { a, b };
+      }
+    }
+  } else {
+    // New composite format
+    if (
+      typeof obj.probability === 'number'
+      && isFinite(obj.probability)
+    ) {
+      sc.probability = Math.max(
+        PROB_MIN,
+        Math.min(
+          PROB_MAX, Math.round(obj.probability)
+        )
+      );
+    }
+    const cyc = obj.cycle;
+    if (
+      cyc !== null && cyc !== undefined
+      && typeof cyc === 'object'
+    ) {
+      const c = cyc as Record<string, unknown>;
+      if (
+        typeof c.a === 'number' && isFinite(c.a)
+        && typeof c.b === 'number' && isFinite(c.b)
+      ) {
+        const rawB = Math.round(c.b);
+        if (rawB >= CYCLE_B_MIN) {
+          const b = Math.min(CYCLE_B_MAX, rawB);
+          const a = Math.max(
+            1, Math.min(b, Math.round(c.a))
+          );
+          sc.cycle = { a, b };
+        }
+      }
+    }
   }
 
-  return null;
+  if (Object.keys(sc).length === 0) return null;
+  return sc;
 }
 
 /**
- * Validate trigConditions map. Drops entries with invalid
- * step indices (>= trackLength) or invalid condition objects.
+ * Validate trigConditions map. Drops entries with
+ * invalid step indices (>= trackLength) or invalid
+ * condition objects.
  */
 function validateTrigConditions(
   value: unknown,
   trackLengths: Record<TrackId, number>
 ): SequencerConfig['trigConditions'] {
-  if (value === null || typeof value !== 'object') return {};
+  if (
+    value === null || typeof value !== 'object'
+  ) return {};
   const obj = value as Record<string, unknown>;
   const result: SequencerConfig['trigConditions'] = {};
 
   for (const id of TRACK_IDS) {
     const trackEntry = obj[id];
     if (
-      trackEntry === null ||
-      typeof trackEntry !== 'object'
+      trackEntry === null
+      || typeof trackEntry !== 'object'
     ) continue;
 
     const trackLength = trackLengths[id];
-    const stepMap = trackEntry as Record<string, unknown>;
-    const validSteps: Record<number, TrigCondition> = {};
+    const stepMap =
+      trackEntry as Record<string, unknown>;
+    const validSteps: Record<
+      number, StepConditions
+    > = {};
 
     for (const key of Object.keys(stepMap)) {
       const stepIndex = Number(key);
       if (
-        !Number.isInteger(stepIndex) ||
-        stepIndex < 0 ||
-        stepIndex >= trackLength
+        !Number.isInteger(stepIndex)
+        || stepIndex < 0
+        || stepIndex >= trackLength
       ) continue;
-      const cond = validateSingleCondition(stepMap[key]);
+      const cond = validateSingleCondition(
+        stepMap[key]
+      );
       if (cond !== null) {
         validSteps[stepIndex] = cond;
       }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import {
+  Geist, Geist_Mono, Orbitron,
+} from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -9,6 +11,11 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const orbitron = Orbitron({
+  variable: "--font-orbitron",
   subsets: ["latin"],
 });
 
@@ -32,12 +39,24 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark" style={{ colorScheme: 'dark' }}>
+    <html
+      lang="en"
+      className="dark"
+      style={{ colorScheme: 'dark' }}
+    >
       <head>
-        <meta name="theme-color" content="#0a0a0a" />
+        <meta
+          name="theme-color"
+          content="#0a0a0a"
+        />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={
+          `${geistSans.variable}`
+          + ` ${geistMono.variable}`
+          + ` ${orbitron.variable}`
+          + ' antialiased'
+        }
       >
         {children}
       </body>

--- a/src/app/trigConditions.ts
+++ b/src/app/trigConditions.ts
@@ -1,4 +1,4 @@
-import type { TrigCondition } from './types';
+import type { StepConditions } from './types';
 
 /**
  * Context needed to evaluate a trig condition.
@@ -10,15 +10,15 @@ export interface ConditionContext {
 
 /**
  * Evaluate whether a step should fire given its
- * condition and the current context.
+ * conditions and the current context. Both probability
+ * and cycle are checked with AND semantics.
  *
  * Returns true if:
- * - No condition (undefined) -- always fire
- * - Probability: Math.random() < value/100
- * - Cycle A:B: (cycleCount % b) === (a - 1)
+ * - No conditions (undefined) -- always fire
+ * - Probability passes AND cycle matches
  *
  * Args:
- *   condition: The trig condition, or undefined
+ *   conditions: The step conditions, or undefined
  *     for unconditional steps.
  *   ctx: Current evaluation context.
  *
@@ -26,15 +26,47 @@ export interface ConditionContext {
  *   Whether the step should fire.
  */
 export function evaluateCondition(
-  condition: TrigCondition | undefined,
+  conditions: StepConditions | undefined,
   ctx: ConditionContext
 ): boolean {
-  if (condition === undefined) return true;
-
-  switch (condition.type) {
-    case 'probability':
-      return Math.random() < condition.value / 100;
-    case 'cycle':
-      return ctx.cycleCount % condition.b === condition.a - 1;
+  if (!conditions) return true;
+  if (conditions.probability !== undefined) {
+    if (
+      Math.random() >= conditions.probability / 100
+    ) {
+      return false;
+    }
   }
+  if (conditions.cycle) {
+    const { a, b } = conditions.cycle;
+    if ((ctx.cycleCount % b) + 1 !== a) {
+      return false;
+    }
+  }
+  return true;
 }
+
+/**
+ * A cycle option for the UI dropdown.
+ */
+export interface CycleOption {
+  label: string;
+  a: number;
+  b: number;
+}
+
+/**
+ * All valid cycle options for the dropdown.
+ * 1:1 means "every cycle" (no filtering).
+ */
+export const CYCLE_OPTIONS: CycleOption[] = (() => {
+  const opts: CycleOption[] = [
+    { label: '1:1', a: 1, b: 1 },
+  ];
+  for (let b = 2; b <= 8; b++) {
+    for (let a = 1; a <= b; a++) {
+      opts.push({ label: `${a}:${b}`, a, b });
+    }
+  }
+  return opts;
+})();

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -13,14 +13,17 @@ export interface Kit {
 }
 
 /**
- * A trig condition controlling when a step fires.
+ * Compound trig conditions for a single step.
+ * Both fields are optional; when both are set they
+ * combine with AND semantics.
  *
- * - probability: fires randomly with the given percentage (1-99)
- * - cycle: fires on step `a` of every `b` repetitions (1/b to b/b)
+ * - probability: fires randomly (1-99%)
+ * - cycle: fires on step a of every b reps (b: 2-8)
  */
-export type TrigCondition =
-  | { type: 'probability'; value: number }
-  | { type: 'cycle'; a: number; b: number };
+export interface StepConditions {
+  probability?: number;
+  cycle?: { a: number; b: number };
+}
 
 /**
  * Represents a pattern with variable-length step strings.
@@ -30,7 +33,7 @@ export interface Pattern {
   name: string;
   steps: Record<TrackId, string>;
   trigConditions?: Partial<
-    Record<TrackId, Record<number, TrigCondition>>
+    Record<TrackId, Record<number, StepConditions>>
   >;
 }
 
@@ -82,6 +85,6 @@ export interface SequencerConfig {
   mixer: Record<TrackId, TrackMixerState>;
   swing: number;
   trigConditions: Partial<
-    Record<TrackId, Record<number, TrigCondition>>
+    Record<TrackId, Record<number, StepConditions>>
   >;
 }


### PR DESCRIPTION
## Summary

- Replace `TrigCondition` discriminated union with `StepConditions` interface supporting compound probability + cycle conditions with AND semantics (both can be set on one step)
- Add per-step trig condition popover triggered by right-click (desktop) or long-press (mobile) on active steps
- Add visual indicators on step buttons: probability bar at bottom, cycle A:B label in Orbitron font
- Add ProbabilitySlider component with pointer-capture drag and full keyboard support
- Add configCodec validation for compound StepConditions with clamping and pruning

## Out of scope

This PR does not change the accent trig condition evaluation that was added in PR #23. The accent track continues to use the same evaluateCondition function, which now supports compound conditions.

## Test plan

- [x] 188 tests pass (14 test files)
- [x] Zero lint errors
- [x] Production build succeeds
- [ ] Right-click active step -> popover opens below step
- [ ] Right-click inactive step -> nothing happens
- [ ] Single click still toggles steps
- [ ] Probability slider updates bar indicator in real time
- [ ] Cycle dropdown updates A:B label on step
- [ ] All defaults (100%, 1:1) -> condition cleared
- [ ] Click outside / Escape dismisses popover
- [ ] Reset button clears condition and closes popover
- [ ] Conditions survive URL export round-trip
- [ ] Long-press on mobile opens popover with haptic
