### PR TITLE
Add per-step gain parameter locks

### DIFF
--- a/docs/specs/2026-03-20-parameter-locks-design.md
+++ b/docs/specs/2026-03-20-parameter-locks-design.md
@@ -1,0 +1,287 @@
+# Parameter Locks — Gain (Issue #30)
+
+## Context
+
+XOX is a 16-step drum sequencer. Currently every step on a
+track plays at the same mixer-set volume. Hardware drum
+machines like the Elektron Analog Rytm allow per-step
+parameter overrides ("parameter locks") for expressive
+variation — ghost notes, accent patterns, velocity ramps.
+
+This spec covers the first parameter lock: **gain** (per-step
+volume override). The design is extensible to future parameters
+(pitch, decay, pan) without structural changes.
+
+## Requirements
+
+- Per-step, per-track gain override (0–100%)
+- Gain lock replaces the track's mixer gain as the base;
+  accent still stacks (1.5x multiplier)
+- Edited via a renamed `StepPopover` (right-click /
+  Ctrl+click / long-press), in a new "Locks" section below
+  trig conditions
+- Popover opens on **any step**, including inactive ones
+  (removing the existing `isActive` guard in StepButton)
+- Visual indicator: active step button opacity maps to
+  locked gain (absolute; 100% lock = full opacity, 50%
+  lock = 50% opacity). Inactive steps do not show opacity.
+- Serialized in URL hash for sharing (backward compatible)
+
+## Data Model
+
+### New types (`src/app/types.ts`)
+
+```typescript
+export interface StepLocks {
+  gain?: number; // 0.0–1.0
+}
+```
+
+### New field in `SequencerConfig`
+
+```typescript
+parameterLocks: Partial<
+  Record<TrackId, Record<number, StepLocks>>
+>;
+```
+
+Mirrors `trigConditions` structure exactly. Empty object `{}`
+when no locks are set.
+
+### `Pattern` type extension
+
+The `Pattern` interface gains an optional field:
+
+```typescript
+parameterLocks?: Partial<
+  Record<TrackId, Record<number, StepLocks>>
+>;
+```
+
+This allows locks to round-trip through pattern
+sharing/export.
+
+## Audio Pipeline
+
+In `handleStep` (SequencerContext.tsx), the gain calculation
+changes. Note: `handleStep` reads config via
+`configRef.current` (aliased as `cfg`) and computes
+`effectiveStep = trackStep(track.id)` for freeRun / per-track
+length support.
+
+```typescript
+const locks =
+  cfg.parameterLocks?.[track.id]?.[effectiveStep];
+const baseGain = locks?.gain ?? st.gain;
+const cubic = baseGain ** 3;
+const gain = isAccented ? cubic * 1.5 : cubic;
+```
+
+The lock overrides the mixer gain. If no lock exists, mixer
+gain is used. Accent multiplier always applies on top.
+
+## Popover UI
+
+### Rename
+
+Rename `TrigConditionPopover` → `StepPopover` (file and
+component). Update all imports in StepGrid, TrackRow, and
+test files.
+
+### Popover on inactive steps
+
+Remove the `if (!isActive) return` guard in
+`StepButton.openPopover()`. The popover now opens on any
+step — active or inactive. This also means trig conditions
+can be set on inactive steps before activating them.
+
+### Layout
+
+```
+┌──────────────────────────┐
+│ Step 3 · SD  [Reset cond]│
+│                          │
+│ PROBABILITY              │
+│ [=========|----] 75%     │
+│                          │
+│ CYCLE                    │
+│ [Every rep         ▾]    │
+│                          │
+│ FILL                     │
+│ [None] [FILL] [!FILL]    │
+│──────────────────────────│
+│ LOCKS        [Reset locks]│
+│                          │
+│ GAIN                     │
+│ [================] 100%  │
+│ Drag to set gain lock    │
+└──────────────────────────┘
+```
+
+### Behavior
+
+- **Slider starts at 100%** when no lock exists for the step
+- **Dragging the slider** creates/updates the gain lock
+- Opening and closing without touching the slider = no change
+- **100% is a valid lock value** — dragging to 100% keeps the
+  lock. Only the "Reset locks" button removes it.
+- **"Reset locks" button** clears all parameter locks for
+  that step (independent from "Reset trig cond." button)
+- Slider shows current locked value when a lock exists
+- Slider uses same orange color as probability slider
+  (`bg-orange-600`) — section headers provide distinction
+
+### RangeSlider component
+
+Generalize `ProbabilitySlider` into a reusable `RangeSlider`
+component with configurable `min`, `max`, and `onChange`
+props. Both probability (1–100) and gain (0–100) use it.
+
+```typescript
+interface RangeSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}
+```
+
+### Actions
+
+Two new actions in SequencerContext:
+
+- `setParameterLock(trackId, stepIndex, locks: StepLocks)` —
+  creates or updates locks for a step
+- `clearParameterLock(trackId, stepIndex)` — removes all
+  locks for a step
+
+## State Management Parity
+
+Every place in `SequencerContext.tsx` that manages
+`trigConditions` must also manage `parameterLocks`:
+
+- **`setPattern`** — load `parameterLocks` from the pattern
+  (if present), else clear to `{}`
+- **`clearPattern`** — reset `parameterLocks` to `{}`
+- **`clearTrack`** — delete `parameterLocks[trackId]`
+- **`setPatternLength`** — prune locks on steps beyond the
+  new length (mirrors trig condition pruning)
+- **`setTrackLength`** — same pruning for per-track length
+
+**Pattern cycling (shift+drag):** Locks are NOT cleared when
+patterns are cycled via drag-paint, matching existing trig
+condition behavior. Orphaned locks on now-inactive steps are
+harmlessly ignored during playback.
+
+**`toggleStep`:** Does NOT clear locks. Locks persist on
+inactive steps and take effect again when the step is
+re-activated.
+
+## Design Decisions
+
+- **Kit switching** does not clear parameter locks. Gain
+  locks are kit-agnostic (0–1 scalar), so they remain valid
+  across kit changes.
+- **Accent track (`ac`)** is excluded from parameter locks.
+  It has no UI surface (hidden from grid) and its role is
+  purely to flag accent — not to carry its own gain lock.
+  If `ac` entries appear in a shared URL, they are silently
+  dropped during validation.
+- **100% is a valid lock value.** A lock at 100% means "this
+  step always plays at full gain regardless of mixer." Only
+  the "Reset locks" button removes a lock.
+- **No config version bump needed.** The field is optional
+  and backward compatible — old URLs simply lack it and
+  decode to `{}`.
+- **Playback glow is unaffected by opacity.** The step glow
+  uses `box-shadow` which renders independently of element
+  opacity. A dim gain-locked step still shows full playback
+  glow — this is intentional for tracking playback position.
+- **Opacity indicator only on active steps.** Inactive steps
+  remain uniformly dark regardless of any locks they carry.
+  The lock data persists but isn't shown visually until the
+  step is activated.
+- **Combined indicators: gain and probability are independent
+  visually.** Opacity reflects gain lock only. The
+  probability bar at the bottom remains a separate indicator.
+  They are not multiplied.
+
+## Visual Indicator
+
+Step buttons with a gain lock have their opacity set to
+the locked gain value:
+
+- `opacity = Math.max(0.2, lockedGain)` — floor at 20%
+  so steps remain visible even at gain = 0
+- Only **active** steps with a gain lock change opacity;
+  inactive steps and unlocked steps remain at full opacity
+- Applied via inline `style` on the step button, only
+  when the step is active AND
+  `parameterLocks?.[trackId]?.[stepIndex]?.gain` is defined
+- No CSS transition on opacity — changes are instant, which
+  is appropriate for real-time parameter edits during
+  playback
+
+## Serialization (`src/app/configCodec.ts`)
+
+### Encoding
+
+The encoder strips `parameterLocks` from the JSON when it is
+empty (`{}`), keeping URLs identical to current size when no
+locks are in use. When locks exist, the field is included in
+the JSON-stringified config before deflate-raw compression.
+
+### Decoding / Validation
+
+New `validateParameterLocks()` function (follows the
+`validateTrigConditions()` pattern):
+- Validates track IDs against `TRACK_IDS`
+- Drops `ac` (accent) track entries
+- Validates step indices are 0–63 (supports up to 64 steps)
+- Clamps gain to [0, 1]
+- Drops entries with no valid lock fields
+- Returns `{}` for missing/invalid input
+
+### `defaultConfig()`
+
+Add `parameterLocks: {}` to the default config object.
+
+### Backward Compatibility
+
+- URLs without `parameterLocks` decode with `{}`
+  (no locks = current behavior)
+- Old clients ignore the field if present in a URL
+  (`validateConfig` whitelists known fields)
+- Golden test snapshot will need updating (`npm test -- -u`)
+
+## Testing
+
+### `handleStep.test.ts`
+- Gain lock overrides mixer gain
+- Accent stacks on locked gain (1.5x)
+- No lock falls back to mixer gain
+- Gain lock = 0 produces silence
+
+### `configCodec.test.ts`
+- Round-trip encode/decode preserves parameter locks
+- Validation clamps out-of-range gain values
+- Missing `parameterLocks` defaults to `{}`
+- Invalid track IDs / step indices are dropped
+- `ac` track entries are dropped
+- Empty `parameterLocks` is stripped from encoded output
+
+### `configCodec.golden.test.ts`
+- Snapshot update for new defaultConfig shape
+
+### `types.test.ts`
+- Snapshot update for `SequencerConfig` shape (if applicable)
+
+### UI tests
+- Popover renders gain slider in locks section
+- Drag creates a gain lock
+- Reset locks button clears locks (independent of trig reset)
+- Step button opacity reflects locked gain on active steps
+- Inactive steps do not show opacity change
+- Popover shows current locked value for existing locks
+- Popover opens on inactive steps
+- RangeSlider: keyboard and drag controls, min/max clamping

