### PR TITLE
Shift+click track name to reset track

### DIFF
--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -426,6 +426,123 @@ describe('clearAll', () => {
   });
 });
 
+// -------------------------------------------------------
+// F2. clearTrack
+// -------------------------------------------------------
+describe('clearTrack', () => {
+  it('clears steps to all zeros for target track only', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleStep('bd', 0);
+      result.current.actions.toggleStep('bd', 4);
+      result.current.actions.toggleStep('sd', 2);
+    });
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    const bdSteps =
+      result.current.meta.config.steps.bd;
+    expect(bdSteps).toMatch(/^0+$/);
+    // sd should still have its step active
+    expect(
+      result.current.meta.config.steps.sd[2]
+    ).toBe('1');
+  });
+
+  it('resets track length to patternLength', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setTrackLength('bd', 5);
+    });
+    expect(
+      result.current.meta.config.trackLengths.bd
+    ).toBe(5);
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    expect(
+      result.current.meta.config.trackLengths.bd
+    ).toBe(result.current.state.patternLength);
+  });
+
+  it('removes trig conditions for target track only', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleStep('bd', 0);
+      result.current.actions.toggleStep('sd', 0);
+      result.current.actions.setTrigCondition(
+        'bd', 0, { type: 'every', n: 2 }
+      );
+      result.current.actions.setTrigCondition(
+        'sd', 0, { type: 'every', n: 3 }
+      );
+    });
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    expect(
+      result.current.meta.config.trigConditions.bd
+    ).toBeUndefined();
+    expect(
+      result.current.meta.config.trigConditions.sd
+    ).toBeDefined();
+  });
+
+  it('resets freeRun to false for target track', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleFreeRun('bd');
+    });
+    expect(
+      result.current.meta.config.mixer.bd.freeRun
+    ).toBe(true);
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    expect(
+      result.current.meta.config.mixer.bd.freeRun
+    ).toBe(false);
+  });
+
+  it('leaves other tracks untouched', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleStep('sd', 2);
+      result.current.actions.setTrackLength('sd', 8);
+      result.current.actions.toggleFreeRun('sd');
+    });
+    const sdBefore = {
+      steps: result.current.meta.config.steps.sd,
+      length:
+        result.current.meta.config.trackLengths.sd,
+      freeRun:
+        result.current.meta.config.mixer.sd.freeRun,
+    };
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    expect(
+      result.current.meta.config.steps.sd
+    ).toBe(sdBefore.steps);
+    expect(
+      result.current.meta.config.trackLengths.sd
+    ).toBe(sdBefore.length);
+    expect(
+      result.current.meta.config.mixer.sd.freeRun
+    ).toBe(sdBefore.freeRun);
+  });
+
+  it('sets selected pattern to custom', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.clearTrack('bd');
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('custom');
+  });
+});
+
 describe('setSwing', () => {
   it('updates swing value', () => {
     const { result } = renderSequencer();

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -91,6 +91,7 @@ interface SequencerActions {
     trackId: TrackId, length: number
   ) => void;
   clearAll: () => void;
+  clearTrack: (trackId: TrackId) => void;
   setSwing: (value: number) => void;
   toggleFillLatch: () => void;
   setFillHeld: (held: boolean) => void;
@@ -749,6 +750,38 @@ export function SequencerProvider({
     setSelectedPatternId('custom');
   }, []);
 
+  const clearTrack = useCallback(
+    (trackId: TrackId) => {
+      setConfig(prev => {
+        const newTrigConditions = {
+          ...prev.trigConditions,
+        };
+        delete newTrigConditions[trackId];
+        return {
+          ...prev,
+          steps: {
+            ...prev.steps,
+            [trackId]: '0'.repeat(prev.patternLength),
+          },
+          trackLengths: {
+            ...prev.trackLengths,
+            [trackId]: prev.patternLength,
+          },
+          mixer: {
+            ...prev.mixer,
+            [trackId]: {
+              ...prev.mixer[trackId],
+              freeRun: false,
+            },
+          },
+          trigConditions: newTrigConditions,
+        };
+      });
+      setSelectedPatternId('custom');
+    },
+    []
+  );
+
   const setSwing = useCallback(
     (value: number) => {
       setConfig(prev => ({
@@ -894,6 +927,7 @@ export function SequencerProvider({
       setPatternLength,
       setTrackLength,
       clearAll,
+      clearTrack,
       setSwing,
       toggleFillLatch,
       setFillHeld,

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -37,6 +37,7 @@ export default function StepGrid({
   const {
     toggleStep, setStep, toggleMute, toggleSolo,
     setGain, setTrackLength, toggleFreeRun,
+    clearTrack,
   } = actions;
   const { stepRef, totalStepsRef, config } = meta;
 
@@ -117,6 +118,7 @@ export default function StepGrid({
             onSetGain={setGain}
             onSetTrackLength={setTrackLength}
             onToggleFreeRun={toggleFreeRun}
+            onClearTrack={clearTrack}
             trigConditions={
               config.trigConditions[track.id]
             }

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -16,6 +16,7 @@ interface TrackNameButtonProps {
   trackName: string;
   isFreeRun: boolean;
   onToggleFreeRun: () => void;
+  onClearTrack: () => void;
 }
 
 /**
@@ -28,6 +29,7 @@ function TrackNameButtonInner({
   trackName,
   isFreeRun,
   onToggleFreeRun,
+  onClearTrack,
 }: TrackNameButtonProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -62,7 +64,13 @@ function TrackNameButtonInner({
     <div className="relative">
       <button
         ref={size === 'lg' ? nameRef : undefined}
-        onClick={() => setMenuOpen(v => !v)}
+        onClick={(e: React.MouseEvent) => {
+          if (e.shiftKey) {
+            onClearTrack();
+            return;
+          }
+          setMenuOpen(v => !v);
+        }}
         className={
           (size === 'sm'
             ? 'text-[10px]'
@@ -132,6 +140,7 @@ interface TrackRowProps {
     trackId: TrackId, length: number
   ) => void;
   onToggleFreeRun: (trackId: TrackId) => void;
+  onClearTrack: (trackId: TrackId) => void;
   trigConditions?: Record<number, StepConditions>;
   onOpenPopover?: (
     trackId: TrackId,
@@ -166,6 +175,7 @@ function TrackRowInner({
   onSetGain,
   onSetTrackLength,
   onToggleFreeRun,
+  onClearTrack,
   trigConditions,
   onOpenPopover,
 }: TrackRowProps) {
@@ -184,6 +194,10 @@ function TrackRowInner({
   const handleFreeRun = useCallback(
     () => onToggleFreeRun(trackId),
     [onToggleFreeRun, trackId]
+  );
+  const handleClearTrack = useCallback(
+    () => onClearTrack(trackId),
+    [onClearTrack, trackId]
   );
 
   // ─── Drag handle state ─────────────────────────
@@ -269,6 +283,7 @@ function TrackRowInner({
           trackName={trackName}
           isFreeRun={isFreeRun}
           onToggleFreeRun={handleFreeRun}
+          onClearTrack={handleClearTrack}
         />
         <div className="flex gap-1 ml-auto items-center">
           <TrackToggle
@@ -302,6 +317,7 @@ function TrackRowInner({
             trackName={trackName}
             isFreeRun={isFreeRun}
             onToggleFreeRun={handleFreeRun}
+            onClearTrack={handleClearTrack}
           />
           <TrackToggle
             variant="mute"


### PR DESCRIPTION
## Summary

- Add `clearTrack` action to reset a single track (steps,
  length, trig conditions, freeRun) without affecting others
- Wire Shift+click on track name buttons to trigger per-track
  reset
- Add 6 tests covering all reset behaviors and isolation

## Test plan

- [x] `npm test` — 279 tests pass
- [x] `npm run lint` — zero errors
- [x] `npm run build` — clean build
- [x] Manual: Shift+click a track name resets that track only
