### PR TITLE
Add fill button and FILL/!FILL trig conditions

### DIFF
--- a/src/__tests__/FillButton.test.tsx
+++ b/src/__tests__/FillButton.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent }
+  from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach }
+  from 'vitest';
+import FillButton from '../app/FillButton';
+
+const mockToggleFillLatch = vi.fn();
+const mockSetFillHeld = vi.fn();
+
+vi.mock('../app/SequencerContext', () => ({
+  useSequencer: () => ({
+    state: {
+      isFillActive: false,
+      fillMode: 'off',
+    },
+    actions: {
+      toggleFillLatch: mockToggleFillLatch,
+      setFillHeld: mockSetFillHeld,
+    },
+  }),
+}));
+
+describe('FillButton', () => {
+  beforeEach(() => {
+    mockToggleFillLatch.mockClear();
+    mockSetFillHeld.mockClear();
+  });
+
+  it('renders with FILL text', () => {
+    render(<FillButton />);
+    expect(
+      screen.getByText('FILL')
+    ).toBeTruthy();
+  });
+
+  it('has aria-pressed attribute', () => {
+    render(<FillButton />);
+    const btn = screen.getByRole('button');
+    expect(
+      btn.getAttribute('aria-pressed')
+    ).toBeDefined();
+  });
+
+  it('pointer down activates momentary fill',
+    () => {
+      render(<FillButton />);
+      const btn = screen.getByRole('button');
+      fireEvent.pointerDown(btn);
+      expect(
+        mockSetFillHeld
+      ).toHaveBeenCalledWith(true);
+    }
+  );
+
+  it('pointer up deactivates momentary fill',
+    () => {
+      render(<FillButton />);
+      const btn = screen.getByRole('button');
+      fireEvent.pointerDown(btn);
+      fireEvent.pointerUp(btn);
+      expect(
+        mockSetFillHeld
+      ).toHaveBeenCalledWith(false);
+    }
+  );
+
+  it('pointerCancel deactivates fill', () => {
+    render(<FillButton />);
+    const btn = screen.getByRole('button');
+    fireEvent.pointerDown(btn);
+    fireEvent.pointerCancel(btn);
+    expect(
+      mockSetFillHeld
+    ).toHaveBeenCalledWith(false);
+  });
+
+  it('Cmd+click toggles latch', () => {
+    render(<FillButton />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn, { metaKey: true });
+    expect(
+      mockToggleFillLatch
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+click toggles latch', () => {
+    render(<FillButton />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn, { ctrlKey: true });
+    expect(
+      mockToggleFillLatch
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('plain click does not toggle latch', () => {
+    render(<FillButton />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    expect(
+      mockToggleFillLatch
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -469,6 +469,105 @@ describe('setSwing', () => {
 });
 
 // -------------------------------------------------------
+// G. Fill state
+// -------------------------------------------------------
+describe('fill state', () => {
+  it('initial fill state is off', () => {
+    const { result } = renderSequencer();
+    expect(
+      result.current.state.isFillActive
+    ).toBe(false);
+    expect(
+      result.current.state.fillMode
+    ).toBe('off');
+  });
+
+  it('toggleFillLatch toggles fill active', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleFillLatch();
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(true);
+    expect(
+      result.current.state.fillMode
+    ).toBe('latched');
+    act(() => {
+      result.current.actions.toggleFillLatch();
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(false);
+    expect(
+      result.current.state.fillMode
+    ).toBe('off');
+  });
+
+  it('setFillHeld(true) activates fill', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setFillHeld(true);
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(true);
+    expect(
+      result.current.state.fillMode
+    ).toBe('momentary');
+  });
+
+  it('setFillHeld(false) clears latch too', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleFillLatch();
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(true);
+    act(() => {
+      result.current.actions.setFillHeld(false);
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(false);
+  });
+
+  it('clearAll resets fill state', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleFillLatch();
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(true);
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    expect(
+      result.current.state.isFillActive
+    ).toBe(false);
+    expect(
+      result.current.state.fillMode
+    ).toBe('off');
+  });
+
+  it('fill state not in config (transient)', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleFillLatch();
+    });
+    const config = result.current.meta.config;
+    expect(
+      'isFillActive' in config
+    ).toBe(false);
+    expect(
+      'fillMode' in config
+    ).toBe(false);
+  });
+});
+
+// -------------------------------------------------------
 // D. URL hash import
 // -------------------------------------------------------
 describe('URL hash import', () => {

--- a/src/__tests__/StepButton.test.tsx
+++ b/src/__tests__/StepButton.test.tsx
@@ -66,6 +66,48 @@ describe('StepButton indicators', () => {
     expect(container.textContent).toContain('1:3');
   });
 
+  it('F badge for fill:fill on active step', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        conditions={{ fill: 'fill' }}
+      />
+    );
+    const badge = container.querySelector(
+      '[data-testid="fill-badge"]'
+    );
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('F');
+  });
+
+  it('!F badge for fill:!fill on active step',
+    () => {
+      const { container } = render(
+        <StepButton
+          {...base}
+          conditions={{ fill: '!fill' }}
+        />
+      );
+      const badge = container.querySelector(
+        '[data-testid="fill-badge"]'
+      );
+      expect(badge).toBeTruthy();
+      expect(badge?.textContent).toBe('!F');
+    }
+  );
+
+  it('no fill badge when fill undefined', () => {
+    const { container } = render(
+      <StepButton
+        {...base}
+        conditions={{ probability: 50 }}
+      />
+    );
+    expect(container.querySelector(
+      '[data-testid="fill-badge"]'
+    )).toBeNull();
+  });
+
   it('no indicators on inactive step', () => {
     const { container } = render(
       <StepButton

--- a/src/__tests__/TrigConditionPopover.test.tsx
+++ b/src/__tests__/TrigConditionPopover.test.tsx
@@ -117,6 +117,68 @@ describe('TrigConditionPopover', () => {
     vi.useRealTimers();
   });
 
+  it('fill section renders three options', () => {
+    render(<TrigConditionPopover {...base} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    expect(radios[0].textContent).toBe('None');
+    expect(radios[1].textContent).toBe('FILL');
+    expect(radios[2].textContent).toBe('!FILL');
+  });
+
+  it('selecting FILL sets fill condition', () => {
+    render(<TrigConditionPopover {...base} />);
+    const fillBtn = screen.getByRole('radio', {
+      name: /^FILL$/,
+    });
+    fireEvent.click(fillBtn);
+    expect(mockSet).toHaveBeenCalledWith(
+      'bd', 3, { fill: 'fill' }
+    );
+  });
+
+  it('selecting !FILL sets fill condition', () => {
+    render(<TrigConditionPopover {...base} />);
+    const nfillBtn = screen.getByRole('radio', {
+      name: /^!FILL$/,
+    });
+    fireEvent.click(nfillBtn);
+    expect(mockSet).toHaveBeenCalledWith(
+      'bd', 3, { fill: '!fill' }
+    );
+  });
+
+  it('selecting None removes fill', () => {
+    render(
+      <TrigConditionPopover
+        {...base}
+        conditions={{ fill: 'fill' }}
+      />
+    );
+    const noneBtn = screen.getByRole('radio', {
+      name: /^None$/,
+    });
+    fireEvent.click(noneBtn);
+    expect(mockClear).toHaveBeenCalledWith(
+      'bd', 3
+    );
+  });
+
+  it('pre-populates fill from conditions', () => {
+    render(
+      <TrigConditionPopover
+        {...base}
+        conditions={{ fill: '!fill' }}
+      />
+    );
+    const nfillRadio = screen.getByRole('radio', {
+      name: /^!FILL$/,
+    });
+    expect(
+      nfillRadio.getAttribute('aria-checked')
+    ).toBe('true');
+  });
+
   it('pre-populates from existing conditions',
     () => {
       render(

--- a/src/__tests__/configCodec.test.ts
+++ b/src/__tests__/configCodec.test.ts
@@ -518,6 +518,58 @@ describe('validateTrigConditions', () => {
   });
 });
 
+describe('fill condition validation', () => {
+  it('round-trips fill:fill', async () => {
+    const config = defaultConfig();
+    config.trigConditions = {
+      bd: { 0: { fill: 'fill' } },
+    };
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(
+      decoded.trigConditions.bd?.[0]
+    ).toEqual({ fill: 'fill' });
+  });
+
+  it('round-trips fill:!fill', async () => {
+    const config = defaultConfig();
+    config.trigConditions = {
+      sd: { 4: { fill: '!fill' } },
+    };
+    const hash = await encodeConfig(config);
+    const decoded = await decodeConfig(hash);
+    expect(
+      decoded.trigConditions.sd?.[4]
+    ).toEqual({ fill: '!fill' });
+  });
+
+  it('invalid fill values stripped', async () => {
+    const raw = {
+      ...defaultConfig(),
+      trigConditions: {
+        bd: { 0: { fill: 'invalid' } },
+      },
+    };
+    const hash = await encodeRaw(raw);
+    const decoded = await decodeConfig(hash);
+    expect(decoded.trigConditions).toEqual({});
+  });
+
+  it('old configs without fill decode normally',
+    async () => {
+      const config = defaultConfig();
+      config.trigConditions = {
+        bd: { 0: { probability: 50 } },
+      };
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(
+        decoded.trigConditions.bd?.[0]
+      ).toEqual({ probability: 50 });
+    }
+  );
+});
+
 describe('validateMixer', () => {
   it('negative gain clamped to 0', async () => {
     const config = defaultConfig();

--- a/src/__tests__/trigConditions.test.ts
+++ b/src/__tests__/trigConditions.test.ts
@@ -13,10 +13,10 @@ describe('evaluateCondition', () => {
     it('always fires when condition is undefined',
       () => {
         expect(evaluateCondition(
-          undefined, { cycleCount: 0 }
+          undefined, { cycleCount: 0, fillActive: false }
         )).toBe(true);
         expect(evaluateCondition(
-          undefined, { cycleCount: 99 }
+          undefined, { cycleCount: 99, fillActive: false }
         )).toBe(true);
       }
     );
@@ -28,7 +28,7 @@ describe('evaluateCondition', () => {
         vi.spyOn(Math, 'random')
           .mockReturnValue(0.49);
         expect(evaluateCondition(
-          { probability: 50 }, { cycleCount: 0 }
+          { probability: 50 }, { cycleCount: 0, fillActive: false }
         )).toBe(true);
       }
     );
@@ -38,7 +38,7 @@ describe('evaluateCondition', () => {
         vi.spyOn(Math, 'random')
           .mockReturnValue(0.50);
         expect(evaluateCondition(
-          { probability: 50 }, { cycleCount: 0 }
+          { probability: 50 }, { cycleCount: 0, fillActive: false }
         )).toBe(false);
       }
     );
@@ -48,7 +48,7 @@ describe('evaluateCondition', () => {
         vi.spyOn(Math, 'random')
           .mockReturnValue(0.009);
         expect(evaluateCondition(
-          { probability: 1 }, { cycleCount: 0 }
+          { probability: 1 }, { cycleCount: 0, fillActive: false }
         )).toBe(true);
       }
     );
@@ -58,7 +58,7 @@ describe('evaluateCondition', () => {
         vi.spyOn(Math, 'random')
           .mockReturnValue(0.99);
         expect(evaluateCondition(
-          { probability: 99 }, { cycleCount: 0 }
+          { probability: 99 }, { cycleCount: 0, fillActive: false }
         )).toBe(false);
       }
     );
@@ -68,7 +68,7 @@ describe('evaluateCondition', () => {
     it('cycle 1:4 fires on cycle 0', () => {
       expect(evaluateCondition(
         { cycle: { a: 1, b: 4 } },
-        { cycleCount: 0 }
+        { cycleCount: 0, fillActive: false }
       )).toBe(true);
     });
 
@@ -76,13 +76,13 @@ describe('evaluateCondition', () => {
       () => {
         const cond = { cycle: { a: 1, b: 4 } };
         expect(evaluateCondition(
-          cond, { cycleCount: 1 }
+          cond, { cycleCount: 1, fillActive: false }
         )).toBe(false);
         expect(evaluateCondition(
-          cond, { cycleCount: 2 }
+          cond, { cycleCount: 2, fillActive: false }
         )).toBe(false);
         expect(evaluateCondition(
-          cond, { cycleCount: 3 }
+          cond, { cycleCount: 3, fillActive: false }
         )).toBe(false);
       }
     );
@@ -90,7 +90,7 @@ describe('evaluateCondition', () => {
     it('cycle 3:4 fires on cycle 2', () => {
       expect(evaluateCondition(
         { cycle: { a: 3, b: 4 } },
-        { cycleCount: 2 }
+        { cycleCount: 2, fillActive: false }
       )).toBe(true);
     });
 
@@ -98,19 +98,62 @@ describe('evaluateCondition', () => {
       () => {
         const cond = { cycle: { a: 2, b: 2 } };
         expect(evaluateCondition(
-          cond, { cycleCount: 0 }
+          cond, { cycleCount: 0, fillActive: false }
         )).toBe(false);
         expect(evaluateCondition(
-          cond, { cycleCount: 1 }
+          cond, { cycleCount: 1, fillActive: false }
         )).toBe(true);
         expect(evaluateCondition(
-          cond, { cycleCount: 2 }
+          cond, { cycleCount: 2, fillActive: false }
         )).toBe(false);
         expect(evaluateCondition(
-          cond, { cycleCount: 3 }
+          cond, { cycleCount: 3, fillActive: false }
         )).toBe(true);
       }
     );
+  });
+
+  describe('fill condition', () => {
+    it('FILL fires when fillActive=true', () => {
+      expect(evaluateCondition(
+        { fill: 'fill' },
+        { cycleCount: 0, fillActive: true }
+      )).toBe(true);
+    });
+
+    it('FILL suppressed when fillActive=false',
+      () => {
+        expect(evaluateCondition(
+          { fill: 'fill' },
+          { cycleCount: 0, fillActive: false }
+        )).toBe(false);
+      }
+    );
+
+    it('!FILL fires when fillActive=false', () => {
+      expect(evaluateCondition(
+        { fill: '!fill' },
+        { cycleCount: 0, fillActive: false }
+      )).toBe(true);
+    });
+
+    it('!FILL suppressed when fillActive=true',
+      () => {
+        expect(evaluateCondition(
+          { fill: '!fill' },
+          { cycleCount: 0, fillActive: true }
+        )).toBe(false);
+      }
+    );
+
+    it('undefined fill has no effect', () => {
+      expect(evaluateCondition(
+        {}, { cycleCount: 0, fillActive: true }
+      )).toBe(true);
+      expect(evaluateCondition(
+        {}, { cycleCount: 0, fillActive: false }
+      )).toBe(true);
+    });
   });
 
   describe('AND semantics', () => {
@@ -121,7 +164,7 @@ describe('evaluateCondition', () => {
       // cycle 0 => (0%2)+1=1 === a=1 => true
       expect(evaluateCondition(
         { probability: 50, cycle: { a: 1, b: 2 } },
-        { cycleCount: 0 }
+        { cycleCount: 0, fillActive: false }
       )).toBe(true);
     });
 
@@ -135,7 +178,7 @@ describe('evaluateCondition', () => {
             probability: 50,
             cycle: { a: 1, b: 2 },
           },
-          { cycleCount: 1 }
+          { cycleCount: 1, fillActive: false }
         )).toBe(false);
       }
     );
@@ -149,10 +192,34 @@ describe('evaluateCondition', () => {
             probability: 50,
             cycle: { a: 1, b: 2 },
           },
-          { cycleCount: 0 }
+          { cycleCount: 0, fillActive: false }
         )).toBe(false);
       }
     );
+
+    it('fill + probability: both must pass', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValue(0.49);
+      expect(evaluateCondition(
+        { fill: 'fill', probability: 50 },
+        { cycleCount: 0, fillActive: true }
+      )).toBe(true);
+      expect(evaluateCondition(
+        { fill: 'fill', probability: 50 },
+        { cycleCount: 0, fillActive: false }
+      )).toBe(false);
+    });
+
+    it('fill + cycle: both must pass', () => {
+      expect(evaluateCondition(
+        { fill: 'fill', cycle: { a: 1, b: 2 } },
+        { cycleCount: 0, fillActive: true }
+      )).toBe(true);
+      expect(evaluateCondition(
+        { fill: 'fill', cycle: { a: 1, b: 2 } },
+        { cycleCount: 0, fillActive: false }
+      )).toBe(false);
+    });
   });
 });
 

--- a/src/app/FillButton.tsx
+++ b/src/app/FillButton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback } from 'react';
+import { useSequencer } from './SequencerContext';
+
+/**
+ * Fill button: momentary by default (hold to
+ * activate), Cmd/Ctrl+click to toggle latch.
+ */
+export default function FillButton() {
+  const { state, actions } = useSequencer();
+  const { isFillActive, fillMode } = state;
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.metaKey || e.ctrlKey) return;
+      actions.setFillHeld(true);
+    },
+    [actions]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.metaKey || e.ctrlKey) return;
+      actions.setFillHeld(false);
+    },
+    [actions]
+  );
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.metaKey || e.ctrlKey) {
+        actions.toggleFillLatch();
+      }
+    },
+    [actions]
+  );
+
+  let bg: string;
+  if (fillMode === 'momentary') {
+    bg = 'bg-orange-400'
+      + ' shadow-[0_0_20px_rgba(251,146,60,0.6)]';
+  } else if (fillMode === 'latched') {
+    bg = 'bg-orange-600'
+      + ' shadow-[0_0_20px_rgba(234,88,12,0.4)]';
+  } else {
+    bg = 'bg-orange-600/30';
+  }
+
+  return (
+    <button
+      aria-pressed={isFillActive}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onClick={handleClick}
+      style={{ touchAction: 'manipulation' }}
+      className={
+        'self-stretch px-2 lg:px-3 rounded-full'
+        + ' font-bold text-sm lg:text-base'
+        + ' border border-orange-700'
+        + ' transition-colors'
+        + ' focus-visible:outline-none'
+        + ' focus-visible:ring-2'
+        + ' focus-visible:ring-orange-500'
+        + ' focus-visible:ring-offset-2'
+        + ' focus-visible:ring-offset-neutral-950 '
+        + bg
+      }
+    >
+      FILL
+    </button>
+  );
+}

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -70,6 +70,8 @@ interface SequencerState {
   trackStates: Record<TrackId, TrackState>;
   isLoaded: boolean;
   swing: number;
+  isFillActive: boolean;
+  fillMode: 'off' | 'latched' | 'momentary';
 }
 
 interface SequencerActions {
@@ -90,6 +92,8 @@ interface SequencerActions {
   ) => void;
   clearAll: () => void;
   setSwing: (value: number) => void;
+  toggleFillLatch: () => void;
+  setFillHeld: (held: boolean) => void;
   setStep: (
     trackId: TrackId,
     stepIndex: number,
@@ -190,6 +194,16 @@ export function SequencerProvider({
   const [isLoaded, setIsLoaded] = useState(false);
   const stepRef = useRef<number>(-1);
   const totalStepsRef = useRef<number>(0);
+
+  // ─── Fill state ──────────────────────────────────
+  const [isLatched, setIsLatched] = useState(false);
+  const [isHeld, setIsHeld] = useState(false);
+  const fillActiveRef = useRef(false);
+  const isFillActive = isLatched || isHeld;
+  const fillMode: 'off' | 'latched' | 'momentary' =
+    isHeld ? 'momentary'
+      : isLatched ? 'latched'
+        : 'off';
 
   // ─── Import config from URL hash on mount ─────────
   useEffect(() => {
@@ -350,6 +364,7 @@ export function SequencerProvider({
         isAccented = evaluateCondition(accentCond, {
           cycleCount:
             cycleCountRef.current.ac ?? 0,
+          fillActive: fillActiveRef.current,
         });
       }
 
@@ -374,6 +389,7 @@ export function SequencerProvider({
               cycleCount:
                 cycleCountRef.current[track.id]
                   ?? 0,
+              fillActive: fillActiveRef.current,
             }
           );
           if (!shouldFire) return;
@@ -727,6 +743,9 @@ export function SequencerProvider({
         trigConditions: {},
       };
     });
+    setIsLatched(false);
+    setIsHeld(false);
+    fillActiveRef.current = false;
     setSelectedPatternId('custom');
   }, []);
 
@@ -739,6 +758,67 @@ export function SequencerProvider({
     },
     []
   );
+
+  const toggleFillLatch = useCallback(() => {
+    setIsLatched(prev => {
+      const next = !prev;
+      fillActiveRef.current = next || isHeld;
+      return next;
+    });
+  }, [isHeld]);
+
+  const setFillHeld = useCallback(
+    (held: boolean) => {
+      setIsHeld(held);
+      if (!held) {
+        setIsLatched(false);
+        fillActiveRef.current = false;
+      } else {
+        fillActiveRef.current = true;
+      }
+    },
+    []
+  );
+
+  // ─── Fill keyboard shortcut (f key) ─────────────
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'KeyF' || e.repeat) return;
+      const tag =
+        (e.target as HTMLElement)?.tagName;
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT'
+      ) return;
+      e.preventDefault();
+      if (e.metaKey || e.ctrlKey) {
+        toggleFillLatch();
+      } else {
+        setFillHeld(true);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== 'KeyF') return;
+      setFillHeld(false);
+    };
+
+    document.addEventListener(
+      'keydown', handleKeyDown
+    );
+    document.addEventListener(
+      'keyup', handleKeyUp
+    );
+    return () => {
+      document.removeEventListener(
+        'keydown', handleKeyDown
+      );
+      document.removeEventListener(
+        'keyup', handleKeyUp
+      );
+    };
+  }, [toggleFillLatch, setFillHeld]);
 
   const setTrigCondition = useCallback(
     (
@@ -797,6 +877,8 @@ export function SequencerProvider({
       trackStates,
       isLoaded,
       swing: config.swing,
+      isFillActive,
+      fillMode,
     },
     actions: {
       togglePlay,
@@ -813,6 +895,8 @@ export function SequencerProvider({
       setTrackLength,
       clearAll,
       setSwing,
+      toggleFillLatch,
+      setFillHeld,
       setTrigCondition,
       clearTrigCondition,
     },

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -154,6 +154,25 @@ function StepButtonInner({
             }}
           />
         ) : null}
+      {isActive && conditions?.fill
+        ? (
+          <span
+            data-testid="fill-badge"
+            className={
+              'absolute top-0 right-0.5'
+              + ' text-[8px] font-bold'
+              + ' leading-none'
+              + ' pointer-events-none'
+              + ' text-white'
+            }
+            style={{
+              fontFamily: 'var(--font-orbitron)',
+            }}
+          >
+            {conditions.fill === 'fill'
+              ? 'F' : '!F'}
+          </span>
+        ) : null}
       {isActive && conditions?.cycle != null
         && conditions.cycle.b >= 2
         ? (

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -6,6 +6,7 @@ import patternsData from './data/patterns.json';
 import TempoController from './TempoController';
 import SettingsPopover from './SettingsPopover';
 import GlobalControls from './GlobalControls';
+import FillButton from './FillButton';
 import { useSequencer } from './SequencerContext';
 
 /**
@@ -41,6 +42,7 @@ function TransportControlsInner() {
           >
             {isPlaying ? 'STOP' : 'PLAY'}
           </button>
+          <FillButton />
           <SettingsPopover />
         </div>
       </div>

--- a/src/app/TrigConditionPopover.tsx
+++ b/src/app/TrigConditionPopover.tsx
@@ -48,9 +48,16 @@ export default function TrigConditionPopover({
       ? `${conditions.cycle.a}:${conditions.cycle.b}`
       : '1:1'
   );
+  const [fillValue, setFillValue] = useState<
+    'none' | 'fill' | '!fill'
+  >(conditions?.fill ?? 'none');
 
   const updateConditions = useCallback(
-    (prob: number, cycle: string) => {
+    (
+      prob: number,
+      cycle: string,
+      fill: 'none' | 'fill' | '!fill'
+    ) => {
       const sc: StepConditions = {};
       if (prob < 100) {
         sc.probability = prob;
@@ -60,6 +67,9 @@ export default function TrigConditionPopover({
       );
       if (option && option.b >= 2) {
         sc.cycle = { a: option.a, b: option.b };
+      }
+      if (fill !== 'none') {
+        sc.fill = fill;
       }
       if (Object.keys(sc).length === 0) {
         actions.clearTrigCondition(
@@ -77,18 +87,26 @@ export default function TrigConditionPopover({
   const handleProbChange = useCallback(
     (v: number) => {
       setProbability(v);
-      updateConditions(v, cycleValue);
+      updateConditions(v, cycleValue, fillValue);
     },
-    [updateConditions, cycleValue]
+    [updateConditions, cycleValue, fillValue]
   );
 
   const handleCycleChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const v = e.target.value;
       setCycleValue(v);
-      updateConditions(probability, v);
+      updateConditions(probability, v, fillValue);
     },
-    [updateConditions, probability]
+    [updateConditions, probability, fillValue]
+  );
+
+  const handleFillChange = useCallback(
+    (v: 'none' | 'fill' | '!fill') => {
+      setFillValue(v);
+      updateConditions(probability, cycleValue, v);
+    },
+    [updateConditions, probability, cycleValue]
   );
 
   useEffect(() => {
@@ -236,6 +254,55 @@ export default function TrigConditionPopover({
             </option>
           ))}
         </select>
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Fill
+        </div>
+        <div
+          className="flex gap-1"
+          role="radiogroup"
+          aria-label="Fill condition"
+        >
+          {([
+            ['none', 'None'],
+            ['fill', 'FILL'],
+            ['!fill', '!FILL'],
+          ] as const).map(([val, label]) => (
+            <button
+              key={val}
+              role="radio"
+              aria-checked={fillValue === val}
+              onClick={() => handleFillChange(val)}
+              className={
+                'flex-1 text-xs py-1 rounded'
+                + ' border transition-colors'
+                + (fillValue === val
+                  ? val === 'fill'
+                    ? ' bg-orange-600'
+                      + ' border-orange-500'
+                      + ' text-white'
+                    : val === '!fill'
+                      ? ' bg-neutral-700'
+                        + ' border-neutral-600'
+                        + ' text-neutral-200'
+                      : ' bg-neutral-800'
+                        + ' border-neutral-600'
+                        + ' text-neutral-200'
+                  : ' bg-neutral-900'
+                    + ' border-neutral-700'
+                    + ' text-neutral-400'
+                    + ' hover:bg-neutral-800')
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
     </div>

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -369,6 +369,11 @@ function validateSingleCondition(
         }
       }
     }
+    if (
+      obj.fill === 'fill' || obj.fill === '!fill'
+    ) {
+      sc.fill = obj.fill;
+    }
   }
 
   if (Object.keys(sc).length === 0) return null;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,11 +95,13 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 /* Track scroll region — hide scrollbar, keep scroll */
-.track-scroll-region {
-  scrollbar-width: none;
-}
-.track-scroll-region::-webkit-scrollbar {
-  display: none;
+@layer base {
+  .track-scroll-region {
+    scrollbar-width: none;
+  }
+  .track-scroll-region::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @supports (padding-top: env(safe-area-inset-top)) {

--- a/src/app/trigConditions.ts
+++ b/src/app/trigConditions.ts
@@ -6,6 +6,8 @@ import type { StepConditions } from './types';
 export interface ConditionContext {
   /** Current cycle count for this track (0-indexed). */
   cycleCount: number;
+  /** Whether the global fill button is active. */
+  fillActive: boolean;
 }
 
 /**
@@ -42,6 +44,12 @@ export function evaluateCondition(
     if ((ctx.cycleCount % b) + 1 !== a) {
       return false;
     }
+  }
+  if (conditions.fill === 'fill' && !ctx.fillActive) {
+    return false;
+  }
+  if (conditions.fill === '!fill' && ctx.fillActive) {
+    return false;
   }
   return true;
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -23,6 +23,7 @@ export interface Kit {
 export interface StepConditions {
   probability?: number;
   cycle?: { a: number; b: number };
+  fill?: 'fill' | '!fill';
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #9

- Add Fill button to transport row with momentary (hold) and latch
  (Cmd/Ctrl+click) activation modes
- Add FILL/!FILL trig condition type that gates step playback based on
  global fill-active state, with AND semantics alongside probability
  and cycle conditions
- Add `f` keyboard shortcut (hold = momentary, Cmd/Ctrl+f = latch)
- Add "F"/"!F" badge indicators on steps with fill conditions
- Add fill section (None/FILL/!FILL) to trig condition popover
- Fix scrollbar visibility in track scroll region (Tailwind v4
  `@layer base` fix)

## Out of scope

- Fill state is transient only (not serialized in config/URL) per
  design — it controls live playback behavior, not pattern definition
- No config version bump needed — `fill` field is optional and
  backward compatible

## Test plan

- [ ] 245 tests pass (`npm test`)
- [ ] Zero lint errors (`npm run lint`)
- [ ] Static export builds (`npm run build`)
- [ ] Browser: set steps with FILL condition, verify they only fire
  when Fill button is active
- [ ] Browser: hold Fill for momentary, Cmd+click to latch toggle
- [ ] Browser: `f` key hold = momentary, Cmd+f = latch toggle
- [ ] URL sharing preserves FILL/!FILL conditions on steps
- [ ] Old URLs without fill field still decode correctly