--- a/plans/2026-03-20T12-48-parameter-locks-gain.md
+++ b/plans/2026-03-20T12-48-parameter-locks-gain.md
@@ -1,0 +1,1637 @@
+---
+date: 2026-03-20
+summary: >
+  Add per-step gain parameter locks to the XOX drum sequencer
+  (issue #30). Extends the step popover with a gain slider,
+  adds opacity visual indicator, and wires through serialization.
+---
+
+# Parameter Locks — Gain Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use
+> subagent-driven-development (if subagents available) or
+> executing-plans to implement this plan. Steps use checkbox
+> (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-step gain overrides ("parameter locks") so
+each step can have its own volume, independent of the track
+mixer.
+
+**Architecture:** New `StepLocks` type and `parameterLocks`
+field on `SequencerConfig`, mirroring the existing
+`trigConditions` pattern. `ProbabilitySlider` is generalized
+into a reusable `RangeSlider`. The existing
+`TrigConditionPopover` is renamed to `StepPopover` and
+extended with a "Locks" section. Gain lock overrides mixer
+gain in `handleStep`; active steps show opacity proportional
+to locked gain.
+
+**Tech Stack:** React 19, TypeScript strict, Vitest + jsdom,
+Tailwind CSS v4, Next.js App Router
+
+**Spec:** `docs/specs/2026-03-20-parameter-locks-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/app/types.ts` | Add `StepLocks` interface, extend `SequencerConfig` and `Pattern` |
+| Create | `src/app/RangeSlider.tsx` | Generalized horizontal slider (min/max/onChange) |
+| Modify | `src/app/ProbabilitySlider.tsx` | Rewrite as thin wrapper around `RangeSlider` |
+| Rename | `src/app/TrigConditionPopover.tsx` → `src/app/StepPopover.tsx` | Extended with locks section |
+| Modify | `src/app/StepButton.tsx` | Remove `isActive` guard on popover; add opacity style |
+| Modify | `src/app/StepGrid.tsx` | Update import; pass `parameterLocks` to popover |
+| Modify | `src/app/configCodec.ts` | Add `validateParameterLocks()`, update `defaultConfig()`, `validateConfig()`, strip empty on encode |
+| Modify | `src/app/SequencerContext.tsx` | Add actions, wire `parameterLocks` through all state operations |
+| Create | `src/__tests__/RangeSlider.test.tsx` | Slider unit tests |
+| Modify | `src/__tests__/TrigConditionPopover.test.tsx` → rename to `src/__tests__/StepPopover.test.tsx` | Update imports, add locks section tests |
+| Modify | `src/__tests__/handleStep.test.ts` | Gain lock override tests |
+| Modify | `src/__tests__/configCodec.test.ts` | Round-trip, validation, stripping tests |
+| Modify | `src/__tests__/configCodec.golden.test.ts` | Update snapshot |
+| Modify | `src/__tests__/StepButton.test.tsx` | Opacity indicator, popover-on-inactive tests |
+
+---
+
+## Task 1: Types and Data Model
+
+**Files:**
+- Modify: `src/app/types.ts:23-102`
+
+- [ ] **Step 1: Add `StepLocks` interface**
+
+Add after `StepConditions` (line 27):
+
+```typescript
+/**
+ * Per-step parameter lock overrides.
+ * Each field overrides the track-level default when present.
+ */
+export interface StepLocks {
+  gain?: number; // 0.0–1.0
+}
+```
+
+- [ ] **Step 2: Add `parameterLocks` to `SequencerConfig`**
+
+Add after `trigConditions` (line 101):
+
+```typescript
+  parameterLocks: Partial<
+    Record<TrackId, Record<number, StepLocks>>
+  >;
+```
+
+- [ ] **Step 3: Add `parameterLocks` to `Pattern`**
+
+Add after `trigConditions` (line 39):
+
+```typescript
+  parameterLocks?: Partial<
+    Record<TrackId, Record<number, StepLocks>>
+  >;
+```
+
+- [ ] **Step 4: Run tests to confirm nothing breaks**
+
+Run: `npm test -- --run`
+Expected: Snapshot failures in golden test (expected — do NOT
+update yet). No other failures.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/types.ts
+git commit -m "Add StepLocks type and parameterLocks field"
+```
+
+---
+
+## Task 2: configCodec — Validation and Encoding
+
+**Files:**
+- Modify: `src/app/configCodec.ts:1-470`
+- Modify: `src/__tests__/configCodec.test.ts`
+- Modify: `src/__tests__/configCodec.golden.test.ts`
+
+- [ ] **Step 1: Write failing tests for `parameterLocks` validation**
+
+Add to `src/__tests__/configCodec.test.ts`:
+
+```typescript
+describe('parameterLocks validation', () => {
+  it('round-trips parameterLocks through encode/decode',
+    async () => {
+      const config = makeConfig({
+        parameterLocks: {
+          bd: { 0: { gain: 0.5 }, 3: { gain: 0.8 } },
+          sd: { 7: { gain: 0.2 } },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.parameterLocks).toEqual(
+        config.parameterLocks
+      );
+    }
+  );
+
+  it('defaults to {} when missing', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({});
+  });
+
+  it('clamps gain to [0, 1]', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        bd: { 0: { gain: 2.5 }, 1: { gain: -0.3 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks.bd?.[0]?.gain).toBe(1);
+    expect(decoded.parameterLocks.bd?.[1]?.gain).toBe(0);
+  });
+
+  it('drops invalid track IDs', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        zz: { 0: { gain: 0.5 } },
+        bd: { 0: { gain: 0.7 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.7 } },
+    });
+  });
+
+  it('drops ac track entries', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        ac: { 0: { gain: 0.5 } },
+        bd: { 0: { gain: 0.7 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.7 } },
+    });
+  });
+
+  it('drops step indices >= 64', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        bd: { 0: { gain: 0.5 }, 99: { gain: 0.8 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.5 } },
+    });
+  });
+
+  it('strips empty parameterLocks from encoded output',
+    async () => {
+      const config = makeConfig({
+        parameterLocks: {},
+      });
+      const hash = await encodeConfig(config);
+      // Decode raw JSON to inspect
+      const bytes = Uint8Array.from(
+        atob(
+          hash.replace(/-/g, '+').replace(/_/g, '/')
+            + '='.repeat((4 - (hash.length % 4)) % 4)
+        ),
+        c => c.charCodeAt(0)
+      );
+      const stream = new Blob([bytes]).stream()
+        .pipeThrough(
+          new DecompressionStream('deflate-raw')
+        );
+      const json = await new Response(stream).text();
+      const parsed = JSON.parse(json);
+      expect(parsed.parameterLocks).toBeUndefined();
+    }
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/__tests__/configCodec.test.ts`
+Expected: FAIL — `parameterLocks` not handled yet.
+
+- [ ] **Step 3: Add `validateParameterLocks()` to configCodec.ts**
+
+Add after `validateTrigConditions` (after line 433). Import
+`StepLocks` from types:
+
+```typescript
+const MAX_STEP_INDEX = 63;
+
+/**
+ * Validate a single StepLocks object.
+ * Returns null if no valid fields remain.
+ */
+function validateSingleLock(
+  raw: unknown
+): StepLocks | null {
+  if (raw === null || typeof raw !== 'object') {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  const sl: StepLocks = {};
+
+  if (
+    typeof obj.gain === 'number'
+    && isFinite(obj.gain)
+  ) {
+    sl.gain = Math.max(0, Math.min(1, obj.gain));
+  }
+
+  if (Object.keys(sl).length === 0) return null;
+  return sl;
+}
+
+/**
+ * Validate parameterLocks map. Drops ac track,
+ * invalid step indices, and invalid lock objects.
+ */
+function validateParameterLocks(
+  value: unknown,
+  trackLengths: Record<TrackId, number>
+): SequencerConfig['parameterLocks'] {
+  if (
+    value === null || typeof value !== 'object'
+  ) return {};
+  const obj = value as Record<string, unknown>;
+  const result:
+    SequencerConfig['parameterLocks'] = {};
+
+  for (const id of TRACK_IDS) {
+    if (id === 'ac') continue;
+    const trackEntry = obj[id];
+    if (
+      trackEntry === null
+      || typeof trackEntry !== 'object'
+    ) continue;
+
+    const stepMap =
+      trackEntry as Record<string, unknown>;
+    const validSteps: Record<number, StepLocks> = {};
+
+    for (const key of Object.keys(stepMap)) {
+      const stepIndex = Number(key);
+      if (
+        !Number.isInteger(stepIndex)
+        || stepIndex < 0
+        || stepIndex > MAX_STEP_INDEX
+      ) continue;
+      const lock = validateSingleLock(stepMap[key]);
+      if (lock !== null) {
+        validSteps[stepIndex] = lock;
+      }
+    }
+
+    if (Object.keys(validSteps).length > 0) {
+      result[id] = validSteps;
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Update `defaultConfig()` — add `parameterLocks: {}`**
+
+In `defaultConfig()` (line 48, before closing brace):
+
+```typescript
+    parameterLocks: {},
+```
+
+- [ ] **Step 5: Update `validateConfig()` — call `validateParameterLocks`**
+
+Add after the `trigConditions` validation (line 167):
+
+```typescript
+  const parameterLocks = validateParameterLocks(
+    obj.parameterLocks, trackLengths
+  );
+```
+
+Add `parameterLocks` to the return object (line 178):
+
+```typescript
+    parameterLocks,
+```
+
+- [ ] **Step 6: Update `encodeConfig()` — strip empty `parameterLocks`**
+
+Replace the current `encodeConfig` function body:
+
+```typescript
+export async function encodeConfig(
+  config: SequencerConfig
+): Promise<string> {
+  const toEncode: Record<string, unknown> = {
+    ...config,
+  };
+  // Strip empty parameterLocks to keep URLs small
+  if (
+    Object.keys(
+      config.parameterLocks ?? {}
+    ).length === 0
+  ) {
+    delete toEncode.parameterLocks;
+  }
+  const json = JSON.stringify(toEncode);
+  const stream = new Blob([json]).stream()
+    .pipeThrough(
+      new CompressionStream('deflate-raw')
+    );
+  const bytes = new Uint8Array(
+    await new Response(stream).arrayBuffer()
+  );
+  return toBase64url(bytes);
+}
+```
+
+- [ ] **Step 7: Update import in configCodec.ts**
+
+Add `StepLocks` to the import from `'./types'`:
+
+```typescript
+import type {
+  SequencerConfig,
+  StepConditions,
+  StepLocks,
+  TrackId,
+  TrackMixerState,
+} from './types';
+```
+
+- [ ] **Step 8: Run configCodec tests**
+
+Run: `npm test -- --run src/__tests__/configCodec.test.ts`
+Expected: All PASS (including new tests).
+
+- [ ] **Step 9: Update golden test snapshot**
+
+Run: `npm test -- --run -u src/__tests__/configCodec.golden.test.ts`
+Expected: Snapshot updated with `parameterLocks: {}`.
+
+- [ ] **Step 10: Update types.test.ts snapshot (if applicable)**
+
+Run: `npm test -- --run -u src/__tests__/types.test.ts`
+Expected: PASS (snapshot updated if it tracks
+`SequencerConfig` shape).
+
+- [ ] **Step 11: Run full test suite**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 12: Commit**
+
+```
+git add src/app/configCodec.ts src/__tests__/configCodec.test.ts \
+  src/__tests__/configCodec.golden.test.ts \
+  src/__tests__/__snapshots__/
+git commit -m "Add parameterLocks validation and codec support"
+```
+
+---
+
+## Task 3: RangeSlider Component
+
+**Files:**
+- Create: `src/app/RangeSlider.tsx`
+- Modify: `src/app/ProbabilitySlider.tsx`
+- Create: `src/__tests__/RangeSlider.test.tsx`
+
+- [ ] **Step 1: Write failing tests for RangeSlider**
+
+Create `src/__tests__/RangeSlider.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent } from
+  '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RangeSlider from '../app/RangeSlider';
+
+describe('RangeSlider', () => {
+  it('renders with current value', () => {
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('50%')).toBeTruthy();
+  });
+
+  it('clamps at min on Home key', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'Home' });
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('clamps at max on End key', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'End' });
+    expect(onChange).toHaveBeenCalledWith(100);
+  });
+
+  it('respects custom min (e.g., 1 for probability)',
+    () => {
+      const onChange = vi.fn();
+      render(
+        <RangeSlider
+          value={5} min={1} max={100}
+          onChange={onChange}
+        />
+      );
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'Home' });
+      expect(onChange).toHaveBeenCalledWith(1);
+    }
+  );
+
+  it('arrow key increments by 1', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(
+      slider, { key: 'ArrowRight' }
+    );
+    expect(onChange).toHaveBeenCalledWith(51);
+  });
+
+  it('shift+arrow increments by 10', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(
+      slider,
+      { key: 'ArrowRight', shiftKey: true }
+    );
+    expect(onChange).toHaveBeenCalledWith(60);
+  });
+
+  it('sets correct aria attributes', () => {
+    render(
+      <RangeSlider
+        value={42} min={0} max={100}
+        onChange={vi.fn()} label="Gain"
+      />
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider.getAttribute('aria-valuemin'))
+      .toBe('0');
+    expect(slider.getAttribute('aria-valuemax'))
+      .toBe('100');
+    expect(slider.getAttribute('aria-valuenow'))
+      .toBe('42');
+    expect(slider.getAttribute('aria-label'))
+      .toBe('Gain');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/__tests__/RangeSlider.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `RangeSlider.tsx`**
+
+Create `src/app/RangeSlider.tsx`:
+
+```typescript
+"use client";
+
+import { useRef, useCallback, useEffect } from 'react';
+
+interface RangeSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+  label?: string;
+}
+
+/**
+ * Horizontal range slider with pointer-capture drag
+ * and keyboard controls.
+ *
+ * Args:
+ *   value: Current value
+ *   min: Minimum value (inclusive)
+ *   max: Maximum value (inclusive)
+ *   onChange: Callback with new value
+ *   label: Accessible label (default "Value")
+ */
+export default function RangeSlider({
+  value,
+  min,
+  max,
+  onChange,
+  label = 'Value',
+}: RangeSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    startX: number;
+    startValue: number;
+  } | null>(null);
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const range = max - min;
+
+  const clamp = (v: number) =>
+    Math.max(min, Math.min(max, Math.round(v)));
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as Element).setPointerCapture(
+        e.pointerId
+      );
+      dragRef.current = {
+        startX: e.clientX,
+        startValue: valueRef.current,
+      };
+    },
+    []
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current || !trackRef.current) {
+        return;
+      }
+      const width = trackRef.current.offsetWidth;
+      if (width === 0) return;
+      const delta =
+        ((e.clientX - dragRef.current.startX)
+          / width) * range;
+      onChange(
+        clamp(dragRef.current.startValue + delta)
+      );
+    },
+    [onChange, range]
+  );
+
+  const release = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const v = valueRef.current;
+      let next = v;
+      const step = e.shiftKey ? 10 : 1;
+      if (
+        e.key === 'ArrowRight'
+        || e.key === 'ArrowUp'
+      ) {
+        next = clamp(v + step);
+      } else if (
+        e.key === 'ArrowLeft'
+        || e.key === 'ArrowDown'
+      ) {
+        next = clamp(v - step);
+      } else if (e.key === 'Home') {
+        next = min;
+      } else if (e.key === 'End') {
+        next = max;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      onChange(next);
+    },
+    [onChange, min, max]
+  );
+
+  const pct = range > 0
+    ? ((value - min) / range) * 100
+    : 0;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={0}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-label={label}
+        className={
+          'relative h-6 flex-1 rounded'
+          + ' bg-neutral-700 cursor-ew-resize'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500'
+        }
+        style={{ touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={release}
+        onLostPointerCapture={release}
+        onKeyDown={onKeyDown}
+      >
+        <div
+          className={
+            'absolute inset-y-0 left-0 rounded'
+            + ' bg-orange-600'
+          }
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className={
+        'text-xs font-mono text-neutral-300'
+        + ' w-10 text-right tabular-nums'
+      }>
+        {value}%
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run RangeSlider tests**
+
+Run: `npm test -- --run src/__tests__/RangeSlider.test.tsx`
+Expected: All PASS.
+
+- [ ] **Step 5: Rewrite ProbabilitySlider as wrapper**
+
+Replace `src/app/ProbabilitySlider.tsx`:
+
+```typescript
+"use client";
+
+import RangeSlider from './RangeSlider';
+
+interface ProbabilitySliderProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+/**
+ * Probability slider (1-100). Thin wrapper around
+ * RangeSlider.
+ */
+export default function ProbabilitySlider({
+  value,
+  onChange,
+}: ProbabilitySliderProps) {
+  return (
+    <RangeSlider
+      value={value}
+      min={1}
+      max={100}
+      onChange={onChange}
+      label="Probability"
+    />
+  );
+}
+```
+
+- [ ] **Step 6: Run full test suite to verify ProbabilitySlider still works**
+
+Run: `npm test -- --run`
+Expected: All PASS (ProbabilitySlider tests + popover tests
+still pass since behavior is identical).
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/app/RangeSlider.tsx \
+  src/app/ProbabilitySlider.tsx \
+  src/__tests__/RangeSlider.test.tsx
+git commit -m "Extract RangeSlider from ProbabilitySlider"
+```
+
+---
+
+## Task 4: SequencerContext — Actions and State Parity
+
+**Files:**
+- Modify: `src/app/SequencerContext.tsx`
+- Modify: `src/__tests__/handleStep.test.ts`
+
+- [ ] **Step 1: Write failing tests for gain lock in handleStep**
+
+Add to `src/__tests__/handleStep.test.ts`, in a new
+`describe('handleStep parameter locks')` block. The
+`setupAndTrigger` helper needs a new optional
+`parameterLocks` field — add it to the options type and
+wire it through:
+
+In the `setupAndTrigger` options type (line 39), add:
+
+```typescript
+    parameterLocks?: Partial<
+      Record<TrackId, Record<number, StepLocks>>
+    >;
+```
+
+In the destructuring (line 51), add:
+
+```typescript
+    parameterLocks = {},
+```
+
+After gains are set (around line 95), add the lock setup
+using the new `setParameterLock` action:
+
+```typescript
+    for (const [tid, steps] of
+      Object.entries(parameterLocks)) {
+      for (const [si, locks] of
+        Object.entries(steps)) {
+        await act(async () => {
+          result.current.actions.setParameterLock(
+            tid as TrackId,
+            Number(si),
+            locks
+          );
+        });
+      }
+    }
+```
+
+Then add the test cases:
+
+```typescript
+import type { StepLocks } from '../app/types';
+
+describe('handleStep parameter locks', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+    mockStop.mockClear();
+  });
+
+  it('gain lock overrides mixer gain', async () => {
+    const { mockPlaySound: mp } =
+      await setupAndTrigger({
+        activeTracks: ['bd'],
+        gains: { bd: 1.0 },
+        parameterLocks: {
+          bd: { 0: { gain: 0.5 } },
+        },
+      });
+    expect(mp).toHaveBeenCalledTimes(1);
+    // gain = 0.5^3 = 0.125
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.125);
+  });
+
+  it('accent stacks on locked gain', async () => {
+    const { mockPlaySound: mp } =
+      await setupAndTrigger({
+        activeTracks: ['bd'],
+        accentStep0: true,
+        gains: { bd: 1.0 },
+        parameterLocks: {
+          bd: { 0: { gain: 0.5 } },
+        },
+      });
+    expect(mp).toHaveBeenCalledTimes(1);
+    // gain = 0.5^3 * 1.5 = 0.1875
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.1875);
+  });
+
+  it('no lock falls back to mixer gain', async () => {
+    const { mockPlaySound: mp } =
+      await setupAndTrigger({
+        activeTracks: ['bd'],
+        gains: { bd: 0.8 },
+        parameterLocks: {},
+      });
+    expect(mp).toHaveBeenCalledTimes(1);
+    // gain = 0.8^3 = 0.512
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.512);
+  });
+
+  it('gain lock = 0 produces silence', async () => {
+    const { mockPlaySound: mp } =
+      await setupAndTrigger({
+        activeTracks: ['bd'],
+        gains: { bd: 1.0 },
+        parameterLocks: {
+          bd: { 0: { gain: 0 } },
+        },
+      });
+    expect(mp).toHaveBeenCalledTimes(1);
+    // gain = 0^3 = 0
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/__tests__/handleStep.test.ts`
+Expected: FAIL — `setParameterLock` not defined.
+
+- [ ] **Step 3: Add `setParameterLock` and `clearParameterLock` actions to SequencerContext**
+
+Add after `clearTrigCondition` (after line 919):
+
+```typescript
+  const setParameterLock = useCallback(
+    (
+      trackId: TrackId,
+      stepIndex: number,
+      locks: StepLocks
+    ) => {
+      setConfig(prev => ({
+        ...prev,
+        parameterLocks: {
+          ...prev.parameterLocks,
+          [trackId]: {
+            ...prev.parameterLocks[trackId],
+            [stepIndex]: locks,
+          },
+        },
+      }));
+    },
+    []
+  );
+
+  const clearParameterLock = useCallback(
+    (trackId: TrackId, stepIndex: number) => {
+      setConfig(prev => {
+        const trackLocks = {
+          ...prev.parameterLocks[trackId],
+        };
+        delete trackLocks[stepIndex];
+        const newParameterLocks = {
+          ...prev.parameterLocks,
+        };
+        if (
+          Object.keys(trackLocks).length === 0
+        ) {
+          delete newParameterLocks[trackId];
+        } else {
+          newParameterLocks[trackId] = trackLocks;
+        }
+        return {
+          ...prev,
+          parameterLocks: newParameterLocks,
+        };
+      });
+    },
+    []
+  );
+```
+
+Add `StepLocks` to the import from `'./types'`.
+
+Export these actions in the actions object (around line 957):
+
+```typescript
+      setParameterLock,
+      clearParameterLock,
+```
+
+Add them to the `Actions` interface (around line 106):
+
+```typescript
+  setParameterLock: (
+    trackId: TrackId,
+    stepIndex: number,
+    locks: StepLocks
+  ) => void;
+  clearParameterLock: (
+    trackId: TrackId,
+    stepIndex: number
+  ) => void;
+```
+
+- [ ] **Step 4: Update `handleStep` gain calculation**
+
+In `handleStep` (around line 401), replace:
+
+```typescript
+          const cubic = st.gain ** 3;
+          const gain =
+            isAccented ? cubic * 1.5 : cubic;
+```
+
+With:
+
+```typescript
+          const locks =
+            cfg.parameterLocks
+              ?.[track.id]?.[effectiveStep];
+          const baseGain =
+            locks?.gain ?? st.gain;
+          const cubic = baseGain ** 3;
+          const gain =
+            isAccented ? cubic * 1.5 : cubic;
+```
+
+- [ ] **Step 5: Wire `parameterLocks` through state operations**
+
+**`setPattern`** (line 489-494) — add `parameterLocks`:
+
+```typescript
+      return {
+        ...prev,
+        steps: newSteps,
+        trigConditions:
+          pattern.trigConditions ?? {},
+        parameterLocks:
+          pattern.parameterLocks ?? {},
+      };
+```
+
+Note: The spec lists `clearPattern` as needing
+`parameterLocks` reset. No separate `clearPattern` action
+exists — `clearAll` serves this role.
+
+**`clearAll`** (line 760-767) — add `parameterLocks: {}`:
+
+```typescript
+      return {
+        ...prev,
+        steps: newSteps,
+        trackLengths: newTrackLengths,
+        mixer: newMixer,
+        swing: 0,
+        trigConditions: {},
+        parameterLocks: {},
+      };
+```
+
+**`clearTrack`** (line 775-800) — delete parameterLocks
+for the track:
+
+After `delete newTrigConditions[trackId];` (line 781),
+add:
+
+```typescript
+        const newParameterLocks = {
+          ...prev.parameterLocks,
+        };
+        delete newParameterLocks[trackId];
+```
+
+Add `parameterLocks: newParameterLocks` to the return
+object.
+
+**`setPatternLength`** (line 596-635) — prune locks:
+
+After the trig conditions pruning loop (line 614-627),
+add the same pattern for parameterLocks. First, copy
+`prev.parameterLocks` into `newParamLocks` alongside
+`newTrigConds` (line 596):
+
+```typescript
+        const newParamLocks = {
+          ...prev.parameterLocks,
+        };
+```
+
+Then in the per-track loop, after the trig condition
+pruning:
+
+```typescript
+          const trackLocks = newParamLocks[id];
+          if (trackLocks) {
+            const pruned: Record<
+              number, StepLocks
+            > = {};
+            for (const [k, v] of
+              Object.entries(trackLocks)) {
+              if (Number(k) < len) {
+                pruned[Number(k)] = v;
+              }
+            }
+            newParamLocks[id] = pruned;
+          }
+```
+
+Add `parameterLocks: newParamLocks` to the return object.
+
+**`setTrackLength`** (line 642-688) — prune locks:
+
+After the trig conditions pruning (line 657-675), add:
+
+```typescript
+        const trackLocks =
+          prev.parameterLocks[trackId];
+        let newParameterLocks =
+          prev.parameterLocks;
+        if (trackLocks) {
+          const pruned: Record<
+            number, StepLocks
+          > = {};
+          for (const [k, v] of
+            Object.entries(trackLocks)) {
+            if (Number(k) < clamped) {
+              pruned[Number(k)] = v;
+            }
+          }
+          newParameterLocks = {
+            ...prev.parameterLocks,
+            [trackId]: pruned,
+          };
+        }
+```
+
+Add `parameterLocks: newParameterLocks` to the return
+object.
+
+- [ ] **Step 6: Run handleStep tests**
+
+Run: `npm test -- --run src/__tests__/handleStep.test.ts`
+Expected: All PASS.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/app/SequencerContext.tsx \
+  src/__tests__/handleStep.test.ts
+git commit -m "Add parameterLock actions and gain override"
+```
+
+---
+
+## Task 5: Rename TrigConditionPopover → StepPopover
+
+**Files:**
+- Rename: `src/app/TrigConditionPopover.tsx` → `src/app/StepPopover.tsx`
+- Modify: `src/app/StepGrid.tsx:10-11,175`
+- Rename: `src/__tests__/TrigConditionPopover.test.tsx` → `src/__tests__/StepPopover.test.tsx`
+
+- [ ] **Step 1: Rename files**
+
+```bash
+git mv src/app/TrigConditionPopover.tsx \
+  src/app/StepPopover.tsx
+git mv src/__tests__/TrigConditionPopover.test.tsx \
+  src/__tests__/StepPopover.test.tsx
+```
+
+- [ ] **Step 2: Update component name in StepPopover.tsx**
+
+Replace `TrigConditionPopover` with `StepPopover` in:
+- The `interface` name (line 12)
+- The function name (line 32)
+- The `export default function` declaration
+
+Update the aria-label from `"Trig conditions"` to
+`"Step editor"` (line 169).
+
+- [ ] **Step 3: Update imports in StepGrid.tsx**
+
+Replace (lines 10-11):
+
+```typescript
+import StepPopover from './StepPopover';
+```
+
+Replace `<TrigConditionPopover` with `<StepPopover`
+(line 175).
+
+- [ ] **Step 4: Update test file imports**
+
+In `src/__tests__/StepPopover.test.tsx`, replace all
+`TrigConditionPopover` with `StepPopover` and update
+the import path.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add -A
+git commit -m "Rename TrigConditionPopover to StepPopover"
+```
+
+---
+
+## Task 6: StepPopover — Gain Lock UI
+
+**Files:**
+- Modify: `src/app/StepPopover.tsx`
+- Modify: `src/__tests__/StepPopover.test.tsx`
+
+- [ ] **Step 1: Write failing tests for the locks section**
+
+Add to `src/__tests__/StepPopover.test.tsx`:
+
+```typescript
+import type { StepLocks } from '../app/types';
+
+describe('StepPopover gain lock', () => {
+  it('renders gain slider in locks section', () => {
+    render(<StepPopover {...base} />);
+    expect(screen.getByText('Locks'))
+      .toBeTruthy();
+    expect(
+      screen.getByRole('slider', { name: 'Gain' })
+    ).toBeTruthy();
+  });
+
+  it('slider starts at 100 when no lock exists',
+    () => {
+      render(<StepPopover {...base} />);
+      const slider = screen.getByRole(
+        'slider', { name: 'Gain' }
+      );
+      expect(slider.getAttribute('aria-valuenow'))
+        .toBe('100');
+    }
+  );
+
+  it('slider shows current lock value', () => {
+    render(
+      <StepPopover
+        {...base}
+        locks={{ gain: 0.6 }}
+      />
+    );
+    const slider = screen.getByRole(
+      'slider', { name: 'Gain' }
+    );
+    expect(slider.getAttribute('aria-valuenow'))
+      .toBe('60');
+  });
+
+  it('Reset locks button clears locks', async () => {
+    const { actions } = setupMockActions();
+    render(
+      <StepPopover
+        {...base}
+        locks={{ gain: 0.5 }}
+      />
+    );
+    const resetBtn = screen.getByText('Reset locks');
+    fireEvent.click(resetBtn);
+    expect(actions.clearParameterLock)
+      .toHaveBeenCalledWith('bd', 0);
+  });
+});
+```
+
+Note: The test setup mocks `useSequencer`. Add
+`setParameterLock: vi.fn()` and
+`clearParameterLock: vi.fn()` to the mocked actions
+object (follow the existing pattern where
+`setTrigCondition` and `clearTrigCondition` are mocked).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/__tests__/StepPopover.test.tsx`
+Expected: FAIL — no "Locks" heading, no gain slider.
+
+- [ ] **Step 3: Add `locks` prop and gain slider to StepPopover**
+
+Add to `StepPopoverProps` interface:
+
+```typescript
+  locks?: StepLocks;
+```
+
+Add import for `RangeSlider` and `StepLocks`:
+
+```typescript
+import RangeSlider from './RangeSlider';
+import type {
+  StepConditions, StepLocks, TrackId,
+} from './types';
+```
+
+Add state for gain (after fillValue state):
+
+```typescript
+  const [gainValue, setGainValue] = useState(
+    locks?.gain !== undefined
+      ? Math.round(locks.gain * 100)
+      : 100
+  );
+  const gainTouched = useRef(false);
+```
+
+Add gain change handler (after handleFillChange):
+
+```typescript
+  const handleGainChange = useCallback(
+    (v: number) => {
+      setGainValue(v);
+      gainTouched.current = true;
+      actions.setParameterLock(
+        trackId,
+        stepIndex,
+        { gain: v / 100 }
+      );
+    },
+    [actions, trackId, stepIndex]
+  );
+```
+
+Add the locks section JSX after the Fill section's
+closing `</div>` and before the popover's closing
+`</div>`:
+
+```tsx
+      {/* Divider */}
+      <div className="border-t border-neutral-700" />
+
+      {/* Locks section */}
+      <div className={
+        'flex items-center justify-between'
+      }>
+        <div className={
+          'text-xs font-bold uppercase'
+          + ' tracking-wider text-neutral-400'
+        }>
+          Locks
+        </div>
+        <button
+          onClick={() => {
+            actions.clearParameterLock(
+              trackId, stepIndex
+            );
+            setGainValue(100);
+            gainTouched.current = false;
+          }}
+          disabled={locks === undefined}
+          className={
+            'text-[11px] px-1.5 py-0.5 rounded'
+            + ' border transition-colors'
+            + (locks !== undefined
+              ? ' text-neutral-400'
+                + ' hover:text-neutral-200'
+                + ' border-neutral-700'
+                + ' hover:bg-neutral-800'
+              : ' text-neutral-700'
+                + ' border-neutral-800'
+                + ' cursor-default')
+          }
+        >
+          Reset locks
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Gain
+        </div>
+        <RangeSlider
+          value={gainValue}
+          min={0}
+          max={100}
+          onChange={handleGainChange}
+          label="Gain"
+        />
+      </div>
+```
+
+- [ ] **Step 4: Pass `locks` prop from StepGrid**
+
+In `src/app/StepGrid.tsx`, update the `<StepPopover>`
+rendering (around line 175) to pass `locks`:
+
+```tsx
+        <StepPopover
+          trackId={openPopover.trackId}
+          stepIndex={openPopover.stepIndex}
+          conditions={
+            config.trigConditions[
+              openPopover.trackId
+            ]?.[openPopover.stepIndex]
+          }
+          locks={
+            config.parameterLocks[
+              openPopover.trackId
+            ]?.[openPopover.stepIndex]
+          }
+          anchorRect={openPopover.anchorRect}
+          onClose={() => setOpenPopover(null)}
+          scrollContainerRef={scrollContainerRef}
+        />
+```
+
+- [ ] **Step 5: Run StepPopover tests**
+
+Run: `npm test -- --run src/__tests__/StepPopover.test.tsx`
+Expected: All PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/app/StepPopover.tsx src/app/StepGrid.tsx \
+  src/__tests__/StepPopover.test.tsx
+git commit -m "Add gain lock slider to StepPopover"
+```
+
+---
+
+## Task 7: StepButton — Opacity Indicator and Popover on Inactive Steps
+
+**Files:**
+- Modify: `src/app/StepButton.tsx:49-59,150`
+- Modify: `src/__tests__/StepButton.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `src/__tests__/StepButton.test.tsx`:
+
+```typescript
+describe('StepButton gain lock opacity', () => {
+  it('active step with gain lock shows opacity',
+    () => {
+      render(
+        <StepButton
+          {...defaultProps}
+          isActive={true}
+          gainLock={0.5}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('0.5');
+    }
+  );
+
+  it('active step with gain lock 0 shows min opacity',
+    () => {
+      render(
+        <StepButton
+          {...defaultProps}
+          isActive={true}
+          gainLock={0}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('0.2');
+    }
+  );
+
+  it('inactive step with gain lock has no opacity',
+    () => {
+      render(
+        <StepButton
+          {...defaultProps}
+          isActive={false}
+          gainLock={0.3}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('');
+    }
+  );
+
+  it('active step without gain lock has no opacity',
+    () => {
+      render(
+        <StepButton
+          {...defaultProps}
+          isActive={true}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('');
+    }
+  );
+});
+
+describe('StepButton popover on inactive steps',
+  () => {
+    it('opens popover on inactive step right-click',
+      () => {
+        const onOpenPopover = vi.fn();
+        render(
+          <StepButton
+            {...defaultProps}
+            isActive={false}
+            onOpenPopover={onOpenPopover}
+          />
+        );
+        const btn = screen.getByRole('button');
+        fireEvent.contextMenu(btn);
+        expect(onOpenPopover).toHaveBeenCalled();
+      }
+    );
+  }
+);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/__tests__/StepButton.test.tsx`
+Expected: FAIL — no `gainLock` prop, popover blocked on
+inactive.
+
+- [ ] **Step 3: Add `gainLock` prop and opacity style**
+
+In `StepButtonProps` interface, add:
+
+```typescript
+  gainLock?: number;
+```
+
+In the button's `style` prop (line 150), replace:
+
+```typescript
+      style={{ touchAction: 'manipulation' }}
+```
+
+With:
+
+```typescript
+      style={{
+        touchAction: 'manipulation',
+        ...(
+          isActive && gainLock !== undefined
+            ? {
+                opacity: Math.max(0.2, gainLock),
+              }
+            : {}
+        ),
+      }}
+```
+
+- [ ] **Step 4: Remove `isActive` guard from `openPopover`**
+
+In `openPopover` callback (line 51), change:
+
+```typescript
+      if (!isActive || !onOpenPopover) return;
+```
+
+To:
+
+```typescript
+      if (!onOpenPopover) return;
+```
+
+Also remove `isActive` from the dependency array (line 59).
+
+- [ ] **Step 5: Pass `gainLock` from StepGrid → TrackRow → StepButton**
+
+**StepGrid.tsx** — add prop to `<TrackRow>` (after the
+`trigConditions` prop, around line 161):
+
+```tsx
+            parameterLocks={
+              config.parameterLocks[track.id]
+            }
+```
+
+**TrackRow.tsx** — add to `TrackRowProps` interface (after
+`trigConditions`, around line 146):
+
+```typescript
+  parameterLocks?: Record<number, StepLocks>;
+```
+
+Add `StepLocks` to the import from `'./types'`.
+
+Add `parameterLocks` to the destructured props (after
+`trigConditions`, around line 183).
+
+In the `<StepButton>` render (around line 403), add
+after the `conditions` prop:
+
+```tsx
+                    gainLock={
+                      parameterLocks?.[globalIdx]
+                        ?.gain
+                    }
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/app/StepButton.tsx src/app/StepGrid.tsx \
+  src/app/TrackRow.tsx \
+  src/__tests__/StepButton.test.tsx
+git commit -m "Add gain lock opacity and inactive popover"
+```
+
+---
+
+## Task 8: Lint, Build, and Browser Verification
+
+**Files:** None new — verification only.
+
+- [ ] **Step 1: Run linter**
+
+Run: `npm run lint`
+Expected: Zero errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test -- --run`
+Expected: All PASS.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: Clean build, no errors.
+
+- [ ] **Step 4: Browser test**
+
+Start dev server: `npm run dev`
+
+Test in browser:
+1. Right-click a step → popover shows "Locks" section
+   with gain slider at 100%
+2. Drag gain slider to ~50% → step button dims to ~50%
+   opacity
+3. Play the pattern → the gain-locked step plays quieter
+4. Right-click an inactive step → popover opens
+5. Set gain lock on inactive step → no visual change
+6. Activate the step → opacity indicator appears
+7. Click "Reset locks" → opacity returns to full
+8. Share URL → reload → gain locks preserved
+
+- [ ] **Step 5: Stop dev server**
+
+- [ ] **Step 6: Final commit if any lint fixes were needed**
+
+```
+git add -A
+git commit -m "Fix lint issues"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `npm run lint` — zero errors
+- [ ] `npm test -- --run` — all pass
+- [ ] `npm run build` — clean static export
+- [ ] Browser: gain slider in popover works
+- [ ] Browser: opacity indicator on active steps
+- [ ] Browser: popover opens on inactive steps
+- [ ] Browser: URL sharing preserves gain locks
+- [ ] Browser: accent stacks on gain-locked steps
+- [ ] Browser: playback glow visible on dim steps

--- a/src/__tests__/RangeSlider.test.tsx
+++ b/src/__tests__/RangeSlider.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from
+  '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RangeSlider from '../app/RangeSlider';
+
+describe('RangeSlider', () => {
+  it('renders with current value', () => {
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('50%')).toBeTruthy();
+  });
+
+  it('clamps at min on Home key', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'Home' });
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('clamps at max on End key', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'End' });
+    expect(onChange).toHaveBeenCalledWith(100);
+  });
+
+  it('respects custom min (e.g., 1 for probability)',
+    () => {
+      const onChange = vi.fn();
+      render(
+        <RangeSlider
+          value={5} min={1} max={100}
+          onChange={onChange}
+        />
+      );
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'Home' });
+      expect(onChange).toHaveBeenCalledWith(1);
+    }
+  );
+
+  it('arrow key increments by 1', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(
+      slider, { key: 'ArrowRight' }
+    );
+    expect(onChange).toHaveBeenCalledWith(51);
+  });
+
+  it('shift+arrow increments by 10', () => {
+    const onChange = vi.fn();
+    render(
+      <RangeSlider
+        value={50} min={0} max={100}
+        onChange={onChange}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(
+      slider,
+      { key: 'ArrowRight', shiftKey: true }
+    );
+    expect(onChange).toHaveBeenCalledWith(60);
+  });
+
+  it('sets correct aria attributes', () => {
+    render(
+      <RangeSlider
+        value={42} min={0} max={100}
+        onChange={vi.fn()} label="Gain"
+      />
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider.getAttribute('aria-valuemin'))
+      .toBe('0');
+    expect(slider.getAttribute('aria-valuemax'))
+      .toBe('100');
+    expect(slider.getAttribute('aria-valuenow'))
+      .toBe('42');
+    expect(slider.getAttribute('aria-label'))
+      .toBe('Gain');
+  });
+});

