### PR TITLE
Support up to 64 steps with page navigation

### DIFF
--- a/docs/plans/2026-03-19-64-steps-plan.md
+++ b/docs/plans/2026-03-19-64-steps-plan.md
@@ -1,0 +1,1399 @@
+# 64-Step Page Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use
+> subagent-driven-development (if subagents available)
+> or executing-plans to implement this plan. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the XOX sequencer from 16 to 1-64
+steps with paged display (16 steps per page) and page
+navigation dots in the transport bar.
+
+**Architecture:** Page state (`currentPage`,
+`autoFollow`) lives in the `Sequencer` component and
+flows down as props. TrackRow and RunningLight receive
+a `pageOffset` prop and render a 16-step window shifted
+by that offset. A new `PageIndicator` component renders
+clickable dots and a follow toggle inside the Pattern
+section of TransportControls.
+
+**Tech Stack:** React 19, Next.js 16, TypeScript,
+Tailwind CSS v4, Vitest + jsdom
+
+**Spec:** `docs/specs/2026-03-19-64-steps-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `src/app/SequencerContext.tsx:567` | Bump clamp 16 → 64 |
+| Modify | `src/app/GlobalControls.tsx:50-57` | Dropdown range 16 → 64 |
+| Create | `src/app/PageIndicator.tsx` | Follow toggle + page dots |
+| Create | `src/__tests__/PageIndicator.test.tsx` | PageIndicator tests |
+| Modify | `src/app/RunningLight.tsx` | Add `pageOffset` prop, shift dots |
+| Modify | `src/app/TrackRow.tsx` | Add `pageOffset` prop, shift steps + drag handle |
+| Modify | `src/app/StepButton.tsx` | No changes (receives shifted indices) |
+| Modify | `src/app/useDragPaint.ts` | Add `pageOffset`, fix `paintOne` guard |
+| Modify | `src/app/StepGrid.tsx` | Pass `pageOffset`, auto-follow in rAF, `autoFollow` ref |
+| Modify | `src/app/Sequencer.tsx` | Own page state, pass to children |
+| Modify | `src/app/TransportControls.tsx` | Accept `pageIndicator` slot, widen pattern section |
+| Modify | `src/__tests__/GlobalControls.test.tsx` | Test dropdown has 64 options |
+| Create | `src/__tests__/PageIndicator.test.tsx` | Dot count, click, follow toggle |
+| Modify | `src/__tests__/SequencerContext.test.tsx` | Test setPatternLength up to 64 |
+| Modify | `src/__tests__/useDragPaint.test.tsx` | Test pageOffset guard |
+
+---
+
+## Task 1: Bump setPatternLength Clamp to 64
+
+**Files:**
+- Modify: `src/app/SequencerContext.tsx:567`
+- Modify: `src/__tests__/SequencerContext.test.tsx`
+
+This is the backend gate — everything else depends on
+the context accepting lengths > 16.
+
+- [ ] **Step 1: Write failing test for patternLength > 16**
+
+Add to the `setPatternLength track lengths` describe
+block in `src/__tests__/SequencerContext.test.tsx`:
+
+```typescript
+it('accepts pattern length up to 64', () => {
+  const { result } = renderSequencer();
+  act(() => {
+    result.current.actions.setPatternLength(32);
+  });
+  expect(
+    result.current.state.patternLength
+  ).toBe(32);
+  for (const id of TRACK_IDS) {
+    expect(
+      result.current.meta.config.trackLengths[id]
+    ).toBe(32);
+    expect(
+      result.current.meta.config.steps[id].length
+    ).toBe(32);
+  }
+});
+
+it('clamps pattern length at 64', () => {
+  const { result } = renderSequencer();
+  act(() => {
+    result.current.actions.setPatternLength(100);
+  });
+  expect(
+    result.current.state.patternLength
+  ).toBe(64);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/SequencerContext.test.tsx -t "accepts pattern length up to 64"`
+Expected: FAIL — patternLength is 16 (clamped)
+
+- [ ] **Step 3: Change the clamp**
+
+In `src/app/SequencerContext.tsx` line 567, change:
+
+```typescript
+// Before:
+const clamped =
+  Math.max(1, Math.min(16, length));
+
+// After:
+const clamped =
+  Math.max(1, Math.min(64, length));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/SequencerContext.test.tsx -t "setPatternLength"`
+Expected: All setPatternLength tests PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm test`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/app/SequencerContext.tsx \
+  src/__tests__/SequencerContext.test.tsx
+git commit -m "Bump setPatternLength clamp from 16 to 64"
+```
+
+---
+
+## Task 2: Extend GlobalControls Dropdown to 64
+
+**Files:**
+- Modify: `src/app/GlobalControls.tsx:50-57`
+- Modify: `src/__tests__/GlobalControls.test.tsx`
+
+- [ ] **Step 1: Write failing test for 64 options**
+
+Add to `src/__tests__/GlobalControls.test.tsx`:
+
+```typescript
+it('renders 64 step options', () => {
+  render(<GlobalControls />);
+  const select = screen.getByRole('combobox');
+  const options = select.querySelectorAll('option');
+  expect(options.length).toBe(64);
+  expect(options[0].value).toBe('1');
+  expect(options[63].value).toBe('64');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/GlobalControls.test.tsx -t "renders 64"`
+Expected: FAIL — only 16 options
+
+- [ ] **Step 3: Change the dropdown range**
+
+In `src/app/GlobalControls.tsx` line 50-51, change:
+
+```typescript
+// Before:
+{Array.from(
+  { length: 16 },
+
+// After:
+{Array.from(
+  { length: 64 },
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/GlobalControls.test.tsx`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/GlobalControls.tsx \
+  src/__tests__/GlobalControls.test.tsx
+git commit -m "Extend steps dropdown from 16 to 64"
+```
+
+---
+
+## Task 3: Create PageIndicator Component
+
+**Files:**
+- Create: `src/app/PageIndicator.tsx`
+- Create: `src/__tests__/PageIndicator.test.tsx`
+
+- [ ] **Step 1: Write tests first**
+
+Create `src/__tests__/PageIndicator.test.tsx`:
+
+```typescript
+import {
+  render, screen, fireEvent,
+} from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PageIndicator from '../app/PageIndicator';
+
+describe('PageIndicator', () => {
+  const defaults = {
+    currentPage: 0,
+    pageCount: 4,
+    autoFollow: true,
+    setPage: vi.fn(),
+    setAutoFollow: vi.fn(),
+  };
+
+  it('renders correct number of page dots', () => {
+    render(<PageIndicator {...defaults} />);
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(4);
+  });
+
+  it('renders single dot when pageCount is 1', () => {
+    render(
+      <PageIndicator
+        {...defaults}
+        pageCount={1}
+      />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(1);
+  });
+
+  it('clicking a dot calls setPage', () => {
+    const setPage = vi.fn();
+    render(
+      <PageIndicator
+        {...defaults}
+        setPage={setPage}
+      />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    fireEvent.click(dots[2]);
+    expect(setPage).toHaveBeenCalledWith(2);
+  });
+
+  it('active dot has orange styling', () => {
+    render(
+      <PageIndicator
+        {...defaults}
+        currentPage={1}
+      />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(
+      dots[1].className
+    ).toContain('bg-orange');
+  });
+
+  it('follow toggle shows active state', () => {
+    render(
+      <PageIndicator
+        {...defaults}
+        autoFollow={true}
+      />
+    );
+    const toggle = screen.getByRole('button', {
+      name: /follow/i,
+    });
+    expect(
+      toggle.getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  it('follow toggle click calls setAutoFollow', () => {
+    const setAutoFollow = vi.fn();
+    render(
+      <PageIndicator
+        {...defaults}
+        setAutoFollow={setAutoFollow}
+      />
+    );
+    const toggle = screen.getByRole('button', {
+      name: /follow/i,
+    });
+    fireEvent.click(toggle);
+    expect(
+      setAutoFollow
+    ).toHaveBeenCalledWith(false);
+  });
+
+  it('dynamic dot count: 2 dots for pageCount=2', () => {
+    render(
+      <PageIndicator
+        {...defaults}
+        pageCount={2}
+      />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/__tests__/PageIndicator.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement PageIndicator**
+
+Create `src/app/PageIndicator.tsx`:
+
+```typescript
+"use client";
+
+import { memo } from 'react';
+
+interface PageIndicatorProps {
+  currentPage: number;
+  pageCount: number;
+  autoFollow: boolean;
+  setPage: (page: number) => void;
+  setAutoFollow: (value: boolean) => void;
+}
+
+/**
+ * Page navigation dots with auto-follow toggle.
+ * Shows one dot per page; clicking a dot switches
+ * the visible page. The "F" button toggles whether
+ * the page auto-follows the playhead.
+ */
+function PageIndicatorInner({
+  currentPage,
+  pageCount,
+  autoFollow,
+  setPage,
+  setAutoFollow,
+}: PageIndicatorProps) {
+  return (
+    <div
+      className={
+        'flex flex-col items-center gap-1'
+        + ' flex-shrink-0'
+      }
+    >
+      <button
+        aria-label="Auto-follow playhead"
+        aria-pressed={autoFollow}
+        onClick={() => setAutoFollow(!autoFollow)}
+        className={
+          'w-4 h-4 rounded text-[8px]'
+          + ' font-bold transition-colors'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500 '
+          + (autoFollow
+            ? 'bg-orange-600 text-white'
+            : 'bg-neutral-800'
+              + ' border border-neutral-600'
+              + ' text-neutral-500')
+        }
+      >
+        F
+      </button>
+      <div className="flex gap-1">
+        {Array.from(
+          { length: pageCount },
+          (_, i) => (
+            <button
+              key={i}
+              aria-label={`Page ${i + 1}`}
+              onClick={() => setPage(i)}
+              className={
+                'w-[7px] h-[7px] rounded-full'
+                + ' transition-colors'
+                + ' focus-visible:outline-none'
+                + ' focus-visible:ring-2'
+                + ' focus-visible:ring-orange-500 '
+                + (i === currentPage
+                  ? 'bg-orange-500'
+                    + ' shadow-[0_0_6px_rgba('
+                    + '249,115,22,0.6)]'
+                  : 'bg-neutral-600'
+                    + ' hover:bg-neutral-400')
+              }
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+const PageIndicator = memo(PageIndicatorInner);
+export default PageIndicator;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/PageIndicator.test.tsx`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/PageIndicator.tsx \
+  src/__tests__/PageIndicator.test.tsx
+git commit -m "Add PageIndicator component with tests"
+```
+
+---
+
+## Task 4: Update RunningLight for Page Offset
+
+**Files:**
+- Modify: `src/app/RunningLight.tsx`
+- Create: `src/__tests__/RunningLight.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/__tests__/RunningLight.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import RunningLight from '../app/RunningLight';
+
+describe('RunningLight with pageOffset', () => {
+  it('highlights dot matching global step', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={18}
+        patternLength={32}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    // Step 18 is local index 2 on page 2
+    expect(
+      dots[2].className
+    ).toContain('bg-orange');
+    expect(
+      dots[0].className
+    ).not.toContain('bg-orange');
+  });
+
+  it('dims dots beyond patternLength', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={-1}
+        patternLength={24}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    // Steps 17-24 active (indices 0-7), 25-32
+    // dimmed (indices 8-15)
+    expect(
+      dots[7].className
+    ).toContain('bg-neutral');
+    expect(
+      dots[8].className
+    ).toContain('bg-transparent');
+  });
+
+  it('no highlight when step is on another page', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={5}
+        patternLength={32}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    // All should be bg-neutral (no highlight)
+    for (let i = 0; i < 16; i++) {
+      expect(
+        dots[i].className
+      ).not.toContain('bg-orange');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/__tests__/RunningLight.test.tsx`
+Expected: FAIL — `pageOffset` prop not accepted
+
+- [ ] **Step 3: Add `pageOffset` prop**
+
+In `src/app/RunningLight.tsx`, update the interface and
+component:
+
+```typescript
+interface RunningLightProps {
+  currentStep: number;
+  patternLength: number;
+  pageOffset: number;
+}
+```
+
+Update the function signature to accept `pageOffset`.
+
+- [ ] **Step 2: Update highlight and dimming logic**
+
+Change the className logic in the `Array.from` callback:
+
+```typescript
+// Before:
+(i >= patternLength
+  ? 'bg-transparent'
+  : i === currentStep
+
+// After:
+(pageOffset + i >= patternLength
+  ? 'bg-transparent'
+  : pageOffset + i === currentStep
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/RunningLight.test.tsx`
+Expected: All PASS
+
+- [ ] **Step 6: Run lint**
+
+Run: `npm run lint`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/app/RunningLight.tsx \
+  src/__tests__/RunningLight.test.tsx
+git commit -m "Add pageOffset prop to RunningLight"
+```
+
+---
+
+## Task 5: Update TrackRow for Page Offset
+
+**Files:**
+- Modify: `src/app/TrackRow.tsx`
+- Create: `src/__tests__/TrackRow.test.tsx`
+
+This is the most complex change — step rendering,
+drag handle position, and length-from-pointer all
+shift by `pageOffset`.
+
+- [ ] **Step 1: Add `pageOffset` to TrackRowProps**
+
+In `src/app/TrackRow.tsx`, add to the interface:
+
+```typescript
+interface TrackRowProps {
+  // ... existing props ...
+  pageOffset: number;
+}
+```
+
+Add `pageOffset` to the destructured props in
+`TrackRowInner`.
+
+- [ ] **Step 2: Update step rendering loop**
+
+Change the step loop (lines 334-364) to read from
+the offset position and pass global indices:
+
+```typescript
+{Array.from(
+  { length: 16 },
+  (_, i) => {
+    const globalIdx = pageOffset + i;
+    const disabled =
+      globalIdx >= trackLength
+      || globalIdx >= patternLength;
+    return (
+      <StepButton
+        key={i}
+        trackId={trackId}
+        trackName={trackName}
+        stepIndex={i}
+        isActive={
+          !disabled
+          && steps[globalIdx] === '1'
+        }
+        isCurrent={
+          !disabled
+          && effectiveStep === globalIdx
+        }
+        isBeat={globalIdx % 4 === 0}
+        isDisabled={disabled}
+        onToggle={onToggleStep}
+        conditions={
+          trigConditions?.[globalIdx]
+        }
+        onOpenPopover={onOpenPopover}
+      />
+    );
+  }
+)}
+```
+
+**Important:** `stepIndex` stays as `i` (page-local,
+0-15) for `data-step` in StepButton. The `onToggle`
+callback will receive the global index — see step 3.
+
+- [ ] **Step 3: Offset onToggleStep calls**
+
+The `onToggleStep` callback in StepButton receives
+`stepIndex` (page-local). We need TrackRow to pass a
+wrapper that adds the offset. Change `onToggle` prop
+to use a wrapper:
+
+Actually, looking at StepButton, `onToggle` calls
+`onToggle(trackId, stepIndex)` where `stepIndex` is
+the prop. We need `stepIndex` in StepButton to carry
+the **global** index for toggle to work, but the
+**page-local** index for `data-step` (used by
+useDragPaint). These are different concerns.
+
+The cleanest approach: keep `stepIndex` as page-local
+(0-15) for `data-step`, but pass a separate
+`globalStepIndex` for toggle/active/conditions. Or
+simpler: pass the global index as `stepIndex` and
+override `data-step` separately. But StepButton sets
+`data-step={stepIndex}` on line 78/110.
+
+**Revised approach:** StepButton already receives
+`stepIndex` and writes it to `data-step`. For
+useDragPaint to work, `data-step` must be page-local
+(0-15). So we keep `stepIndex` as page-local. But
+`onToggle` needs the global index. The simplest fix
+is to wrap `onToggleStep` in TrackRow:
+
+```typescript
+const handleToggleStep = useCallback(
+  (trackId: TrackId, localStep: number) =>
+    onToggleStep(trackId, localStep + pageOffset),
+  [onToggleStep, pageOffset]
+);
+```
+
+Then pass `handleToggleStep` instead of `onToggleStep`
+to StepButton. Similarly for `onOpenPopover`.
+
+Update the StepButton props accordingly:
+- `stepIndex={i}` (page-local, for data-step)
+- `onToggle={handleToggleStep}` (wrapper adds offset)
+- `isActive`: use `steps[pageOffset + i] === '1'`
+- `isCurrent`: use `effectiveStep === pageOffset + i`
+- `conditions`: use `trigConditions?.[pageOffset + i]`
+
+And wrap `onOpenPopover`:
+
+```typescript
+const handleOpenPopover = useCallback(
+  (
+    tid: TrackId,
+    localStep: number,
+    rect: { top: number; left: number }
+  ) => onOpenPopover?.(
+    tid, localStep + pageOffset, rect
+  ),
+  [onOpenPopover, pageOffset]
+);
+```
+
+- [ ] **Step 4: Update drag handle position**
+
+Change line 260-261:
+
+```typescript
+// Before:
+const handlePct =
+  (trackLength / 16) * 100;
+
+// After:
+const handlePct = Math.max(
+  0,
+  Math.min(
+    100,
+    ((trackLength - pageOffset) / 16) * 100
+  )
+);
+```
+
+- [ ] **Step 5: Update lengthFromPointer**
+
+Change `lengthFromPointer` (lines 212-225):
+
+```typescript
+const lengthFromPointer = useCallback(
+  (clientX: number): number => {
+    const grid = gridRef.current;
+    if (!grid) return trackLength;
+    const rect = grid.getBoundingClientRect();
+    const x = clientX - rect.left;
+    const stepWidth = rect.width / 16;
+    const raw = Math.round(x / stepWidth);
+    return Math.max(
+      1,
+      Math.min(
+        patternLength, raw + pageOffset
+      )
+    );
+  },
+  [patternLength, trackLength, pageOffset]
+);
+```
+
+- [ ] **Step 6: Write TrackRow page-offset tests**
+
+Create `src/__tests__/TrackRow.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TrackRow from '../app/TrackRow';
+import type { TrackId } from '../app/types';
+
+const noop = vi.fn();
+
+function renderTrackRow(overrides = {}) {
+  const defaults = {
+    trackId: 'bd' as TrackId,
+    trackName: 'Kick',
+    steps: '1010101010101010'
+      + '0101010101010101',
+    trackLength: 32,
+    patternLength: 32,
+    pageOffset: 0,
+    isMuted: false,
+    isSolo: false,
+    isFreeRun: false,
+    gain: 1,
+    currentStep: -1,
+    totalSteps: 0,
+    onToggleStep: noop,
+    onToggleMute: noop,
+    onToggleSolo: noop,
+    onSetGain: noop,
+    onSetTrackLength: noop,
+    onToggleFreeRun: noop,
+  };
+  return render(
+    <TrackRow {...defaults} {...overrides} />
+  );
+}
+
+describe('TrackRow with pageOffset', () => {
+  it('page 1 shows first 16 steps', () => {
+    renderTrackRow({ pageOffset: 0 });
+    // steps[0]='1', so first button is pressed
+    const buttons = screen.getAllByRole('button', {
+      name: /Kick step/,
+    });
+    expect(
+      buttons[0].getAttribute('aria-pressed')
+    ).toBe('true');
+    // steps[1]='0'
+    expect(
+      buttons[1].getAttribute('aria-pressed')
+    ).toBe('false');
+  });
+
+  it('page 2 shows steps 17-32', () => {
+    renderTrackRow({ pageOffset: 16 });
+    // steps[16]='0' (from second half)
+    const buttons = screen.getAllByRole('button', {
+      name: /Kick step/,
+    });
+    expect(
+      buttons[0].getAttribute('aria-pressed')
+    ).toBe('false');
+    // steps[17]='1'
+    expect(
+      buttons[1].getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  it('dims steps beyond patternLength', () => {
+    renderTrackRow({
+      patternLength: 24,
+      pageOffset: 16,
+    });
+    // Steps 17-24 active (0-7), 25-32 dimmed (8-15)
+    const allSteps = screen.getAllByLabelText(
+      /Kick step/
+    );
+    expect(allSteps.length).toBe(16);
+    // Step 25 (index 8) should be inactive
+    expect(
+      allSteps[8].getAttribute('aria-label')
+    ).toContain('inactive');
+  });
+});
+```
+
+- [ ] **Step 7: Run TrackRow tests**
+
+Run: `npm test -- src/__tests__/TrackRow.test.tsx`
+Expected: All PASS
+
+- [ ] **Step 8: Run lint**
+
+Run: `npm run lint`
+Expected: No errors (fix any that appear)
+
+- [ ] **Step 9: Commit**
+
+```
+git add src/app/TrackRow.tsx \
+  src/__tests__/TrackRow.test.tsx
+git commit -m "Add pageOffset prop to TrackRow
+
+Shift step rendering, drag handle position, and
+lengthFromPointer by pageOffset for paged display."
+```
+
+---
+
+## Task 6: Update useDragPaint for Page Offset
+
+**Files:**
+- Modify: `src/app/useDragPaint.ts`
+- Modify: `src/__tests__/useDragPaint.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `src/__tests__/useDragPaint.test.tsx`:
+
+```typescript
+describe('pageOffset support', () => {
+  it('paintOne rejects steps beyond track length with offset', () => {
+    // With pageOffset=16, a page-local step 5 is
+    // global step 21. If trackLength is 18, this
+    // should be rejected.
+    const onSetStep = vi.fn();
+    const tracks: TrackId[] = ['bd', 'sd'];
+    const { container, elements } = makeMockDOM(
+      tracks
+    );
+    mockElementFromPoint(elements, tracks);
+
+    const { result } = renderHook(() =>
+      useDragPaint({
+        containerRef: { current: container },
+        trackOrder: tracks,
+        trackLengths: { bd: 18, sd: 18 } as Record<
+          TrackId, number
+        >,
+        steps: {
+          bd: '0'.repeat(32),
+          sd: '0'.repeat(32),
+        } as Record<TrackId, string>,
+        onSetStep,
+        pageOffset: 16,
+      })
+    );
+
+    // Simulate pointer down on bd step 5
+    // (global 21, beyond trackLength 18)
+    act(() => {
+      result.current.onPointerDown({
+        button: 0,
+        clientX: 5 * 40 + 20,
+        clientY: 16,
+        pointerId: 1,
+        pointerType: 'mouse',
+        shiftKey: false,
+      } as unknown as React.PointerEvent<
+        HTMLDivElement
+      >);
+    });
+
+    expect(onSetStep).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/useDragPaint.test.tsx -t "pageOffset"`
+Expected: FAIL — `pageOffset` not in options
+
+- [ ] **Step 3: Add `pageOffset` to useDragPaint**
+
+In `src/app/useDragPaint.ts`:
+
+Add to `UseDragPaintOptions` interface:
+
+```typescript
+pageOffset?: number;
+```
+
+Destructure with default in the hook:
+
+```typescript
+export function useDragPaint({
+  containerRef,
+  trackOrder,
+  trackLengths,
+  steps,
+  onSetStep,
+  pageOffset = 0,
+}: UseDragPaintOptions) {
+```
+
+Update `paintOne` guard (line 158):
+
+```typescript
+// Before:
+if (stepIdx >= trackLengths[tid]) return false;
+
+// After:
+if (
+  stepIdx + pageOffset >= trackLengths[tid]
+) return false;
+```
+
+Update `onSetStep` call in `paintOne` (line 167):
+
+```typescript
+// Before:
+onSetStep(tid, stepIdx, drag.paintValue);
+
+// After:
+onSetStep(
+  tid, stepIdx + pageOffset, drag.paintValue
+);
+```
+
+Update `onPointerDown` guard (line 211):
+
+```typescript
+// Before:
+if (stepIndex >= trackLengths[trackId]) return;
+
+// After:
+if (
+  stepIndex + pageOffset
+  >= trackLengths[trackId]
+) return;
+```
+
+Update `stepsAtDown` reference in `onPointerDown`
+paint value check (line 228):
+
+```typescript
+// Before:
+stepsAtDown.current[trackId][stepIndex]
+
+// After:
+stepsAtDown.current[trackId][
+  stepIndex + pageOffset
+]
+```
+
+Add `pageOffset` to dependency arrays of `paintOne`,
+`onPointerDown`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/useDragPaint.test.tsx`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/useDragPaint.ts \
+  src/__tests__/useDragPaint.test.tsx
+git commit -m "Add pageOffset support to useDragPaint"
+```
+
+---
+
+## Task 7: Wire Page State into Sequencer + StepGrid
+
+**Files:**
+- Modify: `src/app/Sequencer.tsx`
+- Modify: `src/app/StepGrid.tsx`
+
+This is the integration task that connects page state
+to the grid components.
+
+- [ ] **Step 1: Add page state to Sequencer**
+
+In `src/app/Sequencer.tsx`, add state and clamping:
+
+```typescript
+"use client";
+
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import { SequencerProvider, useSequencer }
+  from './SequencerContext';
+import TransportControls from './TransportControls';
+import StepGrid from './StepGrid';
+import PageIndicator from './PageIndicator';
+
+function SequencerInner() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { state } = useSequencer();
+  const { patternLength } = state;
+
+  const [currentPage, setCurrentPage] = useState(0);
+  const [autoFollow, setAutoFollow] = useState(true);
+
+  const pageCount = Math.ceil(patternLength / 16);
+  const pageOffset = currentPage * 16;
+
+  // Clamp page when patternLength shrinks
+  useEffect(() => {
+    setCurrentPage(prev =>
+      Math.min(prev, pageCount - 1)
+    );
+  }, [pageCount]);
+
+  const pageIndicator = (
+    <PageIndicator
+      currentPage={currentPage}
+      pageCount={pageCount}
+      autoFollow={autoFollow}
+      setPage={setCurrentPage}
+      setAutoFollow={setAutoFollow}
+    />
+  );
+
+  return (
+    <div className="h-dvh overflow-hidden flex flex-col bg-neutral-950 text-neutral-100 font-sans">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-orange-600 focus:text-white focus:rounded"
+      >
+        Skip to main content
+      </a>
+      <div className="max-w-none lg:max-w-4xl w-full mx-auto px-3 lg:px-8 pt-3 lg:pt-4 flex flex-col flex-1 min-h-0">
+        <TransportControls
+          pageIndicator={pageIndicator}
+        />
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto py-3 lg:py-4 track-scroll-region"
+        >
+          <StepGrid
+            scrollContainerRef={scrollRef}
+            pageOffset={pageOffset}
+            currentPage={currentPage}
+            autoFollow={autoFollow}
+            setPage={setCurrentPage}
+          />
+          <footer className="grid grid-cols-3 items-center pt-4 lg:pt-8">
+            <div />
+            <a
+              href="https://github.com/memestreak/xox"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] text-neutral-600 uppercase tracking-[0.2em] font-bold hover:text-orange-500 transition-colors text-center"
+            >
+              Source Code
+            </a>
+            <span className="text-[10px] text-neutral-600 uppercase tracking-[0.2em] font-bold font-mono text-right">
+              Built at commit {process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev'}
+            </span>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Sequencer() {
+  return (
+    <SequencerProvider>
+      <SequencerInner />
+    </SequencerProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Update StepGrid props and wiring**
+
+In `src/app/StepGrid.tsx`, update the interface:
+
+```typescript
+interface StepGridProps {
+  scrollContainerRef: RefObject<
+    HTMLDivElement | null
+  >;
+  pageOffset: number;
+  currentPage: number;
+  autoFollow: boolean;
+  setPage: (page: number) => void;
+}
+```
+
+Update the function signature. Add `autoFollow` ref
+for the rAF loop:
+
+```typescript
+const autoFollowRef = useRef(autoFollow);
+useEffect(() => {
+  autoFollowRef.current = autoFollow;
+}, [autoFollow]);
+```
+
+Update the rAF loop to check page boundaries:
+
+```typescript
+useEffect(() => {
+  let raf: number;
+  let prevStep = -1;
+  let prevTotal = 0;
+
+  const tick = () => {
+    const curStep = stepRef.current;
+    const curTotal = totalStepsRef.current;
+    if (
+      curStep !== prevStep
+      || curTotal !== prevTotal
+    ) {
+      prevStep = curStep;
+      prevTotal = curTotal;
+      setDisplayStep(curStep);
+      setDisplayTotal(
+        Math.max(0, curTotal - 1)
+      );
+      // Auto-follow page
+      if (
+        autoFollowRef.current
+        && curStep >= 0
+      ) {
+        const stepPage =
+          Math.floor(curStep / 16);
+        setPage(stepPage);
+      }
+    }
+    raf = requestAnimationFrame(tick);
+  };
+
+  raf = requestAnimationFrame(tick);
+  return () => cancelAnimationFrame(raf);
+}, [stepRef, totalStepsRef, setPage]);
+```
+
+Pass `pageOffset` to `useDragPaint`:
+
+```typescript
+const dragPaint = useDragPaint({
+  containerRef: dragContainerRef,
+  trackOrder: TRACK_ORDER,
+  trackLengths,
+  steps: currentPattern.steps,
+  onSetStep: setStep,
+  pageOffset,
+});
+```
+
+Pass `pageOffset` to each `TrackRow`:
+
+```typescript
+<TrackRow
+  // ... existing props ...
+  pageOffset={pageOffset}
+/>
+```
+
+Pass `pageOffset` to `RunningLight`:
+
+```typescript
+<RunningLight
+  currentStep={displayStep}
+  patternLength={patternLength}
+  pageOffset={pageOffset}
+/>
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No errors (fix any that appear)
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/app/Sequencer.tsx src/app/StepGrid.tsx
+git commit -m "Wire page state through Sequencer and StepGrid
+
+Sequencer owns currentPage/autoFollow state and
+passes pageOffset down to StepGrid, TrackRow, and
+RunningLight. Auto-follow logic runs in StepGrid's
+rAF loop using a ref to avoid stale closures."
+```
+
+---
+
+## Task 8: Update TransportControls for PageIndicator Slot
+
+**Files:**
+- Modify: `src/app/TransportControls.tsx`
+
+- [ ] **Step 1: Add `pageIndicator` prop**
+
+TransportControls is memoized. Add a `ReactNode` slot
+prop to avoid re-renders from page state changes.
+
+```typescript
+import type { ReactNode } from 'react';
+
+interface TransportControlsProps {
+  pageIndicator?: ReactNode;
+}
+
+function TransportControlsInner({
+  pageIndicator,
+}: TransportControlsProps) {
+```
+
+Update the `memo` call:
+
+```typescript
+const TransportControls = memo(
+  TransportControlsInner
+);
+```
+
+- [ ] **Step 2: Widen pattern section and render slot**
+
+Change the grid-cols on row 2 (line 57):
+
+```typescript
+// Before:
+<div className="grid grid-cols-3 gap-2 lg:gap-4 pt-2 lg:pt-0">
+
+// After:
+<div className="grid grid-cols-[1fr_1fr_1.5fr] gap-2 lg:gap-4 pt-2 lg:pt-0">
+```
+
+In the Pattern section `<div>` (line 84-93), add the
+`pageIndicator` slot inline with the PatternPicker:
+
+```typescript
+<div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
+  <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
+    Pattern
+  </span>
+  <div className="flex items-center gap-2">
+    <div className="flex-1 min-w-0">
+      <PatternPicker
+        categories={categories}
+        currentPattern={currentPattern}
+        onSelect={setPattern}
+      />
+    </div>
+    {pageIndicator}
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No errors
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npm test`
+Expected: All PASS. Existing TransportControls tests
+should still pass since `pageIndicator` is optional.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/TransportControls.tsx
+git commit -m "Add pageIndicator slot to TransportControls
+
+Widen pattern section to 1.5fr. Render PageIndicator
+inline with PatternPicker via slot prop to avoid
+re-renders from page state changes."
+```
+
+---
+
+## Task 9: Full Test Suite + Lint + Build
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: No errors
+
+- [ ] **Step 3: Run production build**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 4: Fix any issues found**
+
+If tests, lint, or build fail, fix the issues and
+re-run. Commit fixes separately.
+
+---
+
+## Task 10: Browser Verification
+
+**Files:** None (manual testing)
+
+Start the dev server and verify in the browser:
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Verify 16-step default**
+
+- Page dots visible with 1 dot
+- Follow toggle visible and active (orange)
+- Grid shows 16 steps as before
+
+- [ ] **Step 3: Verify 32-step paging**
+
+- Change Steps dropdown to 32
+- Two page dots appear
+- Click dot 2 — grid shows empty page
+- Toggle steps on page 2
+- Click dot 1 — page 1 unchanged
+- Click dot 2 — page 2 has your toggles
+
+- [ ] **Step 4: Verify auto-follow during playback**
+
+- Set Steps to 32, stay on page 1
+- Press PLAY
+- When playback passes step 16, page should
+  auto-switch to page 2 and dot 2 activates
+- When it loops back, page switches to page 1
+
+- [ ] **Step 5: Verify follow toggle off**
+
+- With playback running, click the F toggle (off)
+- Manually click dot 1 — page stays on 1 even
+  as playback moves to page 2
+- Click F toggle back on — page follows again
+
+- [ ] **Step 6: Verify partial page (e.g., 24 steps)**
+
+- Set Steps to 24
+- Two page dots
+- Page 2 shows 8 active steps + 8 dimmed
+
+- [ ] **Step 7: Verify 64 steps**
+
+- Set Steps to 64
+- Four page dots
+- All four pages navigable
+
+- [ ] **Step 8: Verify drag handle across pages**
+
+- Set Steps to 32
+- On page 1, drag track length handle — works as
+  before (sets length in 1-16 range)
+- Go to page 2, drag handle — sets length in
+  17-32 range
+
+- [ ] **Step 9: Verify page clamp on length reduction**
+
+- Set Steps to 64, navigate to page 4
+- Change Steps to 16 — should snap to page 1
+
+- [ ] **Step 10: Verify mobile layout**
+
+- Resize to mobile width
+- Pattern section wider, dots and F toggle visible
+- Steps grid still 8-col on mobile
+
+- [ ] **Step 11: Stop dev server**
+
+After testing is complete, stop the dev server.

--- a/docs/specs/2026-03-19-64-steps-design.md
+++ b/docs/specs/2026-03-19-64-steps-design.md
@@ -55,9 +55,12 @@ Derived values:
 - `pageCount = Math.ceil(patternLength / 16)`
 - `pageOffset = currentPage * 16`
 
-Auto-follow runs in StepGrid's existing rAF loop. When
-`autoFollow` is true and playing, `currentPage` updates
-when `Math.floor(displayStep / 16) !== currentPage`.
+Auto-follow runs in StepGrid's existing rAF loop. The
+condition checks `stepRef.current` (the ref already read
+inside the tick function, not the `displayStep` state
+which would be stale in the closure): when `autoFollow`
+is true and playing, `currentPage` updates when
+`Math.floor(stepRef.current / 16) !== currentPage`.
 
 ### SequencerContext Change
 
@@ -124,8 +127,11 @@ the rAF closure always reads the current value without
 restarting the animation loop.
 
 `useDragPaint` receives a new `pageOffset` parameter.
-Step indices from pointer positions are offset by
-`pageOffset` before calling `onSetStep`.
+Step buttons keep page-local `data-step` values (0-15).
+`useDragPaint` adds `pageOffset` to get the global step
+index before calling `onSetStep`. The `paintOne` guard
+must also compare `stepIdx + pageOffset >= trackLength`
+(global index) instead of `stepIdx >= trackLength`.
 
 Passes `pageOffset` to TrackRow and RunningLight.
 
@@ -149,7 +155,8 @@ Steps dropdown range: `{ length: 16 }` → `{ length: 64 }`.
 
 **Reducing step count while on a later page:**
 `currentPage` clamps to `pageCount - 1` when
-`patternLength` changes.
+`patternLength` changes. This runs in a `useEffect` in
+`Sequencer` with `[patternLength]` dependency.
 
 **Per-track length + paging:**
 Track-level dimming works as today. On page 2+, a track

--- a/docs/specs/2026-03-19-64-steps-design.md
+++ b/docs/specs/2026-03-19-64-steps-design.md
@@ -1,0 +1,155 @@
+# 64-Step Support with Page Navigation
+
+**Issue:** #29 — FR: Support up to 64 steps with page navigation
+**Date:** 2026-03-19
+**Status:** Approved
+
+## Summary
+
+Extend the sequencer from a fixed 16-step display to a
+configurable length of 1-64 steps. Steps are displayed 16
+at a time across pages, with page navigation dots in the
+transport bar's Pattern section.
+
+## Decisions
+
+- **Step count control:** Existing Steps dropdown in
+  GlobalControls, range extended from 1-16 to 1-64.
+- **Page dots:** Inline right of the pattern button in the
+  Pattern section (section widened from 1fr to 1.5fr).
+  Always visible, even with a single page.
+- **Auto-follow toggle:** Small "F" button above the page
+  dots. On by default. When active, the visible page tracks
+  the playhead during playback.
+- **Preset patterns:** Padded with zeros when step count
+  increases beyond 16.
+- **Dot count:** Dynamic — one dot per page
+  (`ceil(patternLength / 16)`).
+- **Partial pages:** Last page shows 16 buttons; steps
+  beyond `patternLength` are dimmed (same treatment as
+  existing per-track length dimming).
+- **Persistence:** `currentPage` and `autoFollow` are
+  session-only state — not saved to URL hash.
+- **Backward compatibility:** Not required. Existing URLs
+  may break.
+
+## Architecture: Approach 1 — Page State in Sequencer
+
+Page state (`currentPage`, `autoFollow`) lives in the
+`Sequencer` component, the common ancestor of
+`TransportControls` and `StepGrid`. No new context needed.
+
+### State & Data Flow
+
+```
+Sequencer (owns currentPage, autoFollow)
+├── TransportControls
+│   └── Pattern section
+│       └── PageIndicator (dots + follow toggle)
+└── StepGrid (receives pageOffset, calls setPage)
+    ├── TrackRow × 11 (renders steps[offset..offset+16])
+    └── RunningLight (dots shifted by pageOffset)
+```
+
+Derived values:
+- `pageCount = Math.ceil(patternLength / 16)`
+- `pageOffset = currentPage * 16`
+
+Auto-follow runs in StepGrid's existing rAF loop. When
+`autoFollow` is true and playing, `currentPage` updates
+when `Math.floor(displayStep / 16) !== currentPage`.
+
+### SequencerContext Change
+
+One line: bump `setPatternLength` clamp from
+`Math.min(16, length)` to `Math.min(64, length)`.
+
+## UI Components
+
+### PageIndicator (new)
+
+Rendered inside the Pattern section of TransportControls.
+
+Props: `currentPage`, `pageCount`, `autoFollow`,
+`setPage`, `setAutoFollow`.
+
+Contains:
+- Follow toggle button ("F", orange when active,
+  `aria-pressed`)
+- Row of clickable dots (one per page, `aria-label`)
+
+### TrackRow (modified)
+
+New prop: `pageOffset`.
+
+Step loop renders `steps[pageOffset..pageOffset+16]`.
+Always 16 buttons. Step indices passed to `onToggleStep`
+adjusted by `pageOffset`. Dimming adds:
+`pageOffset + i >= patternLength`.
+
+The drag handle for track length accounts for
+`pageOffset` — dragging on page 2 sets lengths in the
+17-32 range.
+
+### RunningLight (modified)
+
+New prop: `pageOffset`. Dot at position `i` represents
+global step `pageOffset + i`.
+
+### StepGrid (modified)
+
+Receives `currentPage`, `pageOffset`, `setPage` from
+parent. rAF loop checks page boundaries and calls
+`setPage` when auto-follow is active. Passes `pageOffset`
+to TrackRow and RunningLight.
+
+### TransportControls (modified)
+
+Pattern section grid column: `1fr` → `1.5fr`. Renders
+`PageIndicator` inline after the pattern button.
+
+### GlobalControls (modified)
+
+Steps dropdown range: `{ length: 16 }` → `{ length: 64 }`.
+
+## Edge Cases
+
+**Reducing step count while on a later page:**
+`currentPage` clamps to `pageCount - 1` when
+`patternLength` changes.
+
+**Per-track length + paging:**
+Track-level dimming works as today. On page 2+, a track
+with `trackLength: 8` has all steps dimmed since
+`pageOffset + i >= trackLength`.
+
+**Pattern loading:**
+Preset patterns (16-char strings) pad with zeros for
+steps beyond 16. `validateSteps` in configCodec already
+handles this.
+
+## Testing
+
+### Unit Tests
+
+- `StepGrid` / `TrackRow`: correct steps render for each
+  page offset
+- `PageIndicator`: dot count matches `pageCount`, click
+  updates `currentPage`, follow toggle works
+- `RunningLight`: dots shift by page offset
+- `GlobalControls`: dropdown goes to 64
+- `SequencerContext`: `setPatternLength` accepts up to 64,
+  page clamps when length reduces
+
+### Integration Tests
+
+- Set steps to 32, verify page 2 shows empty steps
+- Toggle steps on page 2, switch back to page 1, verify
+  page 1 unchanged
+- Reduce step count while on later page, verify clamping
+
+### Browser Verification
+
+- Playback across page boundaries with auto-follow
+- Partial last page (e.g., 24 steps) dimming
+- Mobile layout with wider pattern section

--- a/docs/specs/2026-03-19-64-steps-design.md
+++ b/docs/specs/2026-03-19-64-steps-design.md
@@ -61,8 +61,12 @@ when `Math.floor(displayStep / 16) !== currentPage`.
 
 ### SequencerContext Change
 
-One line: bump `setPatternLength` clamp from
-`Math.min(16, length)` to `Math.min(64, length)`.
+Bump `setPatternLength` clamp from `Math.min(16, length)`
+to `Math.min(64, length)`. The existing expansion logic
+in `setPatternLength` (lines 576-605) already handles
+step-string padding when track lengths grow — no further
+changes needed, but the expansion path must be tested
+with lengths beyond 16.
 
 ## UI Components
 
@@ -87,26 +91,55 @@ Always 16 buttons. Step indices passed to `onToggleStep`
 adjusted by `pageOffset`. Dimming adds:
 `pageOffset + i >= patternLength`.
 
-The drag handle for track length accounts for
-`pageOffset` — dragging on page 2 sets lengths in the
-17-32 range.
+**Drag handle with paging:**
+
+Visual position changes from `(trackLength / 16) * 100`
+to `clamp((trackLength - pageOffset) / 16, 0, 1) * 100`.
+When `trackLength <= pageOffset`, the handle is at 0%
+(pinned left). When `trackLength >= pageOffset + 16`, it
+is at 100% (pinned right / hidden).
+
+`lengthFromPointer` changes its divisor from
+`rect.width / patternLength` to `rect.width / 16` (page
+size), then adds `pageOffset` to the computed raw step:
+`Math.max(1, Math.min(patternLength, raw + pageOffset))`.
 
 ### RunningLight (modified)
 
 New prop: `pageOffset`. Dot at position `i` represents
-global step `pageOffset + i`.
+global step `pageOffset + i`. The highlight condition
+changes from `i === currentStep` to
+`pageOffset + i === currentStep`. The dimming condition
+changes from `i >= patternLength` to
+`pageOffset + i >= patternLength`.
 
 ### StepGrid (modified)
 
-Receives `currentPage`, `pageOffset`, `setPage` from
-parent. rAF loop checks page boundaries and calls
-`setPage` when auto-follow is active. Passes `pageOffset`
-to TrackRow and RunningLight.
+Receives `currentPage`, `pageOffset`, `autoFollow`,
+`setPage` from parent. The rAF loop checks page
+boundaries and calls `setPage` when auto-follow is
+active. `autoFollow` is mirrored to a `useRef` inside
+StepGrid (like `fillActiveRef` in SequencerContext) so
+the rAF closure always reads the current value without
+restarting the animation loop.
+
+`useDragPaint` receives a new `pageOffset` parameter.
+Step indices from pointer positions are offset by
+`pageOffset` before calling `onSetStep`.
+
+Passes `pageOffset` to TrackRow and RunningLight.
 
 ### TransportControls (modified)
 
-Pattern section grid column: `1fr` → `1.5fr`. Renders
-`PageIndicator` inline after the pattern button.
+Pattern section grid column: `1fr` → `1.5fr`.
+`PageIndicator` is rendered by `Sequencer` as a sibling
+passed into TransportControls (or the Pattern section
+directly), avoiding re-render of the memoized
+TransportControls on every page change. The exact
+threading (render prop, slot prop, or direct sibling)
+is an implementation detail — the key constraint is
+that page-state changes must not trigger a full
+TransportControls re-render.
 
 ### GlobalControls (modified)
 

--- a/src/__tests__/GlobalControls.test.tsx
+++ b/src/__tests__/GlobalControls.test.tsx
@@ -66,4 +66,13 @@ describe('GlobalControls', () => {
     fireEvent.keyDown(knob, { key: 'ArrowUp' });
     expect(mockSetSwing).toHaveBeenCalled();
   });
+
+  it('renders 64 step options', () => {
+    render(<GlobalControls />);
+    const select = screen.getByRole('combobox');
+    const options = select.querySelectorAll('option');
+    expect(options.length).toBe(64);
+    expect(options[0].value).toBe('1');
+    expect(options[63].value).toBe('64');
+  });
 });

--- a/src/__tests__/PageIndicator.test.tsx
+++ b/src/__tests__/PageIndicator.test.tsx
@@ -1,0 +1,90 @@
+import {
+  render, screen, fireEvent,
+} from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PageIndicator from '../app/PageIndicator';
+
+describe('PageIndicator', () => {
+  const defaults = {
+    currentPage: 0,
+    pageCount: 4,
+    autoFollow: true,
+    setPage: vi.fn(),
+    setAutoFollow: vi.fn(),
+  };
+
+  it('renders correct number of page dots', () => {
+    render(<PageIndicator {...defaults} />);
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(4);
+  });
+
+  it('renders single dot when pageCount is 1', () => {
+    render(
+      <PageIndicator {...defaults} pageCount={1} />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(1);
+  });
+
+  it('clicking a dot calls setPage', () => {
+    const setPage = vi.fn();
+    render(
+      <PageIndicator {...defaults} setPage={setPage} />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    fireEvent.click(dots[2]);
+    expect(setPage).toHaveBeenCalledWith(2);
+  });
+
+  it('active dot has orange styling', () => {
+    render(
+      <PageIndicator {...defaults} currentPage={1} />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots[1].className).toContain('bg-orange');
+  });
+
+  it('follow toggle shows active state', () => {
+    render(
+      <PageIndicator {...defaults} autoFollow={true} />
+    );
+    const toggle = screen.getByRole('button', {
+      name: /follow/i,
+    });
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('follow toggle click calls setAutoFollow', () => {
+    const setAutoFollow = vi.fn();
+    render(
+      <PageIndicator
+        {...defaults}
+        setAutoFollow={setAutoFollow}
+      />
+    );
+    const toggle = screen.getByRole('button', {
+      name: /follow/i,
+    });
+    fireEvent.click(toggle);
+    expect(setAutoFollow).toHaveBeenCalledWith(false);
+  });
+
+  it('dynamic dot count: 2 dots for pageCount=2', () => {
+    render(
+      <PageIndicator {...defaults} pageCount={2} />
+    );
+    const dots = screen.getAllByRole('button', {
+      name: /^Page \d/,
+    });
+    expect(dots.length).toBe(2);
+  });
+});

--- a/src/__tests__/RunningLight.test.tsx
+++ b/src/__tests__/RunningLight.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import RunningLight from '../app/RunningLight';
+
+describe('RunningLight with pageOffset', () => {
+  it('highlights dot matching global step', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={18}
+        patternLength={32}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    // Step 18 is local index 2 on page 2
+    expect(
+      dots[2].className
+    ).toContain('bg-orange');
+    expect(
+      dots[0].className
+    ).not.toContain('bg-orange');
+  });
+
+  it('dims dots beyond patternLength', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={-1}
+        patternLength={24}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    // Steps 17-24 active (indices 0-7), 25-32 dimmed (8-15)
+    expect(
+      dots[7].className
+    ).toContain('bg-neutral');
+    expect(
+      dots[8].className
+    ).toContain('bg-transparent');
+  });
+
+  it('no highlight when step is on another page', () => {
+    const { container } = render(
+      <RunningLight
+        currentStep={5}
+        patternLength={32}
+        pageOffset={16}
+      />
+    );
+    const dots = container.querySelectorAll(
+      '.rounded-full'
+    );
+    for (let i = 0; i < 16; i++) {
+      expect(
+        dots[i].className
+      ).not.toContain('bg-orange');
+    }
+  });
+});

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -394,6 +394,34 @@ describe('setPatternLength track lengths', () => {
       result.current.meta.config.trackLengths.ch
     ).toBe(12);
   });
+
+  it('accepts pattern length up to 64', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setPatternLength(32);
+    });
+    expect(
+      result.current.state.patternLength
+    ).toBe(32);
+    for (const id of TRACK_IDS) {
+      expect(
+        result.current.meta.config.trackLengths[id]
+      ).toBe(32);
+      expect(
+        result.current.meta.config.steps[id].length
+      ).toBe(32);
+    }
+  });
+
+  it('clamps pattern length at 64', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setPatternLength(100);
+    });
+    expect(
+      result.current.state.patternLength
+    ).toBe(64);
+  });
 });
 
 // -------------------------------------------------------

--- a/src/__tests__/TrackEndBar.test.tsx
+++ b/src/__tests__/TrackEndBar.test.tsx
@@ -19,6 +19,7 @@ const base = {
   steps: '1010101010101010',
   trackLength: 16,
   patternLength: 16,
+  pageOffset: 0,
   isMuted: false,
   isSolo: false,
   isFreeRun: false,

--- a/src/__tests__/TrackRow.test.tsx
+++ b/src/__tests__/TrackRow.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TrackRow from '../app/TrackRow';
+import type { TrackId } from '../app/types';
+
+const noop = vi.fn();
+
+function renderTrackRow(overrides = {}) {
+  const defaults = {
+    trackId: 'bd' as TrackId,
+    trackName: 'Kick',
+    steps: '1010101010101010'
+      + '0101010101010101',
+    trackLength: 32,
+    patternLength: 32,
+    pageOffset: 0,
+    isMuted: false,
+    isSolo: false,
+    isFreeRun: false,
+    gain: 1,
+    currentStep: -1,
+    totalSteps: 0,
+    onToggleStep: noop,
+    onToggleMute: noop,
+    onToggleSolo: noop,
+    onSetGain: noop,
+    onSetTrackLength: noop,
+    onToggleFreeRun: noop,
+  };
+  return render(
+    <TrackRow {...defaults} {...overrides} />
+  );
+}
+
+describe('TrackRow with pageOffset', () => {
+  it('page 1 shows first 16 steps', () => {
+    renderTrackRow({ pageOffset: 0 });
+    const buttons = screen.getAllByRole('button', {
+      name: /Kick step/,
+    });
+    // steps[0]='1', so first button is pressed
+    expect(
+      buttons[0].getAttribute('aria-pressed')
+    ).toBe('true');
+    // steps[1]='0'
+    expect(
+      buttons[1].getAttribute('aria-pressed')
+    ).toBe('false');
+  });
+
+  it('page 2 shows steps 17-32', () => {
+    renderTrackRow({ pageOffset: 16 });
+    const buttons = screen.getAllByRole('button', {
+      name: /Kick step/,
+    });
+    // steps[16]='0' (from second half '0101...')
+    expect(
+      buttons[0].getAttribute('aria-pressed')
+    ).toBe('false');
+    // steps[17]='1'
+    expect(
+      buttons[1].getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  it('dims steps beyond patternLength', () => {
+    renderTrackRow({
+      patternLength: 24,
+      pageOffset: 16,
+    });
+    const allSteps = screen.getAllByLabelText(
+      /Kick step/
+    );
+    expect(allSteps.length).toBe(16);
+    // Step 25 (index 8) should be inactive
+    expect(
+      allSteps[8].getAttribute('aria-label')
+    ).toContain('inactive');
+  });
+});

--- a/src/__tests__/useDragPaint.test.tsx
+++ b/src/__tests__/useDragPaint.test.tsx
@@ -927,3 +927,41 @@ describe('useDragPaint', () => {
     );
   });
 });
+
+describe('pageOffset support', () => {
+  it('paintOne rejects steps beyond track length with offset', () => {
+    const onSetStep = vi.fn();
+    const tracks: TrackId[] = ['bd', 'sd'];
+    const { container, elements } = makeMockDOM(tracks);
+    mockElementFromPoint(elements, tracks);
+
+    const { result } = renderHook(() =>
+      useDragPaint({
+        containerRef: { current: container },
+        trackOrder: tracks,
+        trackLengths: { bd: 18, sd: 18 } as Record<TrackId, number>,
+        steps: {
+          bd: '0'.repeat(32),
+          sd: '0'.repeat(32),
+        } as Record<TrackId, string>,
+        onSetStep,
+        pageOffset: 16,
+      })
+    );
+
+    // Simulate pointer down on bd step 5
+    // (global 21, beyond trackLength 18)
+    act(() => {
+      result.current.onPointerDown({
+        button: 0,
+        clientX: 5 * 40 + 20,
+        clientY: 16,
+        pointerId: 1,
+        pointerType: 'mouse',
+        shiftKey: false,
+      } as unknown as React.PointerEvent<HTMLDivElement>);
+    });
+
+    expect(onSetStep).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/GlobalControls.tsx
+++ b/src/app/GlobalControls.tsx
@@ -48,7 +48,7 @@ function GlobalControlsInner() {
             className="bg-neutral-800 border border-neutral-700 rounded p-1 text-xs lg:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 hover:border-neutral-600 transition-colors w-12 lg:w-14"
           >
             {Array.from(
-              { length: 16 },
+              { length: 64 },
               (_, i) => (
                 <option key={i + 1} value={i + 1}>
                   {i + 1}

--- a/src/app/PageIndicator.tsx
+++ b/src/app/PageIndicator.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { memo } from 'react';
+
+interface PageIndicatorProps {
+  currentPage: number;
+  pageCount: number;
+  autoFollow: boolean;
+  setPage: (page: number) => void;
+  setAutoFollow: (value: boolean) => void;
+}
+
+/**
+ * Page navigation dots with auto-follow toggle.
+ * Shows one dot per page; clicking a dot switches
+ * the visible page. The "F" button toggles whether
+ * the page auto-follows the playhead.
+ */
+function PageIndicatorInner({
+  currentPage,
+  pageCount,
+  autoFollow,
+  setPage,
+  setAutoFollow,
+}: PageIndicatorProps) {
+  return (
+    <div
+      className={
+        'flex flex-col items-center gap-1'
+        + ' flex-shrink-0'
+      }
+    >
+      <button
+        aria-label="Auto-follow playhead"
+        aria-pressed={autoFollow}
+        onClick={() => setAutoFollow(!autoFollow)}
+        className={
+          'w-4 h-4 rounded text-[8px]'
+          + ' font-bold transition-colors'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500 '
+          + (autoFollow
+            ? 'bg-orange-600 text-white'
+            : 'bg-neutral-800'
+              + ' border border-neutral-600'
+              + ' text-neutral-500')
+        }
+      >
+        F
+      </button>
+      <div className="flex gap-1">
+        {Array.from(
+          { length: pageCount },
+          (_, i) => (
+            <button
+              key={i}
+              aria-label={`Page ${i + 1}`}
+              onClick={() => setPage(i)}
+              className={
+                'w-[7px] h-[7px] rounded-full'
+                + ' transition-colors'
+                + ' focus-visible:outline-none'
+                + ' focus-visible:ring-2'
+                + ' focus-visible:ring-orange-500 '
+                + (i === currentPage
+                  ? 'bg-orange-500'
+                    + ' shadow-[0_0_6px_rgba('
+                    + '249,115,22,0.6)]'
+                  : 'bg-neutral-600'
+                    + ' hover:bg-neutral-400')
+              }
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+const PageIndicator = memo(PageIndicatorInner);
+export default PageIndicator;

--- a/src/app/PageIndicator.tsx
+++ b/src/app/PageIndicator.tsx
@@ -6,7 +6,6 @@ interface PageIndicatorProps {
   currentPage: number;
   pageCount: number;
   autoFollow: boolean;
-  playbackPage: number;
   setPage: (page: number) => void;
   setAutoFollow: (value: boolean) => void;
 }
@@ -21,7 +20,6 @@ function PageIndicatorInner({
   currentPage,
   pageCount,
   autoFollow,
-  playbackPage,
   setPage,
   setAutoFollow,
 }: PageIndicatorProps) {
@@ -63,7 +61,7 @@ function PageIndicatorInner({
               onClick={() => setPage(i)}
               className={
                 'w-2.5 h-2.5 rounded-full'
-                + ' transition-all'
+                + ' transition-colors'
                 + ' focus-visible:outline-none'
                 + ' focus-visible:ring-2'
                 + ' focus-visible:ring-orange-500 '
@@ -71,13 +69,8 @@ function PageIndicatorInner({
                   ? 'bg-orange-500'
                     + ' shadow-[0_0_8px_rgba('
                     + '249,115,22,0.6)]'
-                  : i === playbackPage
-                    ? 'bg-neutral-600'
-                      + ' ring-1 ring-orange-500/60'
-                      + ' shadow-[0_0_6px_rgba('
-                      + '249,115,22,0.3)]'
-                    : 'bg-neutral-600'
-                      + ' hover:bg-neutral-400')
+                  : 'bg-neutral-600'
+                    + ' hover:bg-neutral-400')
               }
             />
           )

--- a/src/app/PageIndicator.tsx
+++ b/src/app/PageIndicator.tsx
@@ -6,6 +6,7 @@ interface PageIndicatorProps {
   currentPage: number;
   pageCount: number;
   autoFollow: boolean;
+  playbackPage: number;
   setPage: (page: number) => void;
   setAutoFollow: (value: boolean) => void;
 }
@@ -20,6 +21,7 @@ function PageIndicatorInner({
   currentPage,
   pageCount,
   autoFollow,
+  playbackPage,
   setPage,
   setAutoFollow,
 }: PageIndicatorProps) {
@@ -61,7 +63,7 @@ function PageIndicatorInner({
               onClick={() => setPage(i)}
               className={
                 'w-2.5 h-2.5 rounded-full'
-                + ' transition-colors'
+                + ' transition-all'
                 + ' focus-visible:outline-none'
                 + ' focus-visible:ring-2'
                 + ' focus-visible:ring-orange-500 '
@@ -69,8 +71,13 @@ function PageIndicatorInner({
                   ? 'bg-orange-500'
                     + ' shadow-[0_0_8px_rgba('
                     + '249,115,22,0.6)]'
-                  : 'bg-neutral-600'
-                    + ' hover:bg-neutral-400')
+                  : i === playbackPage
+                    ? 'bg-neutral-600'
+                      + ' ring-1 ring-orange-500/60'
+                      + ' shadow-[0_0_6px_rgba('
+                      + '249,115,22,0.3)]'
+                    : 'bg-neutral-600'
+                      + ' hover:bg-neutral-400')
               }
             />
           )

--- a/src/app/PageIndicator.tsx
+++ b/src/app/PageIndicator.tsx
@@ -26,7 +26,7 @@ function PageIndicatorInner({
   return (
     <div
       className={
-        'flex flex-col items-center gap-1'
+        'flex flex-col items-start gap-1.5'
         + ' flex-shrink-0'
       }
     >
@@ -35,7 +35,9 @@ function PageIndicatorInner({
         aria-pressed={autoFollow}
         onClick={() => setAutoFollow(!autoFollow)}
         className={
-          'w-4 h-4 rounded text-[8px]'
+          'px-2.5 py-px rounded-full'
+          + ' text-[10px] lg:text-xs'
+          + ' whitespace-nowrap'
           + ' font-bold transition-colors'
           + ' focus-visible:outline-none'
           + ' focus-visible:ring-2'
@@ -47,9 +49,9 @@ function PageIndicatorInner({
               + ' text-neutral-500')
         }
       >
-        F
+        Follow
       </button>
-      <div className="flex gap-1">
+      <div className="flex gap-1.5 self-center">
         {Array.from(
           { length: pageCount },
           (_, i) => (
@@ -58,14 +60,14 @@ function PageIndicatorInner({
               aria-label={`Page ${i + 1}`}
               onClick={() => setPage(i)}
               className={
-                'w-[7px] h-[7px] rounded-full'
+                'w-2.5 h-2.5 rounded-full'
                 + ' transition-colors'
                 + ' focus-visible:outline-none'
                 + ' focus-visible:ring-2'
                 + ' focus-visible:ring-orange-500 '
                 + (i === currentPage
                   ? 'bg-orange-500'
-                    + ' shadow-[0_0_6px_rgba('
+                    + ' shadow-[0_0_8px_rgba('
                     + '249,115,22,0.6)]'
                   : 'bg-neutral-600'
                     + ' hover:bg-neutral-400')

--- a/src/app/PatternPicker.tsx
+++ b/src/app/PatternPicker.tsx
@@ -97,7 +97,7 @@ export default function PatternPicker({
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-label="Pattern"
-        className="w-full px-4 lg:px-8 py-2 rounded-full
+        className="w-full px-3 lg:px-4 py-2 rounded-full
           font-bold text-sm lg:text-base truncate
           bg-neutral-800 text-neutral-400
           hover:text-neutral-200 hover:bg-neutral-700

--- a/src/app/RunningLight.tsx
+++ b/src/app/RunningLight.tsx
@@ -5,6 +5,7 @@ import { memo } from 'react';
 interface RunningLightProps {
   currentStep: number;
   patternLength: number;
+  pageOffset: number;
 }
 
 /**
@@ -15,6 +16,7 @@ interface RunningLightProps {
 function RunningLightInner({
   currentStep,
   patternLength,
+  pageOffset,
 }: RunningLightProps) {
   return (
     <div className="flex gap-4 items-center pt-2">
@@ -28,9 +30,9 @@ function RunningLightInner({
               className={
                 'h-1.5 rounded-full'
                 + ' transition-colors duration-100 '
-                + (i >= patternLength
+                + (pageOffset + i >= patternLength
                   ? 'bg-transparent'
-                  : i === currentStep
+                  : pageOffset + i === currentStep
                     ? 'bg-orange-500'
                       + ' shadow-[0_0_10px_rgba(249,115,22,0.8)]'
                     : 'bg-neutral-900')

--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -1,15 +1,37 @@
 "use client";
 
-import { useRef } from 'react';
-import { SequencerProvider } from './SequencerContext';
+import {
+  useRef, useState,
+} from 'react';
+import { SequencerProvider, useSequencer }
+  from './SequencerContext';
 import TransportControls from './TransportControls';
 import StepGrid from './StepGrid';
+import PageIndicator from './PageIndicator';
 
-/**
- * Inner shell that composes the major UI sections.
- */
 function SequencerInner() {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { state } = useSequencer();
+  const { patternLength } = state;
+
+  const [currentPage, setCurrentPage] = useState(0);
+  const [autoFollow, setAutoFollow] = useState(true);
+
+  const pageCount = Math.ceil(patternLength / 16);
+  const clampedPage = Math.min(
+    currentPage, pageCount - 1
+  );
+  const pageOffset = clampedPage * 16;
+
+  const pageIndicator = (
+    <PageIndicator
+      currentPage={currentPage}
+      pageCount={pageCount}
+      autoFollow={autoFollow}
+      setPage={setCurrentPage}
+      setAutoFollow={setAutoFollow}
+    />
+  );
 
   return (
     <div className="h-dvh overflow-hidden flex flex-col bg-neutral-950 text-neutral-100 font-sans">
@@ -20,12 +42,19 @@ function SequencerInner() {
         Skip to main content
       </a>
       <div className="max-w-none lg:max-w-4xl w-full mx-auto px-3 lg:px-8 pt-3 lg:pt-4 flex flex-col flex-1 min-h-0">
-        <TransportControls />
+        <TransportControls
+          pageIndicator={pageIndicator}
+        />
         <div
           ref={scrollRef}
           className="flex-1 overflow-y-auto py-3 lg:py-4 track-scroll-region"
         >
-          <StepGrid scrollContainerRef={scrollRef} />
+          <StepGrid
+            scrollContainerRef={scrollRef}
+            pageOffset={pageOffset}
+            autoFollow={autoFollow}
+            setPage={setCurrentPage}
+          />
           <footer className="grid grid-cols-3 items-center pt-4 lg:pt-8">
             <div />
             <a
@@ -46,10 +75,6 @@ function SequencerInner() {
   );
 }
 
-/**
- * Top-level Sequencer component. Wraps the UI in the
- * SequencerProvider that owns all state and audio logic.
- */
 export default function Sequencer() {
   return (
     <SequencerProvider>

--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -16,7 +16,6 @@ function SequencerInner() {
 
   const [currentPage, setCurrentPage] = useState(0);
   const [autoFollow, setAutoFollow] = useState(true);
-  const [playbackPage, setPlaybackPage] = useState(-1);
 
   const pageCount = Math.ceil(patternLength / 16);
   const clampedPage = Math.min(
@@ -29,7 +28,6 @@ function SequencerInner() {
       currentPage={currentPage}
       pageCount={pageCount}
       autoFollow={autoFollow}
-      playbackPage={playbackPage}
       setPage={setCurrentPage}
       setAutoFollow={setAutoFollow}
     />
@@ -56,7 +54,6 @@ function SequencerInner() {
             pageOffset={pageOffset}
             autoFollow={autoFollow}
             setPage={setCurrentPage}
-            setPlaybackPage={setPlaybackPage}
           />
           <footer className="grid grid-cols-3 items-center pt-4 lg:pt-8">
             <div />

--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -16,6 +16,7 @@ function SequencerInner() {
 
   const [currentPage, setCurrentPage] = useState(0);
   const [autoFollow, setAutoFollow] = useState(true);
+  const [playbackPage, setPlaybackPage] = useState(-1);
 
   const pageCount = Math.ceil(patternLength / 16);
   const clampedPage = Math.min(
@@ -28,6 +29,7 @@ function SequencerInner() {
       currentPage={currentPage}
       pageCount={pageCount}
       autoFollow={autoFollow}
+      playbackPage={playbackPage}
       setPage={setCurrentPage}
       setAutoFollow={setAutoFollow}
     />
@@ -54,6 +56,7 @@ function SequencerInner() {
             pageOffset={pageOffset}
             autoFollow={autoFollow}
             setPage={setCurrentPage}
+            setPlaybackPage={setPlaybackPage}
           />
           <footer className="grid grid-cols-3 items-center pt-4 lg:pt-8">
             <div />

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -587,7 +587,7 @@ export function SequencerProvider({
   const setPatternLength = useCallback(
     (length: number) => {
       const clamped =
-        Math.max(1, Math.min(16, length));
+        Math.max(1, Math.min(64, length));
       setConfig(prev => {
         const newTrackLengths = {
           ...prev.trackLengths,

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -22,6 +22,9 @@ const TRACK_ORDER: TrackId[] = TRACKS.map(
 
 interface StepGridProps {
   scrollContainerRef: RefObject<HTMLDivElement | null>;
+  pageOffset: number;
+  autoFollow: boolean;
+  setPage: (page: number) => void;
 }
 
 /**
@@ -32,6 +35,9 @@ interface StepGridProps {
  */
 export default function StepGrid({
   scrollContainerRef,
+  pageOffset,
+  autoFollow,
+  setPage,
 }: StepGridProps) {
   const { state, actions, meta } = useSequencer();
   const {
@@ -60,6 +66,7 @@ export default function StepGrid({
     onSetTrackSteps: setTrackSteps,
     longPressActiveRef,
     popoverOpenRef,
+    pageOffset,
   });
 
   const [openPopover, setOpenPopover] = useState<{
@@ -77,6 +84,11 @@ export default function StepGrid({
   // re-render on step ticks.
   const [displayStep, setDisplayStep] = useState(-1);
   const [displayTotal, setDisplayTotal] = useState(0);
+
+  const autoFollowRef = useRef(autoFollow);
+  useEffect(() => {
+    autoFollowRef.current = autoFollow;
+  }, [autoFollow]);
 
   useEffect(() => {
     let raf: number;
@@ -96,13 +108,22 @@ export default function StepGrid({
         setDisplayTotal(
           Math.max(0, curTotal - 1)
         );
+        // Auto-follow page
+        if (
+          autoFollowRef.current
+          && curStep >= 0
+        ) {
+          const stepPage =
+            Math.floor(curStep / 16);
+          setPage(stepPage);
+        }
       }
       raf = requestAnimationFrame(tick);
     };
 
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [stepRef, totalStepsRef]);
+  }, [stepRef, totalStepsRef, setPage]);
 
   return (
     <div className="space-y-2 lg:space-y-4 bg-neutral-900/30 p-3 lg:p-6 rounded-xl lg:rounded-2xl border border-neutral-800/50">
@@ -120,7 +141,7 @@ export default function StepGrid({
             steps={currentPattern.steps[track.id]}
             trackLength={trackLengths[track.id]}
             patternLength={patternLength}
-            pageOffset={0}
+            pageOffset={pageOffset}
             isMuted={trackStates[track.id].isMuted}
             isSolo={trackStates[track.id].isSolo}
             isFreeRun={
@@ -167,6 +188,7 @@ export default function StepGrid({
       <RunningLight
         currentStep={displayStep}
         patternLength={patternLength}
+        pageOffset={pageOffset}
       />
     </div>
   );

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -120,6 +120,7 @@ export default function StepGrid({
             steps={currentPattern.steps[track.id]}
             trackLength={trackLengths[track.id]}
             patternLength={patternLength}
+            pageOffset={0}
             isMuted={trackStates[track.id].isMuted}
             isSolo={trackStates[track.id].isSolo}
             isFreeRun={

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -25,7 +25,6 @@ interface StepGridProps {
   pageOffset: number;
   autoFollow: boolean;
   setPage: (page: number) => void;
-  setPlaybackPage: (page: number) => void;
 }
 
 /**
@@ -39,7 +38,6 @@ export default function StepGrid({
   pageOffset,
   autoFollow,
   setPage,
-  setPlaybackPage,
 }: StepGridProps) {
   const { state, actions, meta } = useSequencer();
   const {
@@ -110,16 +108,13 @@ export default function StepGrid({
         setDisplayTotal(
           Math.max(0, curTotal - 1)
         );
-        // Report playback page
-        const stepPage = curStep >= 0
-          ? Math.floor(curStep / 16)
-          : -1;
-        setPlaybackPage(stepPage);
         // Auto-follow page
         if (
           autoFollowRef.current
           && curStep >= 0
         ) {
+          const stepPage =
+            Math.floor(curStep / 16);
           setPage(stepPage);
         }
       }
@@ -128,7 +123,7 @@ export default function StepGrid({
 
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [stepRef, totalStepsRef, setPage, setPlaybackPage]);
+  }, [stepRef, totalStepsRef, setPage]);
 
   return (
     <div className="space-y-2 lg:space-y-4 bg-neutral-900/30 p-3 lg:p-6 rounded-xl lg:rounded-2xl border border-neutral-800/50">

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -25,6 +25,7 @@ interface StepGridProps {
   pageOffset: number;
   autoFollow: boolean;
   setPage: (page: number) => void;
+  setPlaybackPage: (page: number) => void;
 }
 
 /**
@@ -38,6 +39,7 @@ export default function StepGrid({
   pageOffset,
   autoFollow,
   setPage,
+  setPlaybackPage,
 }: StepGridProps) {
   const { state, actions, meta } = useSequencer();
   const {
@@ -108,13 +110,16 @@ export default function StepGrid({
         setDisplayTotal(
           Math.max(0, curTotal - 1)
         );
+        // Report playback page
+        const stepPage = curStep >= 0
+          ? Math.floor(curStep / 16)
+          : -1;
+        setPlaybackPage(stepPage);
         // Auto-follow page
         if (
           autoFollowRef.current
           && curStep >= 0
         ) {
-          const stepPage =
-            Math.floor(curStep / 16);
           setPage(stepPage);
         }
       }
@@ -123,7 +128,7 @@ export default function StepGrid({
 
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [stepRef, totalStepsRef, setPage]);
+  }, [stepRef, totalStepsRef, setPage, setPlaybackPage]);
 
   return (
     <div className="space-y-2 lg:space-y-4 bg-neutral-900/30 p-3 lg:p-6 rounded-xl lg:rounded-2xl border border-neutral-800/50">

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -279,13 +279,12 @@ function TrackRowInner({
     setIsDragging(false);
   }, []);
 
-  const handlePct = Math.max(
-    0,
-    Math.min(
-      100,
-      ((trackLength - pageOffset) / 16) * 100
-    )
-  );
+  const handleOnPage =
+    trackLength > pageOffset
+    && trackLength <= pageOffset + 16;
+  const handlePct = handleOnPage
+    ? ((trackLength - pageOffset) / 16) * 100
+    : 0;
 
   const handleToggleStep = useCallback(
     (tid: TrackId, localStep: number) =>
@@ -415,46 +414,48 @@ function TrackRowInner({
           </div>
 
           {/* Draggable length handle */}
-          <div
-            role="slider"
-            aria-label={`${trackName} length`}
-            aria-valuemin={1}
-            aria-valuemax={patternLength}
-            aria-valuenow={trackLength}
-            tabIndex={0}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            onPointerCancel={handlePointerUp}
-            {...endBarLongPress()}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              if (!isDragging) handleFreeRun();
-            }}
-            style={{
-              left: `${handlePct}%`,
-              touchAction: 'none',
-            }}
-            className={
-              'absolute top-0 h-full w-4'
-              + ' -translate-x-1/2 z-20'
-              + (isDragging
-                ? ' cursor-col-resize'
-                : ' cursor-default')
-              + ' before:absolute before:inset-y-0'
-              + ' before:left-1/2'
-              + ' before:-translate-x-1/2'
-              + ' before:w-1.5 before:rounded-full'
-              + ' before:transition-colors'
-              + (isDragging
-                ? ' before:bg-neutral-300'
-                : ' before:bg-neutral-500/60'
-                  + ' hover:before:bg-neutral-300')
-            }
-          />
+          {handleOnPage && (
+            <div
+              role="slider"
+              aria-label={`${trackName} length`}
+              aria-valuemin={1}
+              aria-valuemax={patternLength}
+              aria-valuenow={trackLength}
+              tabIndex={0}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
+              {...endBarLongPress()}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                if (!isDragging) handleFreeRun();
+              }}
+              style={{
+                left: `${handlePct}%`,
+                touchAction: 'none',
+              }}
+              className={
+                'absolute top-0 h-full w-4'
+                + ' -translate-x-1/2 z-20'
+                + (isDragging
+                  ? ' cursor-col-resize'
+                  : ' cursor-default')
+                + ' before:absolute before:inset-y-0'
+                + ' before:left-1/2'
+                + ' before:-translate-x-1/2'
+                + ' before:w-1.5 before:rounded-full'
+                + ' before:transition-colors'
+                + (isDragging
+                  ? ' before:bg-neutral-300'
+                  : ' before:bg-neutral-500/60'
+                    + ' hover:before:bg-neutral-300')
+              }
+            />
+          )}
 
           {/* Free-run indicator */}
-          {isFreeRun && (
+          {isFreeRun && handleOnPage && (
             <span
               aria-label="free run"
               style={{

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -123,6 +123,7 @@ interface TrackRowProps {
   steps: string;
   trackLength: number;
   patternLength: number;
+  pageOffset: number;
   isMuted: boolean;
   isSolo: boolean;
   isFreeRun: boolean;
@@ -165,6 +166,7 @@ function TrackRowInner({
   steps,
   trackLength,
   patternLength,
+  pageOffset,
   isMuted,
   isSolo,
   isFreeRun,
@@ -232,13 +234,16 @@ function TrackRowInner({
       if (!grid) return trackLength;
       const rect = grid.getBoundingClientRect();
       const x = clientX - rect.left;
-      const stepWidth = rect.width / patternLength;
+      const stepWidth = rect.width / 16;
       const raw = Math.round(x / stepWidth);
       return Math.max(
-        1, Math.min(patternLength, raw)
+        1,
+        Math.min(
+          patternLength, raw + pageOffset
+        )
       );
     },
-    [patternLength, trackLength]
+    [patternLength, trackLength, pageOffset]
   );
 
   const handlePointerDown = useCallback(
@@ -274,8 +279,30 @@ function TrackRowInner({
     setIsDragging(false);
   }, []);
 
-  const handlePct =
-    (trackLength / 16) * 100;
+  const handlePct = Math.max(
+    0,
+    Math.min(
+      100,
+      ((trackLength - pageOffset) / 16) * 100
+    )
+  );
+
+  const handleToggleStep = useCallback(
+    (tid: TrackId, localStep: number) =>
+      onToggleStep(tid, localStep + pageOffset),
+    [onToggleStep, pageOffset]
+  );
+
+  const handleOpenPopover = useCallback(
+    (
+      tid: TrackId,
+      localStep: number,
+      rect: { top: number; left: number }
+    ) => onOpenPopover?.(
+      tid, localStep + pageOffset, rect
+    ),
+    [onOpenPopover, pageOffset]
+  );
 
   return (
     <div>
@@ -353,9 +380,10 @@ function TrackRowInner({
             {Array.from(
               { length: 16 },
               (_, i) => {
+                const globalIdx = pageOffset + i;
                 const disabled =
-                  i >= trackLength
-                  || i >= patternLength;
+                  globalIdx >= trackLength
+                  || globalIdx >= patternLength;
                 return (
                   <StepButton
                     key={i}
@@ -364,19 +392,19 @@ function TrackRowInner({
                     stepIndex={i}
                     isActive={
                       !disabled
-                      && steps[i] === '1'
+                      && steps[globalIdx] === '1'
                     }
                     isCurrent={
                       !disabled
-                      && effectiveStep === i
+                      && effectiveStep === globalIdx
                     }
-                    isBeat={i % 4 === 0}
+                    isBeat={globalIdx % 4 === 0}
                     isDisabled={disabled}
-                    onToggle={onToggleStep}
+                    onToggle={handleToggleStep}
                     conditions={
-                      trigConditions?.[i]
+                      trigConditions?.[globalIdx]
                     }
-                    onOpenPopover={onOpenPopover}
+                    onOpenPopover={handleOpenPopover}
                     longPressActiveRef={
                       longPressActiveRef
                     }

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo } from 'react';
+import type { ReactNode } from 'react';
 import kitsData from './data/kits.json';
 import patternsData from './data/patterns.json';
 import TempoController from './TempoController';
@@ -16,11 +17,17 @@ const categories = getCategorizedPatterns(
   patternsData.patterns as Pattern[]
 );
 
+interface TransportControlsProps {
+  pageIndicator?: ReactNode;
+}
+
 /**
  * Header section with logo, BPM, play/stop, kit and
  * pattern selectors.
  */
-function TransportControlsInner() {
+function TransportControlsInner({
+  pageIndicator,
+}: TransportControlsProps) {
   const { state, actions } = useSequencer();
   const {
     isPlaying, bpm, currentKit,
@@ -54,7 +61,7 @@ function TransportControlsInner() {
         </div>
       </div>
       {/* Row 2: Kit + Pattern */}
-      <div className="grid grid-cols-3 gap-2 lg:gap-4 pt-2 lg:pt-0">
+      <div className="grid grid-cols-[1fr_1fr_1.5fr] gap-2 lg:gap-4 pt-2 lg:pt-0">
         <GlobalControls />
         <div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
           <label
@@ -85,11 +92,16 @@ function TransportControlsInner() {
           <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
             Pattern
           </span>
-          <PatternPicker
-            categories={categories}
-            currentPattern={currentPattern}
-            onSelect={setPattern}
-          />
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <PatternPicker
+                categories={categories}
+                currentPattern={currentPattern}
+                onSelect={setPattern}
+              />
+            </div>
+            {pageIndicator}
+          </div>
         </div>
       </div>
     </header>

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -92,7 +92,7 @@ function TransportControlsInner({
           <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
             Pattern
           </span>
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <div className="flex-1 min-w-0">
               <PatternPicker
                 categories={categories}

--- a/src/app/useDragPaint.ts
+++ b/src/app/useDragPaint.ts
@@ -18,6 +18,7 @@ interface UseDragPaintOptions {
   onSetTrackSteps?: (trackId: TrackId, steps: string) => void;
   longPressActiveRef?: RefObject<boolean>;
   popoverOpenRef?: RefObject<boolean>;
+  pageOffset?: number;
 }
 
 interface CellHit {
@@ -138,6 +139,7 @@ export function useDragPaint({
   onSetTrackSteps,
   longPressActiveRef,
   popoverOpenRef,
+  pageOffset = 0,
 }: UseDragPaintOptions) {
   const dragRef = useRef<DragState>({
     active: false,
@@ -181,7 +183,7 @@ export function useDragPaint({
         return false;
       }
       const tid = trackOrder[trackIdx];
-      if (stepIdx >= trackLengths[tid]) return false;
+      if (stepIdx + pageOffset >= trackLengths[tid]) return false;
       if (
         trackIdx === drag.lastTrackIdx
         && stepIdx === drag.lastStep
@@ -190,10 +192,10 @@ export function useDragPaint({
       }
       drag.lastTrackIdx = trackIdx;
       drag.lastStep = stepIdx;
-      onSetStep(tid, stepIdx, drag.paintValue);
+      onSetStep(tid, stepIdx + pageOffset, drag.paintValue);
       return true;
     },
-    [trackOrder, trackLengths, onSetStep]
+    [trackOrder, trackLengths, onSetStep, pageOffset]
   );
 
   /**
@@ -268,7 +270,7 @@ export function useDragPaint({
       if (!hit) return;
 
       const { trackId, stepIndex } = hit;
-      if (stepIndex >= trackLengths[trackId]) return;
+      if (stepIndex + pageOffset >= trackLengths[trackId]) return;
 
       stepsAtDown.current = steps;
 
@@ -309,7 +311,9 @@ export function useDragPaint({
       // Normal paint mode
       drag.cyclingMode = false;
       drag.paintValue =
-        stepsAtDown.current[trackId][stepIndex] === '1'
+        stepsAtDown.current[trackId][
+          stepIndex + pageOffset
+        ] === '1'
           ? '0' : '1';
     },
     [
@@ -319,6 +323,7 @@ export function useDragPaint({
       onSetTrackSteps,
       longPressActiveRef,
       popoverOpenRef,
+      pageOffset,
     ]
   );
 


### PR DESCRIPTION
## Summary

- Extend sequencer from fixed 16 steps to configurable 1-64 steps
- Display 16 steps at a time across pages with clickable dot navigation
- Add "Follow" toggle that auto-scrolls pages during playback
- Page indicator always visible in the Pattern section of the transport bar
- Track end handles only render on the page where the track ends

## Details

Closes #29

**Architecture:** Page state (`currentPage`, `autoFollow`) lives in the
`Sequencer` component and flows down as props. TrackRow and RunningLight
receive a `pageOffset` prop and render a 16-step window shifted by that
offset. A new `PageIndicator` component renders clickable dots and a
follow toggle inside the Pattern section of TransportControls via a
slot prop (avoiding unnecessary re-renders of the memoized transport).

**Key changes:**
- `SequencerContext`: bump `setPatternLength` clamp from 16 to 64
- `GlobalControls`: steps dropdown extended to 64
- `PageIndicator`: new component (follow toggle + page dots)
- `TrackRow`: shifted step rendering, drag handle, lengthFromPointer
- `RunningLight`: shifted highlight and dimming by pageOffset
- `useDragPaint`: pageOffset support with corrected paintOne guard
- `StepGrid`: auto-follow logic in rAF loop via ref
- `TransportControls`: pageIndicator slot, wider pattern section

## Test plan

- [ ] 316 automated tests pass (23 test files)
- [ ] Lint clean, production build succeeds
- [ ] 16-step default: page dot visible, follow toggle active
- [ ] 32 steps: two dots, page switching, step isolation between pages
- [ ] Auto-follow: page tracks playhead during playback
- [ ] Follow off: page stays put while playback advances
- [ ] Partial page (24 steps): 8 active + 8 dimmed on page 2
- [ ] 64 steps: four dots, all navigable
- [ ] Drag handle only shows on the page where track ends
- [ ] Page clamp: reduce from 64 to 16 while on page 4 snaps to page 1
- [ ] Mobile layout: dots and follow toggle visible