--- a/src/__tests__/StepButton.test.tsx
+++ b/src/__tests__/StepButton.test.tsx
@@ -203,20 +203,22 @@ describe('StepButton interactions', () => {
     }
   );
 
-  it('right-click on inactive: no popover', () => {
-    const onOpen = vi.fn();
-    render(
-      <StepButton
-        {...base}
-        isActive={false}
-        onOpenPopover={onOpen}
-      />
-    );
-    fireEvent.contextMenu(
-      screen.getByRole('button')
-    );
-    expect(onOpen).not.toHaveBeenCalled();
-  });
+  it('right-click on inactive: calls onOpenPopover',
+    () => {
+      const onOpen = vi.fn();
+      render(
+        <StepButton
+          {...base}
+          isActive={false}
+          onOpenPopover={onOpen}
+        />
+      );
+      fireEvent.contextMenu(
+        screen.getByRole('button')
+      );
+      expect(onOpen).toHaveBeenCalled();
+    }
+  );
 
   it('click still toggles', () => {
     const toggle = vi.fn();
@@ -230,4 +232,79 @@ describe('StepButton interactions', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(toggle).toHaveBeenCalled();
   });
+});
+
+describe('StepButton gain lock opacity', () => {
+  it('active step with gain lock shows opacity',
+    () => {
+      render(
+        <StepButton
+          {...base}
+          isActive={true}
+          gainLock={0.5}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('0.5');
+    }
+  );
+
+  it('active step with gain lock 0 shows min opacity',
+    () => {
+      render(
+        <StepButton
+          {...base}
+          isActive={true}
+          gainLock={0}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('0.2');
+    }
+  );
+
+  it('inactive step with gain lock has no opacity',
+    () => {
+      render(
+        <StepButton
+          {...base}
+          isActive={false}
+          gainLock={0.3}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('');
+    }
+  );
+
+  it('active step without gain lock has no opacity',
+    () => {
+      render(
+        <StepButton
+          {...base}
+          isActive={true}
+        />
+      );
+      const btn = screen.getByRole('button');
+      expect(btn.style.opacity).toBe('');
+    }
+  );
+});
+
+describe('StepButton popover on inactive steps', () => {
+  it('opens popover on inactive step right-click',
+    () => {
+      const onOpenPopover = vi.fn();
+      render(
+        <StepButton
+          {...base}
+          isActive={false}
+          onOpenPopover={onOpenPopover}
+        />
+      );
+      const btn = screen.getByRole('button');
+      fireEvent.contextMenu(btn);
+      expect(onOpenPopover).toHaveBeenCalled();
+    }
+  );
 });

--- a/src/__tests__/StepPopover.test.tsx
+++ b/src/__tests__/StepPopover.test.tsx
@@ -2,8 +2,7 @@ import { render, screen, fireEvent }
   from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach }
   from 'vitest';
-import TrigConditionPopover
-  from '../app/TrigConditionPopover';
+import StepPopover from '../app/StepPopover';
 
 const mockSet = vi.fn();
 const mockClear = vi.fn();
@@ -24,7 +23,7 @@ const base = {
   onClose: vi.fn(),
 };
 
-describe('TrigConditionPopover', () => {
+describe('StepPopover', () => {
   beforeEach(() => {
     mockSet.mockClear();
     mockClear.mockClear();
@@ -33,7 +32,7 @@ describe('TrigConditionPopover', () => {
 
   it('header shows step number + track abbrev',
     () => {
-      render(<TrigConditionPopover {...base} />);
+      render(<StepPopover {...base} />);
       expect(
         screen.getByText(/Step 4/)
       ).toBeTruthy();
@@ -44,7 +43,7 @@ describe('TrigConditionPopover', () => {
   );
 
   it('slider defaults to 100', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     expect(
       screen.getByRole('slider')
         .getAttribute('aria-valuenow')
@@ -52,7 +51,7 @@ describe('TrigConditionPopover', () => {
   });
 
   it('cycle defaults to 1:1', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     const sel = screen.getByRole(
       'combobox'
     ) as HTMLSelectElement;
@@ -61,7 +60,7 @@ describe('TrigConditionPopover', () => {
 
   it('changing cycle calls setTrigCondition',
     () => {
-      render(<TrigConditionPopover {...base} />);
+      render(<StepPopover {...base} />);
       fireEvent.change(
         screen.getByRole('combobox'),
         { target: { value: '2:4' } }
@@ -75,7 +74,7 @@ describe('TrigConditionPopover', () => {
   it('all defaults calls clearTrigCondition',
     () => {
       render(
-        <TrigConditionPopover
+        <StepPopover
           {...base}
           conditions={{ probability: 50 }}
         />
@@ -90,7 +89,7 @@ describe('TrigConditionPopover', () => {
   );
 
   it('Escape calls onClose', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     fireEvent.keyDown(
       document, { key: 'Escape' }
     );
@@ -103,7 +102,7 @@ describe('TrigConditionPopover', () => {
     render(
       <div>
         <div data-testid="outside">outside</div>
-        <TrigConditionPopover
+        <StepPopover
           {...base}
           onClose={onClose}
         />
@@ -118,7 +117,7 @@ describe('TrigConditionPopover', () => {
   });
 
   it('fill section renders three options', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(3);
     expect(radios[0].textContent).toBe('None');
@@ -127,7 +126,7 @@ describe('TrigConditionPopover', () => {
   });
 
   it('selecting FILL sets fill condition', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     const fillBtn = screen.getByRole('radio', {
       name: /^FILL$/,
     });
@@ -138,7 +137,7 @@ describe('TrigConditionPopover', () => {
   });
 
   it('selecting !FILL sets fill condition', () => {
-    render(<TrigConditionPopover {...base} />);
+    render(<StepPopover {...base} />);
     const nfillBtn = screen.getByRole('radio', {
       name: /^!FILL$/,
     });
@@ -150,7 +149,7 @@ describe('TrigConditionPopover', () => {
 
   it('selecting None removes fill', () => {
     render(
-      <TrigConditionPopover
+      <StepPopover
         {...base}
         conditions={{ fill: 'fill' }}
       />
@@ -166,7 +165,7 @@ describe('TrigConditionPopover', () => {
 
   it('pre-populates fill from conditions', () => {
     render(
-      <TrigConditionPopover
+      <StepPopover
         {...base}
         conditions={{ fill: '!fill' }}
       />
@@ -182,7 +181,7 @@ describe('TrigConditionPopover', () => {
   it('pre-populates from existing conditions',
     () => {
       render(
-        <TrigConditionPopover
+        <StepPopover
           {...base}
           conditions={{
             probability: 75,

--- a/src/__tests__/StepPopover.test.tsx
+++ b/src/__tests__/StepPopover.test.tsx
@@ -6,12 +6,16 @@ import StepPopover from '../app/StepPopover';
 
 const mockSet = vi.fn();
 const mockClear = vi.fn();
+const mockSetLock = vi.fn();
+const mockClearLock = vi.fn();
 
 vi.mock('../app/SequencerContext', () => ({
   useSequencer: () => ({
     actions: {
       setTrigCondition: mockSet,
       clearTrigCondition: mockClear,
+      setParameterLock: mockSetLock,
+      clearParameterLock: mockClearLock,
     },
   }),
 }));
@@ -27,6 +31,8 @@ describe('StepPopover', () => {
   beforeEach(() => {
     mockSet.mockClear();
     mockClear.mockClear();
+    mockSetLock.mockClear();
+    mockClearLock.mockClear();
     base.onClose.mockClear();
   });
 
@@ -45,7 +51,7 @@ describe('StepPopover', () => {
   it('slider defaults to 100', () => {
     render(<StepPopover {...base} />);
     expect(
-      screen.getByRole('slider')
+      screen.getByRole('slider', { name: 'Probability' })
         .getAttribute('aria-valuenow')
     ).toBe('100');
   });
@@ -80,7 +86,8 @@ describe('StepPopover', () => {
         />
       );
       fireEvent.keyDown(
-        screen.getByRole('slider'), { key: 'End' }
+        screen.getByRole('slider', { name: 'Probability' }),
+        { key: 'End' }
       );
       expect(mockClear).toHaveBeenCalledWith(
         'bd', 3
@@ -190,7 +197,7 @@ describe('StepPopover', () => {
         />
       );
       expect(
-        screen.getByRole('slider')
+        screen.getByRole('slider', { name: 'Probability' })
           .getAttribute('aria-valuenow')
       ).toBe('75');
       const sel2 = screen.getByRole(
@@ -199,4 +206,55 @@ describe('StepPopover', () => {
       expect(sel2.value).toBe('1:3');
     }
   );
+});
+
+describe('StepPopover gain lock', () => {
+  beforeEach(() => {
+    mockSet.mockClear();
+    mockClear.mockClear();
+    mockSetLock.mockClear();
+    mockClearLock.mockClear();
+    base.onClose.mockClear();
+  });
+
+  it('renders gain slider in locks section', () => {
+    render(<StepPopover {...base} />);
+    expect(screen.getByText('Locks')).toBeTruthy();
+    expect(
+      screen.getByRole('slider', { name: 'Gain' })
+    ).toBeTruthy();
+  });
+
+  it('slider starts at 100 when no lock exists', () => {
+    render(<StepPopover {...base} />);
+    const slider = screen.getByRole(
+      'slider', { name: 'Gain' }
+    );
+    expect(
+      slider.getAttribute('aria-valuenow')
+    ).toBe('100');
+  });
+
+  it('slider shows current lock value', () => {
+    render(
+      <StepPopover {...base} locks={{ gain: 0.6 }} />
+    );
+    const slider = screen.getByRole(
+      'slider', { name: 'Gain' }
+    );
+    expect(
+      slider.getAttribute('aria-valuenow')
+    ).toBe('60');
+  });
+
+  it('Reset locks button clears locks', () => {
+    render(
+      <StepPopover {...base} locks={{ gain: 0.5 }} />
+    );
+    const resetBtn = screen.getByText('Reset locks');
+    fireEvent.click(resetBtn);
+    expect(mockClearLock).toHaveBeenCalledWith(
+      'bd', 3
+    );
+  });
 });

--- a/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
+++ b/src/__tests__/__snapshots__/configCodec.golden.test.ts.snap
@@ -78,6 +78,7 @@ exports[`golden-file tests > defaultConfig() snapshot 1`] = `
       "isSolo": false,
     },
   },
+  "parameterLocks": {},
   "patternLength": 16,
   "steps": {
     "ac": "0000000000000000",

--- a/src/__tests__/configCodec.golden.test.ts
+++ b/src/__tests__/configCodec.golden.test.ts
@@ -66,6 +66,7 @@ function goldenConfigV1Decoded(): SequencerConfig {
     mixer,
     swing: 0,
     trigConditions: {},
+    parameterLocks: {},
   };
 }
 
@@ -103,6 +104,7 @@ function goldenConfigV2Decoded(): SequencerConfig {
     mixer,
     swing: 0,
     trigConditions: {},
+    parameterLocks: {},
   };
 }
 
@@ -139,6 +141,7 @@ function goldenConfigV2(): SequencerConfig {
     mixer,
     swing: 0,
     trigConditions: {},
+    parameterLocks: {},
   };
 }
 

--- a/src/__tests__/configCodec.test.ts
+++ b/src/__tests__/configCodec.test.ts
@@ -570,6 +570,109 @@ describe('fill condition validation', () => {
   );
 });
 
+describe('parameterLocks validation', () => {
+  it('round-trips parameterLocks through encode/decode',
+    async () => {
+      const config = makeConfig({
+        parameterLocks: {
+          bd: { 0: { gain: 0.5 }, 3: { gain: 0.8 } },
+          sd: { 7: { gain: 0.2 } },
+        },
+      });
+      const hash = await encodeConfig(config);
+      const decoded = await decodeConfig(hash);
+      expect(decoded.parameterLocks).toEqual(
+        config.parameterLocks
+      );
+    }
+  );
+
+  it('defaults to {} when missing', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({});
+  });
+
+  it('clamps gain to [0, 1]', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        bd: { 0: { gain: 2.5 }, 1: { gain: -0.3 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks.bd?.[0]?.gain).toBe(1);
+    expect(decoded.parameterLocks.bd?.[1]?.gain).toBe(0);
+  });
+
+  it('drops invalid track IDs', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        zz: { 0: { gain: 0.5 } },
+        bd: { 0: { gain: 0.7 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.7 } },
+    });
+  });
+
+  it('drops ac track entries', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        ac: { 0: { gain: 0.5 } },
+        bd: { 0: { gain: 0.7 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.7 } },
+    });
+  });
+
+  it('drops step indices >= 64', async () => {
+    const hash = await encodeRaw({
+      ...defaultConfig(),
+      parameterLocks: {
+        bd: { 0: { gain: 0.5 }, 99: { gain: 0.8 } },
+      },
+    });
+    const decoded = await decodeConfig(hash);
+    expect(decoded.parameterLocks).toEqual({
+      bd: { 0: { gain: 0.5 } },
+    });
+  });
+
+  it('strips empty parameterLocks from encoded output',
+    async () => {
+      const config = makeConfig({
+        parameterLocks: {},
+      });
+      const hash = await encodeConfig(config);
+      // Decode raw JSON to inspect
+      const bytes = Uint8Array.from(
+        atob(
+          hash.replace(/-/g, '+').replace(/_/g, '/')
+            + '='.repeat((4 - (hash.length % 4)) % 4)
+        ),
+        c => c.charCodeAt(0)
+      );
+      const stream = new Blob([bytes]).stream()
+        .pipeThrough(
+          new DecompressionStream('deflate-raw')
+        );
+      const json = await new Response(stream).text();
+      const parsed = JSON.parse(json);
+      expect(parsed.parameterLocks).toBeUndefined();
+    }
+  );
+});
+
 describe('validateMixer', () => {
   it('negative gain clamped to 0', async () => {
     const config = defaultConfig();

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useSequencer } from '../app/SequencerContext';
 import { TRACK_IDS } from '../app/types';
-import type { TrackId } from '../app/types';
+import type { TrackId, StepLocks } from '../app/types';
 import patternsData from '../app/data/patterns.json';
 import type { Pattern } from '../app/types';
 import { TestWrapper } from './helpers/sequencer-wrapper';
@@ -41,6 +41,9 @@ async function setupAndTrigger(
     soloTracks?: TrackId[];
     muteTracks?: TrackId[];
     gains?: Partial<Record<TrackId, number>>;
+    parameterLocks?: Partial<
+      Record<TrackId, Record<number, StepLocks>>
+    >;
   } = {}
 ) {
   const {
@@ -49,6 +52,7 @@ async function setupAndTrigger(
     soloTracks = [],
     muteTracks = [],
     gains = {},
+    parameterLocks = {},
   } = options;
 
   const { result } = renderSequencer();
@@ -91,6 +95,17 @@ async function setupAndTrigger(
     }
     for (const [id, value] of Object.entries(gains)) {
       result.current.actions.setGain(id as TrackId, value);
+    }
+    for (const [trackId, stepMap] of
+      Object.entries(parameterLocks)) {
+      for (const [stepIndex, locks] of
+        Object.entries(stepMap as Record<number, StepLocks>)) {
+        result.current.actions.setParameterLock(
+          trackId as TrackId,
+          Number(stepIndex),
+          locks
+        );
+      }
     }
   });
 
@@ -732,6 +747,32 @@ describe('trig conditions in handleStep', () => {
     }
   );
 
+  it('clearTrack removes parameterLocks for track',
+    async () => {
+      const { result } = renderSequencer();
+
+      await act(async () => {
+        result.current.actions.setParameterLock(
+          'bd', 0, { gain: 0.5 }
+        );
+      });
+
+      expect(
+        result.current.meta.config
+          .parameterLocks.bd?.[0]
+      ).toEqual({ gain: 0.5 });
+
+      await act(async () => {
+        result.current.actions.clearTrack('bd');
+      });
+
+      expect(
+        result.current.meta.config
+          .parameterLocks.bd
+      ).toBeUndefined();
+    }
+  );
+
   it('mute resets cycle count for that track',
     async () => {
       const { result } = renderSequencer();
@@ -797,4 +838,67 @@ describe('trig conditions in handleStep', () => {
       expect(mockPlaySound).not.toHaveBeenCalled();
     }
   );
+});
+
+// -------------------------------------------------
+// handleStep parameter locks
+// -------------------------------------------------
+describe('handleStep parameter locks', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+    mockStop.mockClear();
+  });
+
+  it('gain lock overrides mixer gain', async () => {
+    // bd mixer gain = 1.0, but lock = 0.5
+    // Expected: 0.5^3 = 0.125
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      gains: { bd: 1.0 },
+      parameterLocks: { bd: { 0: { gain: 0.5 } } },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.125);
+  });
+
+  it('accent stacks on locked gain', async () => {
+    // bd mixer gain = 1.0, lock = 0.5, accented
+    // Expected: 0.5^3 * 1.5 = 0.1875
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      accentStep0: true,
+      gains: { bd: 1.0 },
+      parameterLocks: { bd: { 0: { gain: 0.5 } } },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.1875);
+  });
+
+  it('no lock falls back to mixer gain', async () => {
+    // bd mixer gain = 0.8, no lock
+    // Expected: 0.8^3 = 0.512
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      gains: { bd: 0.8 },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0.512);
+  });
+
+  it('gain lock = 0 produces silence', async () => {
+    // bd mixer gain = 1.0, lock = 0
+    // Expected: 0^3 = 0
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      gains: { bd: 1.0 },
+      parameterLocks: { bd: { 0: { gain: 0 } } },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const gainArg = mp.mock.calls[0][2];
+    expect(gainArg).toBeCloseTo(0);
+  });
 });

--- a/src/app/ProbabilitySlider.tsx
+++ b/src/app/ProbabilitySlider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useCallback, useEffect } from 'react';
+import RangeSlider from './RangeSlider';
 
 interface ProbabilitySliderProps {
   value: number;
@@ -8,132 +8,20 @@ interface ProbabilitySliderProps {
 }
 
 /**
- * Horizontal probability slider (1-100) with
- * pointer-capture drag and keyboard controls.
- *
- * Args:
- *   value: Current probability (1-100)
- *   onChange: Callback with new value
+ * Probability slider (1-100). Thin wrapper around
+ * RangeSlider.
  */
 export default function ProbabilitySlider({
   value,
   onChange,
 }: ProbabilitySliderProps) {
-  const trackRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<{
-    startX: number;
-    startValue: number;
-  } | null>(null);
-  const valueRef = useRef(value);
-  useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
-
-  const clamp = (v: number) =>
-    Math.max(1, Math.min(100, Math.round(v)));
-
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      (e.target as Element).setPointerCapture(
-        e.pointerId
-      );
-      dragRef.current = {
-        startX: e.clientX,
-        startValue: valueRef.current,
-      };
-    },
-    []
-  );
-
-  const onPointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!dragRef.current || !trackRef.current) {
-        return;
-      }
-      const width = trackRef.current.offsetWidth;
-      if (width === 0) return;
-      const delta =
-        ((e.clientX - dragRef.current.startX)
-          / width) * 99;
-      onChange(
-        clamp(dragRef.current.startValue + delta)
-      );
-    },
-    [onChange]
-  );
-
-  const release = useCallback(() => {
-    dragRef.current = null;
-  }, []);
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      const v = valueRef.current;
-      let next = v;
-      const step = e.shiftKey ? 10 : 1;
-      if (
-        e.key === 'ArrowRight'
-        || e.key === 'ArrowUp'
-      ) {
-        next = clamp(v + step);
-      } else if (
-        e.key === 'ArrowLeft'
-        || e.key === 'ArrowDown'
-      ) {
-        next = clamp(v - step);
-      } else if (e.key === 'Home') {
-        next = 1;
-      } else if (e.key === 'End') {
-        next = 100;
-      } else {
-        return;
-      }
-      e.preventDefault();
-      onChange(next);
-    },
-    [onChange]
-  );
-
-  const pct = ((value - 1) / 99) * 100;
-
   return (
-    <div className="flex items-center gap-2">
-      <div
-        ref={trackRef}
-        role="slider"
-        tabIndex={0}
-        aria-valuemin={1}
-        aria-valuemax={100}
-        aria-valuenow={value}
-        aria-label="Probability"
-        className={
-          'relative h-6 flex-1 rounded'
-          + ' bg-neutral-700 cursor-ew-resize'
-          + ' focus-visible:outline-none'
-          + ' focus-visible:ring-2'
-          + ' focus-visible:ring-orange-500'
-        }
-        style={{ touchAction: 'none' }}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={release}
-        onLostPointerCapture={release}
-        onKeyDown={onKeyDown}
-      >
-        <div
-          className={
-            'absolute inset-y-0 left-0 rounded'
-            + ' bg-orange-600'
-          }
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <span className={
-        'text-xs font-mono text-neutral-300'
-        + ' w-10 text-right tabular-nums'
-      }>
-        {value}%
-      </span>
-    </div>
+    <RangeSlider
+      value={value}
+      min={1}
+      max={100}
+      onChange={onChange}
+      label="Probability"
+    />
   );
 }

--- a/src/app/RangeSlider.tsx
+++ b/src/app/RangeSlider.tsx
@@ -40,8 +40,11 @@ export default function RangeSlider({
 
   const range = max - min;
 
-  const clamp = (v: number) =>
-    Math.max(min, Math.min(max, Math.round(v)));
+  const clamp = useCallback(
+    (v: number) =>
+      Math.max(min, Math.min(max, Math.round(v))),
+    [min, max]
+  );
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -70,7 +73,7 @@ export default function RangeSlider({
         clamp(dragRef.current.startValue + delta)
       );
     },
-    [onChange, range]
+    [onChange, range, clamp]
   );
 
   const release = useCallback(() => {
@@ -102,7 +105,7 @@ export default function RangeSlider({
       e.preventDefault();
       onChange(next);
     },
-    [onChange, min, max]
+    [onChange, min, max, clamp]
   );
 
   const pct = range > 0

--- a/src/app/RangeSlider.tsx
+++ b/src/app/RangeSlider.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useRef, useCallback, useEffect } from 'react';
+
+interface RangeSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+  label?: string;
+}
+
+/**
+ * Horizontal range slider with pointer-capture drag
+ * and keyboard controls.
+ *
+ * Args:
+ *   value: Current value
+ *   min: Minimum value (inclusive)
+ *   max: Maximum value (inclusive)
+ *   onChange: Callback with new value
+ *   label: Accessible label (default "Value")
+ */
+export default function RangeSlider({
+  value,
+  min,
+  max,
+  onChange,
+  label = 'Value',
+}: RangeSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    startX: number;
+    startValue: number;
+  } | null>(null);
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const range = max - min;
+
+  const clamp = (v: number) =>
+    Math.max(min, Math.min(max, Math.round(v)));
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as Element).setPointerCapture(
+        e.pointerId
+      );
+      dragRef.current = {
+        startX: e.clientX,
+        startValue: valueRef.current,
+      };
+    },
+    []
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current || !trackRef.current) {
+        return;
+      }
+      const width = trackRef.current.offsetWidth;
+      if (width === 0) return;
+      const delta =
+        ((e.clientX - dragRef.current.startX)
+          / width) * range;
+      onChange(
+        clamp(dragRef.current.startValue + delta)
+      );
+    },
+    [onChange, range]
+  );
+
+  const release = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const v = valueRef.current;
+      let next = v;
+      const step = e.shiftKey ? 10 : 1;
+      if (
+        e.key === 'ArrowRight'
+        || e.key === 'ArrowUp'
+      ) {
+        next = clamp(v + step);
+      } else if (
+        e.key === 'ArrowLeft'
+        || e.key === 'ArrowDown'
+      ) {
+        next = clamp(v - step);
+      } else if (e.key === 'Home') {
+        next = min;
+      } else if (e.key === 'End') {
+        next = max;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      onChange(next);
+    },
+    [onChange, min, max]
+  );
+
+  const pct = range > 0
+    ? ((value - min) / range) * 100
+    : 0;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={0}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-label={label}
+        className={
+          'relative h-6 flex-1 rounded'
+          + ' bg-neutral-700 cursor-ew-resize'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500'
+        }
+        style={{ touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={release}
+        onLostPointerCapture={release}
+        onKeyDown={onKeyDown}
+      >
+        <div
+          className={
+            'absolute inset-y-0 left-0 rounded'
+            + ' bg-orange-600'
+          }
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className={
+        'text-xs font-mono text-neutral-300'
+        + ' w-10 text-right tabular-nums'
+      }>
+        {value}%
+      </span>
+    </div>
+  );
+}

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -21,6 +21,7 @@ import type {
   Pattern,
   SequencerConfig,
   StepConditions,
+  StepLocks,
   TrackId,
   TrackState,
 } from './types';
@@ -109,6 +110,15 @@ interface SequencerActions {
     conditions: StepConditions
   ) => void;
   clearTrigCondition: (
+    trackId: TrackId,
+    stepIndex: number
+  ) => void;
+  setParameterLock: (
+    trackId: TrackId,
+    stepIndex: number,
+    locks: StepLocks
+  ) => void;
+  clearParameterLock: (
     trackId: TrackId,
     stepIndex: number
   ) => void;
@@ -398,7 +408,11 @@ export function SequencerProvider({
           );
           if (!shouldFire) return;
 
-          const cubic = st.gain ** 3;
+          const locks =
+            cfg.parameterLocks?.[track.id]
+              ?.[effectiveStep];
+          const baseGain = locks?.gain ?? st.gain;
+          const cubic = baseGain ** 3;
           const gain =
             isAccented
               ? cubic * (1 + states.ac.gain)
@@ -493,6 +507,8 @@ export function SequencerProvider({
         steps: newSteps,
         trigConditions:
           pattern.trigConditions ?? {},
+        parameterLocks:
+          pattern.parameterLocks ?? {},
       };
     });
     setSelectedPatternId(pattern.id);
@@ -598,6 +614,9 @@ export function SequencerProvider({
         const newTrigConds = {
           ...prev.trigConditions,
         };
+        const newParamLocks = {
+          ...prev.parameterLocks,
+        };
         for (const id of TRACK_IDS) {
           if (newTrackLengths[id] > clamped) {
             newTrackLengths[id] = clamped;
@@ -627,6 +646,20 @@ export function SequencerProvider({
             }
             newTrigConds[id] = pruned;
           }
+          // Prune locks beyond new length
+          const trackLocks = newParamLocks[id];
+          if (trackLocks) {
+            const pruned: Record<
+              number, StepLocks
+            > = {};
+            for (const [k, v] of
+              Object.entries(trackLocks)) {
+              if (Number(k) < len) {
+                pruned[Number(k)] = v;
+              }
+            }
+            newParamLocks[id] = pruned;
+          }
         }
         return {
           ...prev,
@@ -634,6 +667,7 @@ export function SequencerProvider({
           trackLengths: newTrackLengths,
           steps: newSteps,
           trigConditions: newTrigConds,
+          parameterLocks: newParamLocks,
         };
       });
       setSelectedPatternId('custom');
@@ -675,6 +709,26 @@ export function SequencerProvider({
             [trackId]: pruned,
           };
         }
+        // Prune locks beyond new length
+        const trackLocks =
+          prev.parameterLocks[trackId];
+        let newParameterLocks =
+          prev.parameterLocks;
+        if (trackLocks) {
+          const pruned: Record<
+            number, StepLocks
+          > = {};
+          for (const [k, v] of
+            Object.entries(trackLocks)) {
+            if (Number(k) < clamped) {
+              pruned[Number(k)] = v;
+            }
+          }
+          newParameterLocks = {
+            ...prev.parameterLocks,
+            [trackId]: pruned,
+          };
+        }
         return {
           ...prev,
           trackLengths: {
@@ -686,6 +740,7 @@ export function SequencerProvider({
             [trackId]: newSteps,
           },
           trigConditions: newTrigConditions,
+          parameterLocks: newParameterLocks,
         };
       });
       setSelectedPatternId('custom');
@@ -766,6 +821,7 @@ export function SequencerProvider({
         mixer: newMixer,
         swing: 0,
         trigConditions: {},
+        parameterLocks: {},
       };
     });
     setIsLatched(false);
@@ -781,6 +837,10 @@ export function SequencerProvider({
           ...prev.trigConditions,
         };
         delete newTrigConditions[trackId];
+        const newParameterLocks = {
+          ...prev.parameterLocks,
+        };
+        delete newParameterLocks[trackId];
         return {
           ...prev,
           steps: {
@@ -799,6 +859,7 @@ export function SequencerProvider({
             },
           },
           trigConditions: newTrigConditions,
+          parameterLocks: newParameterLocks,
         };
       });
       setSelectedPatternId('custom');
@@ -921,6 +982,50 @@ export function SequencerProvider({
     []
   );
 
+  const setParameterLock = useCallback(
+    (
+      trackId: TrackId,
+      stepIndex: number,
+      locks: StepLocks
+    ) => {
+      setConfig(prev => ({
+        ...prev,
+        parameterLocks: {
+          ...prev.parameterLocks,
+          [trackId]: {
+            ...prev.parameterLocks[trackId],
+            [stepIndex]: locks,
+          },
+        },
+      }));
+    },
+    []
+  );
+
+  const clearParameterLock = useCallback(
+    (trackId: TrackId, stepIndex: number) => {
+      setConfig(prev => {
+        const trackLocks = {
+          ...prev.parameterLocks[trackId],
+        };
+        delete trackLocks[stepIndex];
+        const newParameterLocks = {
+          ...prev.parameterLocks,
+        };
+        if (Object.keys(trackLocks).length === 0) {
+          delete newParameterLocks[trackId];
+        } else {
+          newParameterLocks[trackId] = trackLocks;
+        }
+        return {
+          ...prev,
+          parameterLocks: newParameterLocks,
+        };
+      });
+    },
+    []
+  );
+
   // ─── Context value ────────────────────────────────
 
   const value: SequencerContextValue = {
@@ -958,6 +1063,8 @@ export function SequencerProvider({
       setFillHeld,
       setTrigCondition,
       clearTrigCondition,
+      setParameterLock,
+      clearParameterLock,
     },
     meta: { stepRef, totalStepsRef, config },
   };

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -17,6 +17,7 @@ interface StepButtonProps {
   onToggle: (
     trackId: TrackId, stepIndex: number
   ) => void;
+  gainLock?: number;
   conditions?: StepConditions;
   onOpenPopover?: (
     trackId: TrackId,
@@ -42,6 +43,7 @@ function StepButtonInner({
   isDisabled,
   mini,
   onToggle,
+  gainLock,
   conditions,
   onOpenPopover,
   longPressActiveRef,
@@ -50,7 +52,7 @@ function StepButtonInner({
 
   const openPopover = useCallback(
     (clientY?: number, clientX?: number) => {
-      if (!isActive || !onOpenPopover) return;
+      if (!onOpenPopover) return;
       const el = buttonRef.current;
       const r = el?.getBoundingClientRect();
       onOpenPopover(trackId, stepIndex, {
@@ -58,7 +60,7 @@ function StepButtonInner({
         left: r?.left ?? clientX ?? 0,
       });
     },
-    [isActive, onOpenPopover, trackId, stepIndex]
+    [onOpenPopover, trackId, stepIndex]
   );
 
   const handleToggle = useCallback(
@@ -158,7 +160,14 @@ function StepButtonInner({
         `${trackName} step ${stepIndex + 1}`
       }
       aria-pressed={isActive}
-      style={{ touchAction: 'manipulation' }}
+      style={{
+        touchAction: 'manipulation',
+        ...(
+          isActive && gainLock !== undefined
+            ? { opacity: Math.max(0.2, gainLock) }
+            : {}
+        ),
+      }}
       className={
         'relative overflow-hidden'
         + ' ' + heightClass + ' rounded-sm'

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -7,8 +7,7 @@ import type { RefObject } from 'react';
 import { TRACKS, useSequencer } from './SequencerContext';
 import TrackRow from './TrackRow';
 import AccentRow from './AccentRow';
-import TrigConditionPopover
-  from './TrigConditionPopover';
+import StepPopover from './StepPopover';
 import { useDragPaint } from './useDragPaint';
 import type { TrackId, TrackPattern } from './types';
 import trackPatternData from './data/trackPatterns.json';
@@ -162,6 +161,9 @@ export default function StepGrid({
             trigConditions={
               config.trigConditions[track.id]
             }
+            parameterLocks={
+              config.parameterLocks[track.id]
+            }
             onOpenPopover={(
               trackId: TrackId,
               stepIndex: number,
@@ -187,11 +189,16 @@ export default function StepGrid({
         />
       </div>
       {openPopover !== null ? (
-        <TrigConditionPopover
+        <StepPopover
           trackId={openPopover.trackId}
           stepIndex={openPopover.stepIndex}
           conditions={
             config.trigConditions[
+              openPopover.trackId
+            ]?.[openPopover.stepIndex]
+          }
+          locks={
+            config.parameterLocks[
               openPopover.trackId
             ]?.[openPopover.stepIndex]
           }

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -187,6 +187,27 @@ export default function StepPopover({
     );
   }, [anchorRect, onClose, scrollContainerRef]);
 
+  // Flip popover above anchor if it would overflow
+  // the viewport bottom.
+  const [flippedTop, setFlippedTop] = useState<
+    number | null
+  >(null);
+  useEffect(() => {
+    const el = popoverRef.current;
+    if (!el || !anchorRect) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom > window.innerHeight - 8) {
+      // 8px margin from viewport edge.
+      // anchorRect.top is button.bottom + 4,
+      // so button.bottom = anchorRect.top - 4.
+      // Place popover above: button.bottom - 4 - gap
+      // - popoverHeight.
+      const above =
+        anchorRect.top - 4 - 4 - rect.height;
+      setFlippedTop(Math.max(8, above));
+    }
+  }, [anchorRect]);
+
   return (
     <div
       ref={popoverRef}
@@ -199,7 +220,7 @@ export default function StepPopover({
         + ' shadow-xl p-3 space-y-3'
       }
       style={anchorRect ? {
-        top: `${anchorRect.top}px`,
+        top: `${flippedTop ?? anchorRect.top}px`,
         left: `${anchorRect.left}px`,
       } : undefined}
     >

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -9,7 +9,7 @@ import { CYCLE_OPTIONS } from './trigConditions';
 import ProbabilitySlider from './ProbabilitySlider';
 import type { StepConditions, TrackId } from './types';
 
-interface TrigConditionPopoverProps {
+interface StepPopoverProps {
   trackId: TrackId;
   stepIndex: number;
   conditions?: StepConditions;
@@ -29,14 +29,14 @@ interface TrigConditionPopoverProps {
  *   anchorRect: Position anchor
  *   onClose: Called when popover should close
  */
-export default function TrigConditionPopover({
+export default function StepPopover({
   trackId,
   stepIndex,
   conditions,
   anchorRect,
   onClose,
   scrollContainerRef,
-}: TrigConditionPopoverProps) {
+}: StepPopoverProps) {
   const { actions } = useSequencer();
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -166,7 +166,7 @@ export default function TrigConditionPopover({
     <div
       ref={popoverRef}
       role="dialog"
-      aria-label="Trig conditions"
+      aria-label="Step editor"
       className={
         'fixed z-30'
         + ' w-56 bg-neutral-900 border'

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -7,12 +7,16 @@ import type { RefObject } from 'react';
 import { useSequencer } from './SequencerContext';
 import { CYCLE_OPTIONS } from './trigConditions';
 import ProbabilitySlider from './ProbabilitySlider';
-import type { StepConditions, TrackId } from './types';
+import RangeSlider from './RangeSlider';
+import type {
+  StepConditions, StepLocks, TrackId,
+} from './types';
 
 interface StepPopoverProps {
   trackId: TrackId;
   stepIndex: number;
   conditions?: StepConditions;
+  locks?: StepLocks;
   anchorRect?: { top: number; left: number };
   onClose: () => void;
   scrollContainerRef?: RefObject<HTMLDivElement | null>;
@@ -33,6 +37,7 @@ export default function StepPopover({
   trackId,
   stepIndex,
   conditions,
+  locks,
   anchorRect,
   onClose,
   scrollContainerRef,
@@ -51,6 +56,13 @@ export default function StepPopover({
   const [fillValue, setFillValue] = useState<
     'none' | 'fill' | '!fill'
   >(conditions?.fill ?? 'none');
+
+  const [gainValue, setGainValue] = useState(
+    locks?.gain !== undefined
+      ? Math.round(locks.gain * 100)
+      : 100
+  );
+  const gainTouched = useRef(false);
 
   const updateConditions = useCallback(
     (
@@ -107,6 +119,19 @@ export default function StepPopover({
       updateConditions(probability, cycleValue, v);
     },
     [updateConditions, probability, cycleValue]
+  );
+
+  const handleGainChange = useCallback(
+    (v: number) => {
+      setGainValue(v);
+      gainTouched.current = true;
+      actions.setParameterLock(
+        trackId,
+        stepIndex,
+        { gain: v / 100 }
+      );
+    },
+    [actions, trackId, stepIndex]
   );
 
   useEffect(() => {
@@ -303,6 +328,61 @@ export default function StepPopover({
             </button>
           ))}
         </div>
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-neutral-700" />
+
+      {/* Locks section */}
+      <div className={
+        'flex items-center justify-between'
+      }>
+        <div className={
+          'text-xs font-bold uppercase'
+          + ' tracking-wider text-neutral-400'
+        }>
+          Locks
+        </div>
+        <button
+          onClick={() => {
+            actions.clearParameterLock(
+              trackId, stepIndex
+            );
+            setGainValue(100);
+            gainTouched.current = false;
+          }}
+          disabled={locks === undefined}
+          className={
+            'text-[11px] px-1.5 py-0.5 rounded'
+            + ' border transition-colors'
+            + (locks !== undefined
+              ? ' text-neutral-400'
+                + ' hover:text-neutral-200'
+                + ' border-neutral-700'
+                + ' hover:bg-neutral-800'
+              : ' text-neutral-700'
+                + ' border-neutral-800'
+                + ' cursor-default')
+          }
+        >
+          Reset locks
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Gain
+        </div>
+        <RangeSlider
+          value={gainValue}
+          min={0}
+          max={100}
+          onChange={handleGainChange}
+          label="Gain"
+        />
       </div>
 
     </div>

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -7,7 +7,9 @@ import type { RefObject } from 'react';
 import {
   LongPressEventType, useLongPress,
 } from 'use-long-press';
-import type { StepConditions, TrackId } from './types';
+import type {
+  StepConditions, StepLocks, TrackId,
+} from './types';
 import TrackToggle from './TrackToggle';
 import StepButton from './StepButton';
 import Knob from './Knob';
@@ -144,6 +146,7 @@ interface TrackRowProps {
   onToggleFreeRun: (trackId: TrackId) => void;
   onClearTrack: (trackId: TrackId) => void;
   trigConditions?: Record<number, StepConditions>;
+  parameterLocks?: Record<number, StepLocks>;
   onOpenPopover?: (
     trackId: TrackId,
     stepIndex: number,
@@ -181,6 +184,7 @@ function TrackRowInner({
   onToggleFreeRun,
   onClearTrack,
   trigConditions,
+  parameterLocks,
   onOpenPopover,
   longPressActiveRef,
 }: TrackRowProps) {
@@ -402,6 +406,10 @@ function TrackRowInner({
                     onToggle={handleToggleStep}
                     conditions={
                       trigConditions?.[globalIdx]
+                    }
+                    gainLock={
+                      parameterLocks?.[globalIdx]
+                        ?.gain
                     }
                     onOpenPopover={handleOpenPopover}
                     longPressActiveRef={

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -5,6 +5,7 @@ import patternsData from './data/patterns.json';
 import type {
   SequencerConfig,
   StepConditions,
+  StepLocks,
   TrackId,
   TrackMixerState,
 } from './types';
@@ -45,6 +46,7 @@ export function defaultConfig(): SequencerConfig {
     mixer,
     swing: 0,
     trigConditions: {},
+    parameterLocks: {},
   };
 }
 
@@ -92,9 +94,22 @@ function fromBase64url(str: string): Uint8Array {
 export async function encodeConfig(
   config: SequencerConfig
 ): Promise<string> {
-  const json = JSON.stringify(config);
+  const toEncode: Record<string, unknown> = {
+    ...config,
+  };
+  // Strip empty parameterLocks to keep URLs small
+  if (
+    Object.keys(
+      config.parameterLocks ?? {}
+    ).length === 0
+  ) {
+    delete toEncode.parameterLocks;
+  }
+  const json = JSON.stringify(toEncode);
   const stream = new Blob([json]).stream()
-    .pipeThrough(new CompressionStream('deflate-raw'));
+    .pipeThrough(
+      new CompressionStream('deflate-raw')
+    );
   const bytes = new Uint8Array(
     await new Response(stream).arrayBuffer()
   );
@@ -165,6 +180,9 @@ function validateConfig(
   const trigConditions = validateTrigConditions(
     obj.trigConditions, trackLengths
   );
+  const parameterLocks = validateParameterLocks(
+    obj.parameterLocks, trackLengths
+  );
 
   return {
     version: CONFIG_VERSION,
@@ -176,6 +194,7 @@ function validateConfig(
     mixer,
     swing,
     trigConditions,
+    parameterLocks,
   };
 }
 
@@ -421,6 +440,80 @@ function validateTrigConditions(
       );
       if (cond !== null) {
         validSteps[stepIndex] = cond;
+      }
+    }
+
+    if (Object.keys(validSteps).length > 0) {
+      result[id] = validSteps;
+    }
+  }
+
+  return result;
+}
+
+const MAX_STEP_INDEX = 63;
+
+/**
+ * Validate a single StepLocks object.
+ * Returns null if no valid fields remain.
+ */
+function validateSingleLock(
+  raw: unknown
+): StepLocks | null {
+  if (raw === null || typeof raw !== 'object') {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  const sl: StepLocks = {};
+
+  if (
+    typeof obj.gain === 'number'
+    && isFinite(obj.gain)
+  ) {
+    sl.gain = Math.max(0, Math.min(1, obj.gain));
+  }
+
+  if (Object.keys(sl).length === 0) return null;
+  return sl;
+}
+
+/**
+ * Validate parameterLocks map. Drops ac track,
+ * invalid step indices, and invalid lock objects.
+ */
+function validateParameterLocks(
+  value: unknown,
+  _trackLengths: Record<TrackId, number>
+): SequencerConfig['parameterLocks'] {
+  if (
+    value === null || typeof value !== 'object'
+  ) return {};
+  const obj = value as Record<string, unknown>;
+  const result:
+    SequencerConfig['parameterLocks'] = {};
+
+  for (const id of TRACK_IDS) {
+    if (id === 'ac') continue;
+    const trackEntry = obj[id];
+    if (
+      trackEntry === null
+      || typeof trackEntry !== 'object'
+    ) continue;
+
+    const stepMap =
+      trackEntry as Record<string, unknown>;
+    const validSteps: Record<number, StepLocks> = {};
+
+    for (const key of Object.keys(stepMap)) {
+      const stepIndex = Number(key);
+      if (
+        !Number.isInteger(stepIndex)
+        || stepIndex < 0
+        || stepIndex > MAX_STEP_INDEX
+      ) continue;
+      const lock = validateSingleLock(stepMap[key]);
+      if (lock !== null) {
+        validSteps[stepIndex] = lock;
       }
     }
 

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -181,7 +181,7 @@ function validateConfig(
     obj.trigConditions, trackLengths
   );
   const parameterLocks = validateParameterLocks(
-    obj.parameterLocks, trackLengths
+    obj.parameterLocks
   );
 
   return {
@@ -482,8 +482,7 @@ function validateSingleLock(
  * invalid step indices, and invalid lock objects.
  */
 function validateParameterLocks(
-  value: unknown,
-  _trackLengths: Record<TrackId, number>
+  value: unknown
 ): SequencerConfig['parameterLocks'] {
   if (
     value === null || typeof value !== 'object'

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -27,6 +27,14 @@ export interface StepConditions {
 }
 
 /**
+ * Per-step parameter lock overrides.
+ * Each field overrides the track-level default when present.
+ */
+export interface StepLocks {
+  gain?: number; // 0.0–1.0
+}
+
+/**
  * Represents a pattern with variable-length step strings.
  */
 export interface Pattern {
@@ -36,6 +44,9 @@ export interface Pattern {
   steps: Record<TrackId, string>;
   trigConditions?: Partial<
     Record<TrackId, Record<number, StepConditions>>
+  >;
+  parameterLocks?: Partial<
+    Record<TrackId, Record<number, StepLocks>>
   >;
 }
 
@@ -98,5 +109,8 @@ export interface SequencerConfig {
   swing: number;
   trigConditions: Partial<
     Record<TrackId, Record<number, StepConditions>>
+  >;
+  parameterLocks: Partial<
+    Record<TrackId, Record<number, StepLocks>>
   >;
 }


### PR DESCRIPTION
## Summary

- Add per-step gain parameter locks — each step can override its track's mixer volume (0–100%)
- Extend the step popover (renamed from TrigConditionPopover → StepPopover) with a "Locks" section containing a gain slider
- Active steps with gain locks show opacity proportional to locked gain (min 20% for visibility)
- Popover now opens on inactive steps too, allowing pre-configuration before activation
- Generalize ProbabilitySlider into reusable RangeSlider component
- Gain locks serialize in URL hash for sharing; empty locks are stripped to keep URLs compact
- Popover auto-flips above the button when near viewport bottom

Closes #30

## Test Plan

- [x] 357 tests pass (13 new tests for parameter locks)
- [x] Zero lint errors
- [x] Clean production build
- [ ] Browser: right-click step → popover shows Locks section with gain slider
- [ ] Browser: drag gain slider → step opacity changes
- [ ] Browser: play pattern → gain-locked steps are quieter
- [ ] Browser: right-click inactive step → popover opens
- [ ] Browser: share URL → reload → gain locks preserved
- [ ] Browser: popover near bottom of screen flips above button
