### PR TITLE
Add pattern modes and temp mode

### DIFF
--- a/docs/specs/2026-03-20-pattern-modes-design.md
+++ b/docs/specs/2026-03-20-pattern-modes-design.md
@@ -1,0 +1,467 @@
+# Pattern Modes Design
+
+**Issue:** #47 — FR: Support pattern modes
+**Date:** 2026-03-20
+
+## Problem
+
+When a user selects a different pattern, it applies immediately.
+Musicians need control over *when* a pattern change takes effect —
+at the end of the current pattern, immediately from step 0, or
+immediately continuing from the current position. They also need
+a "temp" mode that plays a pattern once and reverts to the
+previous one.
+
+## Pattern Modes
+
+Three modes, selectable via dropdown. The application is always
+in exactly one mode. Default: `sequential`.
+
+### Sequential
+
+The new pattern is queued. When the current pattern reaches its
+last step (step index `patternLength - 1`, the global pattern
+length — not per-track lengths), the queued pattern begins
+playing from step 0. The step counter wraps naturally via
+`advanceStep()` — no explicit reset is needed.
+
+If the user selects another pattern before the current one
+finishes, the latest selection replaces any previously queued
+pattern (no playlist — only one pending pattern at a time).
+
+### Direct Start
+
+The new pattern takes effect on the very next step tick. The
+step counter resets to 0, so the new pattern plays from its
+beginning.
+
+### Direct Jump
+
+The new pattern takes effect on the very next step tick. The
+step counter stays at its current position, so the new pattern
+starts playing from whatever step the old pattern was on.
+
+## Temp Mode
+
+An optional one-shot modifier that works with any pattern mode.
+Controlled by a separate toggle button (click-to-arm,
+click-to-cancel — no hold/momentary mode).
+
+### State Machine
+
+```
+off → armed      User clicks Temp button (or presses T)
+armed → active   User selects a pattern while armed
+active → off     Temp pattern reaches its last step
+armed → off      User clicks Temp again (cancel)
+armed → off      User disarms temp before queue triggers
+                  (sequential: also cancels pending queue)
+active → off     User stops playback (immediate revert)
+```
+
+### Behavior
+
+1. **Arm:** User clicks the Temp button (or presses T). It
+   starts blinking.
+2. **Trigger:** User selects a pattern. A snapshot of the
+   current config state is stored as `homeSnapshot` (see
+   HomeSnapshot type below). The new pattern is applied using
+   the current mode's switch semantics (sequential queues it,
+   direct-start/direct-jump apply immediately). Temp state
+   becomes `active`; button stops blinking, stays lit.
+3. **Revert:** When the temp pattern reaches its last step, the
+   `homeSnapshot` is restored and playback starts from step 0.
+   Temp state returns to `off`. Button returns to neutral.
+
+### Edge Cases
+
+- **Selecting another pattern while temp is active:** The new
+  pattern replaces the current temp pattern (same mode switch
+  semantics). `homeSnapshot` is unchanged — revert still goes
+  to the original.
+- **Temp is one-shot:** After revert, temp state is `off`. The
+  user must re-arm for another temp switch.
+- **Temp when stopped:** The Temp button is disabled when
+  playback is stopped.
+- **Step edits during temp:** If the user edits individual
+  steps while temp is active, those edits are discarded on
+  revert (the homeSnapshot is restored as-is).
+- **clearAll during temp/pending:** `clearAll` cancels temp
+  mode (sets `tempState → 'off'`, clears `homeSnapshot`) and
+  clears any `pendingPattern`. This prevents orphaned state.
+- **Disarming temp while queued (sequential):** If temp is
+  armed and a pattern is queued (temp + sequential), disarming
+  temp cancels the pending pattern entirely — clean slate.
+- **Stop during temp active:** Stopping playback immediately
+  reverts to homeSnapshot and clears all temp state. The user
+  sees the original pattern in the grid.
+- **Stop with pending queue:** Stopping playback discards any
+  pendingPattern. The user must re-select after play.
+- **PatternPicker during temp:** PatternPicker highlights
+  whichever pattern is currently active (the temp one). No
+  special indicator for the home pattern.
+
+## Stopped Behavior
+
+When the sequencer is stopped, pattern selection always applies
+immediately regardless of the current mode. Temp state is
+irrelevant when stopped. Stopping clears temp state (reverts to
+home if active) and discards any pending queue.
+
+## State Model
+
+### New Types (`src/app/types.ts`)
+
+```typescript
+type PatternMode = 'sequential' | 'direct-start'
+                 | 'direct-jump';
+
+type TempState = 'off' | 'armed' | 'active';
+
+interface HomeSnapshot {
+  steps: Record<TrackId, string>;
+  trigConditions: SequencerConfig['trigConditions'];
+  selectedPatternId: string;
+  trackLengths: Record<TrackId, number>;
+  patternLength: number;
+}
+```
+
+**Why `patternLength` in HomeSnapshot?** If the user changes
+pattern length during temp, revert must restore the original
+length. This also requires calling
+`audioEngine.setPatternLength()` synchronously during revert.
+
+**Why no mixer state?** `setPattern` only updates `steps` and
+`trigConditions` — it does not touch mixer state (mute/solo/gain).
+Since pattern changes don't modify the mixer, there is nothing
+to revert.
+
+### Transient State (all in SequencerContext)
+
+`patternMode` is a UI preference, not part of the shared
+pattern configuration. It is **not** serialized in the URL hash
+or included in `SequencerConfig`.
+
+- `patternMode: PatternMode` — default `'sequential'`
+- `tempState: TempState` — default `'off'`
+- `homeSnapshot: HomeSnapshot | null` — config fields to
+  restore after temp finishes. Storing a full snapshot (not just
+  a pattern ID) is necessary because the user may have edited
+  steps after loading a preset (making
+  `selectedPatternId = 'custom'`), and `setPattern` normalizes
+  step lengths.
+- `pendingPattern: Pattern | null` — full pattern object queued
+  in sequential mode (not just an ID, since we need steps and
+  trigConditions to apply it). The `category` field is carried
+  along but is cosmetic — only `steps` and `trigConditions` are
+  used during application.
+
+## Architecture
+
+Pattern switch logic lives in `SequencerContext`. The
+`AudioEngine` receives two small additions: a public
+`requestReset()` method and a `pendingReset` flag.
+
+### AudioEngine Changes
+
+`AudioEngine.currentStep` is private. Direct-start mode and
+temp revert need to reset it to 0 during playback.
+
+**Timing hazard:** `handleStep` (the `onStep` callback) runs
+inside the scheduler loop. After `onStep` returns,
+`advanceStep()` immediately increments `currentStep`. If we
+set `currentStep = 0` inside `onStep`, `advanceStep()` would
+increment it to 1 — the wrong result.
+
+**Solution:** Use a `pendingReset` flag that `advanceStep()`
+checks:
+
+```typescript
+private pendingReset = false;
+
+public requestReset() {
+  this.pendingReset = true;
+}
+
+private advanceStep() {
+  if (this.pendingReset) {
+    this.currentStep = 0;
+    this.pendingReset = false;
+    const secondsPerBeat = 60.0 / this.bpm;
+    this.nextStepTime += 0.25 * secondsPerBeat;
+    return;
+  }
+  const secondsPerBeat = 60.0 / this.bpm;
+  this.nextStepTime += 0.25 * secondsPerBeat;
+  this.currentStep =
+    (this.currentStep + 1) % this.patternLength;
+}
+```
+
+When `requestReset()` is called from inside `onStep`,
+`advanceStep()` runs next and sees `pendingReset = true`,
+setting `currentStep = 0` instead of incrementing. The timing
+advance still happens so step spacing is preserved.
+
+**Note:** Sequential mode does NOT need `requestReset()`. The
+step counter naturally wraps from `patternLength - 1` to 0 via
+the modulo in `advanceStep()`. Only direct-start and temp
+revert call `requestReset()`.
+
+**Lookahead behavior:** When `requestReset()` is called inside
+`onStep` at step N, the scheduler's while-loop may immediately
+schedule step 0 in the same tick (since both steps fall within
+the 100ms lookahead window). This is correct — both steps get
+precise Web Audio timestamps, so the swap is inaudible. No
+delay logic is needed.
+
+### Step Boundary Detection via `handleStep`
+
+The `handleStep` callback in SequencerContext is called by
+AudioEngine's look-ahead scheduler. It fires **ahead of real
+time** (up to 100ms early per `scheduleAheadTime`). This is
+the correct place to detect step boundaries, but pattern swaps
+must be done via **refs** (not React state) so `handleStep`
+reads the new pattern data synchronously on the very next
+invocation.
+
+The approach:
+
+1. `handleStep` checks if the current step is the last step
+   (`step === patternLength - 1`).
+2. If a pending pattern or temp revert is needed, it updates
+   `patternRef` (the ref that `handleStep` already reads for
+   step data) **synchronously** within the callback.
+3. A React state update is dispatched in parallel for UI sync,
+   but `handleStep` does not depend on it — it reads from refs.
+4. For direct-start and temp revert, call
+   `audioEngine.requestReset()` so the next `advanceStep()`
+   sets `currentStep` to 0.
+
+This means the pending/home state must also be stored in refs:
+- `pendingPatternRef` — mirrors `pendingPattern` state
+- `homeSnapshotRef` — mirrors `homeSnapshot` state
+- `tempStateRef` — mirrors `tempState`
+
+The refs are the source of truth for the audio thread; React
+state is the source of truth for the UI.
+
+### Ref Synchronization Guard
+
+The existing `useEffect` that syncs `patternRef` from
+`currentPattern` (line 286-288) must be guarded to prevent
+overwriting a fresher ref value set synchronously by
+`handleStep`. Add a guard:
+
+```typescript
+useEffect(() => {
+  // Only sync if state has caught up to the ref;
+  // handleStep may have written a newer value.
+  if (patternRef.current !== currentPattern) {
+    patternRef.current = currentPattern;
+  }
+}, [currentPattern]);
+```
+
+This prevents the race where: handleStep writes new pattern to
+ref → React state update queues → useEffect fires with stale
+`currentPattern` → overwrites the ref. The guard ensures the
+useEffect only writes when React state has truly changed.
+
+### Step Normalization
+
+The existing `setPattern` normalizes pattern steps (pad/truncate
+to match `trackLengths`) inside a `setConfig` callback. For
+immediate pattern changes (direct-start/direct-jump), the ref
+path also needs normalization.
+
+**Approach:** Extract normalization to a shared pure function:
+
+```typescript
+function normalizePatternSteps(
+  steps: Record<TrackId, string>,
+  trackLengths: Record<TrackId, number>
+): Record<TrackId, string> {
+  const result = { ...steps };
+  for (const id of TRACK_IDS) {
+    const cur = result[id] ?? '';
+    const len = trackLengths[id];
+    if (cur.length < len) {
+      result[id] = cur.padEnd(len, '0');
+    } else if (cur.length > len) {
+      result[id] = cur.substring(0, len);
+    }
+  }
+  return result;
+}
+```
+
+Both the ref path and the state path call this function. The
+ref path normalizes against `configRef.current.trackLengths`
+(the active track lengths at time of application).
+
+### `totalStepsRef` on Direct-Start Reset
+
+When direct-start resets the step counter, `totalStepsRef` is
+**not** reset. This is intentional: free-run tracks
+(`freeRun: true`) use `totalStepsRef` to maintain their
+independent position across pattern changes. Non-free-run
+tracks use `step % len`, which naturally aligns to the new step
+counter.
+
+### Modified `setPattern` Flow
+
+The existing `setPattern` action is extended with a wrapper that
+checks playback state, pattern mode, and temp state to determine
+*when* and *how* to apply the pattern:
+
+1. **Stopped:** Apply immediately (existing behavior).
+2. **Playing + temp armed:** Snapshot current config into
+   `homeSnapshot`/`homeSnapshotRef`, apply using current mode
+   semantics, set `tempState → 'active'`.
+3. **Playing + temp active:** Replace temp pattern using current
+   mode semantics, keep `homeSnapshot`.
+4. **Playing + temp off + sequential:** Store full `Pattern`
+   object as `pendingPattern`/`pendingPatternRef`.
+5. **Playing + temp off + direct-start:** Normalize steps
+   against `configRef.current.trackLengths`, update `patternRef`
+   synchronously, call `audioEngine.requestReset()`, then
+   update React state.
+6. **Playing + temp off + direct-jump:** Normalize steps
+   against `configRef.current.trackLengths`, update `patternRef`
+   synchronously, then update React state (step unchanged).
+
+### Step Boundary Hook (inside `handleStep`)
+
+At the end of `handleStep`, after playing sounds for the
+current step, check:
+
+- If `pendingPatternRef.current` is set and
+  `step === patternLength - 1`:
+  → Normalize pending pattern steps against
+  `configRef.current.trackLengths`, apply to `patternRef`,
+  update React state, clear `pendingPatternRef`. Do NOT call
+  `requestReset()` — the step counter wraps naturally.
+
+- If `tempStateRef.current === 'active'` and
+  `step === patternLength - 1`:
+  → Restore `homeSnapshotRef` to `patternRef` and config refs,
+  call `audioEngine.setPatternLength()` synchronously if
+  `homeSnapshot.patternLength` differs from current, call
+  `audioEngine.requestReset()`, update React state, set
+  `tempState → 'off'`, clear `homeSnapshotRef`.
+
+### Stop Behavior
+
+When `togglePlay` stops playback:
+
+1. If `tempState === 'active'`: restore `homeSnapshot` to
+   config state, clear `homeSnapshot`, set `tempState → 'off'`.
+2. If `pendingPattern` is set: clear it.
+3. If `tempState === 'armed'`: set `tempState → 'off'` and
+   clear any `pendingPattern` that was set while armed.
+
+This runs before `audioEngine.stop()` so state is clean.
+
+## UI
+
+### Layout
+
+Row 2 grid changes from 3 columns to 4:
+
+```
+grid-cols-[1fr_1fr_1.5fr]
+→ grid-cols-[1fr_1fr_auto_1.5fr]
+```
+
+The new Mode column sits between Drum Kit and Pattern.
+
+### Component: `PatternModeSelector.tsx`
+
+Contains two controls side by side:
+
+1. **Mode dropdown** (`<select>`): Options are "Sequential",
+   "Direct Start", "Direct Jump". Styled to match the Kit
+   selector.
+
+2. **Temp button**: A square button labeled "T".
+   - **Off:** `bg-neutral-800`, `border-neutral-700`
+   - **Armed:** `bg-orange-600`, CSS blink animation (1s cycle,
+     opacity 0.3–1.0)
+   - **Active:** `bg-orange-600` solid (no animation)
+   - Disabled when playback is stopped.
+
+### Keyboard Shortcut
+
+- **T key:** Toggle temp arm/disarm (same as clicking the
+  button). Follows the existing pattern of Space for play/stop
+  and F for fill.
+
+### Mobile
+
+The Mode column uses `auto` width (only as wide as its content).
+Dropdown option labels may abbreviate on small screens.
+
+## Files to Modify
+
+- `src/app/types.ts` — add `PatternMode`, `TempState`,
+  `HomeSnapshot` types (NOT added to `SequencerConfig`)
+- `src/app/AudioEngine.ts` — add `requestReset()` method and
+  `pendingReset` flag, modify `advanceStep()`
+- `src/app/SequencerContext.tsx` — add transient state + refs,
+  modify `setPattern`, add step-boundary logic in `handleStep`,
+  add stop cleanup, extract `normalizePatternSteps()`, guard
+  `patternRef` useEffect, add T keyboard shortcut
+- `src/app/TransportControls.tsx` — change grid to 4 columns,
+  render `PatternModeSelector`
+
+## New Files
+
+- `src/app/PatternModeSelector.tsx` — mode dropdown + temp
+  button component
+
+## Testing
+
+### Unit Tests
+
+- State machine transitions for temp mode (off → armed →
+  active → off, armed → off cancel)
+- `setPattern` behavior for each mode × temp state combination
+- Sequential mode: pending pattern replaces on re-selection
+- Sequential mode does NOT call `requestReset()` (natural wrap)
+- Step boundary: pending pattern applied at last step
+- Step boundary: temp revert at last step, home snapshot
+  restored from step 0 with patternLength restored
+- Direct-start calls `requestReset()`, next step is 0
+- Stopped behavior: always immediate
+- Stop during temp active: reverts to homeSnapshot
+- Stop with pending queue: discards pendingPattern
+- Disarm temp while queued: cancels pending pattern
+- `clearAll` clears temp state and pending pattern
+- Step edits during temp are discarded on revert
+- `AudioEngine.requestReset()` causes `advanceStep()` to set
+  `currentStep` to 0 instead of incrementing
+- `totalStepsRef` is not reset on direct-start
+- `normalizePatternSteps()` pads/truncates correctly
+- T keyboard shortcut toggles temp state
+
+### Manual Testing
+
+1. Start playback with a pattern in sequential mode
+2. Select a different pattern — verify it changes at end of
+   current pattern
+3. Switch to direct-start — verify immediate switch from step 0
+4. Switch to direct-jump — verify immediate switch keeping
+   step position
+5. Arm temp, select a pattern — verify blink → solid → revert
+6. During temp playback, select another pattern — verify it
+   replaces the temp pattern but still reverts to original
+7. Verify Temp button is disabled when stopped
+8. Verify pattern mode is NOT in the URL hash
+9. Test with patterns of varying lengths (16, 32, 64 steps)
+10. Stop during temp — verify immediate revert to original
+11. Stop with queued pattern — verify queue is discarded
+12. Arm temp in sequential mode, disarm before queue triggers
+    — verify queue is cancelled
+13. Press T key — verify temp toggles

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useSequencer } from '../app/SequencerContext';
 import { defaultConfig, encodeConfig } from '../app/configCodec';
 import { TRACK_IDS } from '../app/types';
-import type { TrackId } from '../app/types';
+import type { Pattern, TrackId } from '../app/types';
 import patternsData from '../app/data/patterns.json';
 import kitsData from '../app/data/kits.json';
 import { TestWrapper } from './helpers/sequencer-wrapper';
@@ -18,6 +18,7 @@ vi.mock('../app/AudioEngine', () => ({
     setPatternLength: vi.fn(),
     playSound: vi.fn(),
     onStep: vi.fn(),
+    requestReset: vi.fn(),
   },
 }));
 
@@ -853,4 +854,315 @@ describe('URL hash import', () => {
       );
     }
   );
+});
+
+// -------------------------------------------------------
+// H. Pattern mode state
+// -------------------------------------------------------
+describe('pattern mode state', () => {
+  it('initial patternMode is sequential', () => {
+    const { result } = renderSequencer();
+    expect(
+      result.current.state.patternMode
+    ).toBe('sequential');
+  });
+
+  it('initial tempState is off', () => {
+    const { result } = renderSequencer();
+    expect(
+      result.current.state.tempState
+    ).toBe('off');
+  });
+
+  it('setPatternMode changes mode', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+    expect(
+      result.current.state.patternMode
+    ).toBe('direct-start');
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-jump'
+      );
+    });
+    expect(
+      result.current.state.patternMode
+    ).toBe('direct-jump');
+  });
+
+  it('toggleTemp arms and disarms', () => {
+    const { result } = renderSequencer();
+    // Need to be playing for temp to arm
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('armed');
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('off');
+  });
+
+  it('toggleTemp does nothing when stopped', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('off');
+  });
+
+  it('patternMode not in config (transient)', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+    const config = result.current.meta.config;
+    expect(
+      'patternMode' in config
+    ).toBe(false);
+  });
+
+  it('clearAll resets temp state', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('armed');
+    act(() => {
+      result.current.actions.clearAll();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('off');
+  });
+});
+
+// -------------------------------------------------------
+// I. Pattern switch logic
+// -------------------------------------------------------
+
+/** Create a minimal test pattern with all tracks zeroed
+ *  except bd which gets the provided steps. */
+function makePattern(
+  id: string, bdSteps: string
+): Pattern {
+  const steps = {} as Record<TrackId, string>;
+  for (const tid of TRACK_IDS) {
+    steps[tid] = tid === 'bd'
+      ? bdSteps
+      : '0'.repeat(bdSteps.length);
+  }
+  return { id, name: id, steps };
+}
+
+describe('pattern switch logic', () => {
+  it('stopped: setPattern applies immediately regardless'
+    + ' of mode', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setPatternMode(
+        'sequential'
+      );
+    });
+    const pat = makePattern(
+      'test', '1010101010101010'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat);
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('test');
+  });
+
+  it('playing + sequential: setPattern queues, does not'
+    + ' apply immediately', () => {
+    const { result } = renderSequencer();
+    const original =
+      result.current.state.currentPattern.id;
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'sequential'
+      );
+    });
+    const pat = makePattern(
+      'queued', '1111000011110000'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat);
+    });
+    // Pattern should NOT have changed yet
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe(original);
+  });
+
+  it('playing + direct-start: setPattern applies'
+    + ' immediately', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+    const pat = makePattern(
+      'direct', '1100110011001100'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat);
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('direct');
+  });
+
+  it('playing + direct-jump: setPattern applies'
+    + ' immediately', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-jump'
+      );
+    });
+    const pat = makePattern(
+      'jump', '1010101010101010'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat);
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('jump');
+  });
+
+  it('playing + sequential: re-selecting replaces'
+    + ' pending', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'sequential'
+      );
+    });
+    const pat1 = makePattern(
+      'first', '1111111111111111'
+    );
+    const pat2 = makePattern(
+      'second', '0000000000000000'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat1);
+    });
+    act(() => {
+      result.current.actions.setPattern(pat2);
+    });
+    // Second selection should have replaced first
+    // (no playlist). We can't directly inspect
+    // pendingPattern, but when sequential triggers,
+    // it should be 'second'.
+  });
+
+  it('playing + temp armed + direct-start: takes'
+    + ' snapshot and applies', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('armed');
+    const pat = makePattern(
+      'temp-pat', '1010101010101010'
+    );
+    act(() => {
+      result.current.actions.setPattern(pat);
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('active');
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('temp-pat');
+  });
+
+  it('stop during temp active reverts to home', () => {
+    const { result } = renderSequencer();
+    // Load a known pattern first
+    const home = (
+      patternsData.patterns as Pattern[]
+    )[0];
+    act(() => {
+      result.current.actions.setPattern(home);
+    });
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    act(() => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+    act(() => {
+      result.current.actions.toggleTemp();
+    });
+    const tempPat = makePattern(
+      'temp', '1111111111111111'
+    );
+    act(() => {
+      result.current.actions.setPattern(tempPat);
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('active');
+    // Stop should revert
+    act(() => {
+      result.current.actions.togglePlay();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('off');
+    // Steps should match the home pattern
+    expect(
+      result.current.meta.config.steps.bd
+    ).toBe(home.steps.bd);
+  });
 });

--- a/src/__tests__/TempoController.test.tsx
+++ b/src/__tests__/TempoController.test.tsx
@@ -194,36 +194,4 @@ describe('TempoController tap tempo', () => {
     expect(setBpm).toHaveBeenCalledWith(30);
   });
 
-  it('T keydown triggers tap tempo', () => {
-    const setBpm = vi.fn();
-    render(
-      <TempoController bpm={120} setBpm={setBpm} />
-    );
-    perfSpy
-      .mockReturnValueOnce(1000)
-      .mockReturnValueOnce(1500);
-    fireEvent.keyDown(document, {
-      code: 'KeyT',
-      key: 't',
-    });
-    fireEvent.keyDown(document, {
-      code: 'KeyT',
-      key: 't',
-    });
-    expect(setBpm).toHaveBeenCalledWith(120);
-  });
-
-  it('T keydown ignored when INPUT is focused', () => {
-    const setBpm = vi.fn();
-    perfSpy.mockReturnValueOnce(1000);
-    render(
-      <TempoController bpm={120} setBpm={setBpm} />
-    );
-    const input = screen.getByLabelText(/bpm/i);
-    fireEvent.keyDown(input, {
-      code: 'KeyT',
-      key: 't',
-    });
-    expect(setBpm).not.toHaveBeenCalled();
-  });
 });

--- a/src/__tests__/audioEngine.test.ts
+++ b/src/__tests__/audioEngine.test.ts
@@ -231,6 +231,107 @@ describe('iOS silent mode bypass', () => {
   });
 });
 
+describe('AudioEngine requestReset', () => {
+  let stepLog: { step: number; time: number }[];
+
+  beforeEach(() => {
+    stepLog = [];
+    mockCurrentTime = 0;
+  });
+
+  afterEach(() => {
+    audioEngine.stop();
+  });
+
+  it('requestReset causes next step to be 0', async () => {
+    const onStep = vi.fn(
+      (step: number, time: number) => {
+        stepLog.push({ step, time });
+        // Request reset when we hit step 3
+        if (step === 3) {
+          audioEngine.requestReset();
+        }
+      }
+    );
+
+    // High BPM so steps advance quickly
+    await audioEngine.start(960, onStep);
+
+    for (let i = 0; i < 10; i++) {
+      mockCurrentTime += 0.05;
+      vi.advanceTimersByTime(25);
+    }
+
+    const steps = stepLog.map(s => s.step);
+    const idx3 = steps.indexOf(3);
+    expect(idx3).toBeGreaterThanOrEqual(0);
+    // After step 3, next step should be 0 (not 4)
+    expect(steps[idx3 + 1]).toBe(0);
+  });
+
+  it('requestReset preserves step timing', async () => {
+    const onStep = vi.fn(
+      (step: number, time: number) => {
+        stepLog.push({ step, time });
+        if (step === 2) {
+          audioEngine.requestReset();
+        }
+      }
+    );
+
+    // 120 BPM: 16th = 0.125s
+    await audioEngine.start(120, onStep);
+
+    for (let i = 0; i < 20; i++) {
+      mockCurrentTime += 0.05;
+      vi.advanceTimersByTime(25);
+    }
+
+    const step2 = stepLog.find(s => s.step === 2);
+    // The step after reset (step 0 again) should be
+    // exactly one 16th note after step 2
+    const resetStep = stepLog[stepLog.indexOf(step2!) + 1];
+    expect(resetStep.step).toBe(0);
+    expect(resetStep.time).toBeCloseTo(
+      step2!.time + 0.125, 6
+    );
+  });
+
+  it('pendingReset is one-shot (only affects next step)',
+    async () => {
+      const onStep = vi.fn(
+        (step: number, time: number) => {
+          stepLog.push({ step, time });
+          // Reset only on the first step 2
+          if (step === 2
+              && stepLog.filter(
+                s => s.step === 2
+              ).length === 1) {
+            audioEngine.requestReset();
+          }
+        }
+      );
+
+      await audioEngine.start(960, onStep);
+
+      for (let i = 0; i < 20; i++) {
+        mockCurrentTime += 0.05;
+        vi.advanceTimersByTime(25);
+      }
+
+      const steps = stepLog.map(s => s.step);
+      // After first reset: 0,1,2,0,1,2,3,...
+      const firstIdx2 = steps.indexOf(2);
+      expect(steps[firstIdx2 + 1]).toBe(0);
+      // Second time through step 2, it should continue
+      // to 3 normally
+      const secondIdx2 = steps.indexOf(2, firstIdx2 + 1);
+      expect(secondIdx2).toBeGreaterThan(firstIdx2);
+      expect(steps[secondIdx2 + 1]).toBe(3);
+    }
+  );
+});
+
 describe('AudioEngine playSound', () => {
   afterEach(() => {
     audioEngine.stop();

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -12,6 +12,8 @@ const mockPlaySound = vi.fn();
 const mockStart = vi.fn();
 const mockStop = vi.fn();
 
+const mockRequestReset = vi.fn();
+
 vi.mock('../app/AudioEngine', () => ({
   audioEngine: {
     preloadKit: vi.fn().mockResolvedValue(undefined),
@@ -20,6 +22,7 @@ vi.mock('../app/AudioEngine', () => ({
     setBpm: vi.fn(),
     setPatternLength: vi.fn(),
     playSound: (...args: unknown[]) => mockPlaySound(...args),
+    requestReset: (...args: unknown[]) => mockRequestReset(...args),
     onStep: vi.fn(),
   },
 }));
@@ -900,5 +903,157 @@ describe('handleStep parameter locks', () => {
     expect(mp).toHaveBeenCalledTimes(1);
     const gainArg = mp.mock.calls[0][2];
     expect(gainArg).toBeCloseTo(0);
+  });
+});
+
+// -------------------------------------------------------
+// Step boundary: sequential pending + temp revert
+// -------------------------------------------------------
+
+/** Create a minimal test pattern. */
+function makePattern(
+  id: string, bdSteps: string
+): Pattern {
+  const steps = {} as Record<TrackId, string>;
+  for (const tid of TRACK_IDS) {
+    steps[tid] = tid === 'bd'
+      ? bdSteps
+      : '0'.repeat(bdSteps.length);
+  }
+  return { id, name: id, steps };
+}
+
+describe('step boundary hooks', () => {
+  beforeEach(() => {
+    mockPlaySound.mockClear();
+    mockStart.mockClear();
+    mockRequestReset.mockClear();
+  });
+
+  it('sequential: pending pattern applied at last'
+    + ' step', async () => {
+    const { result } = renderSequencer();
+
+    // Start playback
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+    expect(mockStart).toHaveBeenCalled();
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+
+    // Set sequential mode and queue a pattern
+    await act(async () => {
+      result.current.actions.setPatternMode(
+        'sequential'
+      );
+    });
+
+    const pending = makePattern(
+      'pending', '1111000011110000'
+    );
+    await act(async () => {
+      result.current.actions.setPattern(pending);
+    });
+
+    // Pattern should NOT have changed yet
+    expect(
+      result.current.state.currentPattern.id
+    ).not.toBe('pending');
+
+    // Step through to the last step (15 for 16-step)
+    await act(async () => {
+      onStep(15, 1.0);
+    });
+
+    // After last step, pending should be applied
+    await waitFor(() => {
+      expect(
+        result.current.state.currentPattern.id
+      ).toBe('pending');
+    });
+
+    // Sequential should NOT call requestReset
+    expect(mockRequestReset).not.toHaveBeenCalled();
+  });
+
+  it('temp revert at last step', async () => {
+    const { result } = renderSequencer();
+
+    // Load a known home pattern
+    const home = makePattern(
+      'home', '1010101010101010'
+    );
+    await act(async () => {
+      result.current.actions.setPattern(home);
+    });
+
+    // Start playback in direct-start mode
+    await act(async () => {
+      result.current.actions.togglePlay();
+    });
+    expect(mockStart).toHaveBeenCalled();
+    const onStep = mockStart.mock.calls[0][1] as (
+      step: number, time: number
+    ) => void;
+
+    await waitFor(() => {
+      expect(
+        result.current.state.isPlaying
+      ).toBe(true);
+    });
+
+    await act(async () => {
+      result.current.actions.setPatternMode(
+        'direct-start'
+      );
+    });
+
+    // Arm temp and select a temp pattern
+    await act(async () => {
+      result.current.actions.toggleTemp();
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('armed');
+
+    const tempPat = makePattern(
+      'temp', '1111111111111111'
+    );
+    await act(async () => {
+      result.current.actions.setPattern(tempPat);
+    });
+    expect(
+      result.current.state.tempState
+    ).toBe('active');
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('temp');
+
+    mockRequestReset.mockClear();
+
+    // Step through to the last step
+    await act(async () => {
+      onStep(15, 1.0);
+    });
+
+    // After last step, should revert to home
+    await waitFor(() => {
+      expect(
+        result.current.state.tempState
+      ).toBe('off');
+    });
+    expect(
+      result.current.state.currentPattern.id
+    ).toBe('home');
+    // Temp revert calls requestReset
+    expect(mockRequestReset).toHaveBeenCalled();
   });
 });

--- a/src/app/AudioEngine.ts
+++ b/src/app/AudioEngine.ts
@@ -33,6 +33,7 @@ class AudioEngine {
   private nextStepTime: number = 0;
   private currentStep: number = 0;
   private schedulerTimer: NodeJS.Timeout | null = null;
+  private pendingReset = false;
 
   // Scheduler Configuration
   private bpm: number = 110;
@@ -172,6 +173,14 @@ class AudioEngine {
   }
 
   /**
+   * Requests a step counter reset to 0 on the next
+   * advanceStep() call. Safe to call from inside onStep.
+   */
+  public requestReset() {
+    this.pendingReset = true;
+  }
+
+  /**
    * The core scheduling loop.
    * It looks ahead in time and pre-schedules events to the AudioContext timeline.
    */
@@ -189,10 +198,14 @@ class AudioEngine {
    */
   private advanceStep() {
     const secondsPerBeat = 60.0 / this.bpm;
-    // 16th note = 1/4 of a quarter note (beat)
     this.nextStepTime += 0.25 * secondsPerBeat;
-    this.currentStep =
-      (this.currentStep + 1) % this.patternLength;
+    if (this.pendingReset) {
+      this.currentStep = 0;
+      this.pendingReset = false;
+    } else {
+      this.currentStep =
+        (this.currentStep + 1) % this.patternLength;
+    }
   }
 
   /**

--- a/src/app/PatternModeSelector.tsx
+++ b/src/app/PatternModeSelector.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useSequencer } from './SequencerContext';
+import type { PatternMode } from './types';
+
+const MODE_OPTIONS: {
+  value: PatternMode;
+  label: string;
+}[] = [
+  { value: 'sequential', label: 'Sequential' },
+  { value: 'direct-start', label: 'Direct Start' },
+  { value: 'direct-jump', label: 'Direct Jump' },
+];
+
+export default function PatternModeSelector() {
+  const { state, actions } = useSequencer();
+  const { patternMode, tempState, isPlaying } = state;
+
+  let tempBg: string;
+  if (tempState === 'armed') {
+    tempBg = 'bg-orange-600 border-orange-500'
+      + ' animate-temp-blink';
+  } else if (tempState === 'active') {
+    tempBg = 'bg-orange-600 border-orange-500'
+      + ' shadow-[0_0_12px_rgba(234,88,12,0.4)]';
+  } else {
+    tempBg = 'bg-neutral-800 border-neutral-700'
+      + ' hover:border-neutral-600';
+  }
+
+  return (
+    <div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
+      <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
+        Mode
+      </span>
+      <div className="flex gap-1 items-stretch">
+        <select
+          id="mode-select"
+          value={patternMode}
+          onChange={(e) => {
+            actions.setPatternMode(
+              e.target.value as PatternMode
+            );
+          }}
+          className="flex-1 min-w-0 bg-neutral-800 border border-neutral-700 rounded p-1 lg:p-2 text-xs lg:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 hover:border-neutral-600 transition-colors"
+        >
+          {MODE_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={() => actions.toggleTemp()}
+          disabled={!isPlaying}
+          aria-pressed={tempState !== 'off'}
+          aria-label="Temp mode"
+          className={
+            'px-2 rounded text-xs lg:text-sm'
+            + ' font-bold border transition-colors'
+            + ' focus-visible:outline-none'
+            + ' focus-visible:ring-2'
+            + ' focus-visible:ring-orange-500'
+            + ' disabled:opacity-40'
+            + ' disabled:cursor-not-allowed '
+            + tempBg
+          }
+        >
+          T
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -17,11 +17,14 @@ import { defaultConfig, decodeConfig } from './configCodec';
 import { evaluateCondition } from './trigConditions';
 import { TRACK_IDS } from './types';
 import type {
+  HomeSnapshot,
   Kit,
   Pattern,
+  PatternMode,
   SequencerConfig,
   StepConditions,
   StepLocks,
+  TempState,
   TrackId,
   TrackState,
 } from './types';
@@ -73,6 +76,8 @@ interface SequencerState {
   swing: number;
   isFillActive: boolean;
   fillMode: 'off' | 'latched' | 'momentary';
+  patternMode: PatternMode;
+  tempState: TempState;
 }
 
 interface SequencerActions {
@@ -122,6 +127,8 @@ interface SequencerActions {
     trackId: TrackId,
     stepIndex: number
   ) => void;
+  setPatternMode: (mode: PatternMode) => void;
+  toggleTemp: () => void;
 }
 
 interface SequencerMeta {
@@ -134,6 +141,27 @@ interface SequencerContextValue {
   state: SequencerState;
   actions: SequencerActions;
   meta: SequencerMeta;
+}
+
+/**
+ * Normalize pattern steps to match track lengths
+ * (pad with '0' or truncate).
+ */
+export function normalizePatternSteps(
+  steps: Record<TrackId, string>,
+  trackLengths: Record<TrackId, number>
+): Record<TrackId, string> {
+  const result = { ...steps };
+  for (const id of TRACK_IDS) {
+    const cur = result[id] ?? '';
+    const len = trackLengths[id];
+    if (cur.length < len) {
+      result[id] = cur.padEnd(len, '0');
+    } else if (cur.length > len) {
+      result[id] = cur.substring(0, len);
+    }
+  }
+  return result;
 }
 
 // ─── Contexts ─────────────────────────────────────────
@@ -218,6 +246,34 @@ export function SequencerProvider({
     isHeld ? 'momentary'
       : isLatched ? 'latched'
         : 'off';
+
+  // ─── Pattern mode state ─────────────────────────────
+  const [patternMode, setPatternMode] =
+    useState<PatternMode>('sequential');
+  const [tempState, setTempState] =
+    useState<TempState>('off');
+  const [homeSnapshot, setHomeSnapshot] =
+    useState<HomeSnapshot | null>(null);
+  const [pendingPattern, setPendingPattern] =
+    useState<Pattern | null>(null);
+
+  const tempStateRef = useRef<TempState>('off');
+  const homeSnapshotRef =
+    useRef<HomeSnapshot | null>(null);
+  const pendingPatternRef =
+    useRef<Pattern | null>(null);
+
+  useEffect(() => {
+    tempStateRef.current = tempState;
+  }, [tempState]);
+
+  useEffect(() => {
+    homeSnapshotRef.current = homeSnapshot;
+  }, [homeSnapshot]);
+
+  useEffect(() => {
+    pendingPatternRef.current = pendingPattern;
+  }, [pendingPattern]);
 
   // ─── Import config from URL hash on mount ─────────
   useEffect(() => {
@@ -422,6 +478,83 @@ export function SequencerProvider({
           );
         }
       });
+
+      // ─── Step boundary: pattern mode hooks ──────
+      if (step === cfg.patternLength - 1) {
+        // Sequential: apply pending pattern
+        const pending = pendingPatternRef.current;
+        if (pending) {
+          const normalized = normalizePatternSteps(
+            pending.steps, cfg.trackLengths
+          );
+          patternRef.current = {
+            ...pending,
+            steps: normalized,
+          };
+          configRef.current = {
+            ...cfg,
+            steps: normalized,
+            trigConditions:
+              pending.trigConditions ?? {},
+          };
+          pendingPatternRef.current = null;
+          // Update React state for UI
+          setConfig(prev => ({
+            ...prev,
+            steps: normalized,
+            trigConditions:
+              pending.trigConditions ?? {},
+          }));
+          setSelectedPatternId(pending.id);
+          setPendingPattern(null);
+          // No requestReset — natural wrap
+        }
+
+        // Temp revert
+        if (
+          tempStateRef.current === 'active'
+          && homeSnapshotRef.current
+          && !pending // Don't revert on same step
+                      // as applying pending
+        ) {
+          const snap = homeSnapshotRef.current;
+          patternRef.current = {
+            id: snap.selectedPatternId,
+            name: snap.selectedPatternId,
+            steps: snap.steps,
+          };
+          configRef.current = {
+            ...cfg,
+            steps: snap.steps,
+            trigConditions: snap.trigConditions,
+            trackLengths: snap.trackLengths,
+            patternLength: snap.patternLength,
+          };
+          if (
+            snap.patternLength !== cfg.patternLength
+          ) {
+            audioEngine.setPatternLength(
+              snap.patternLength
+            );
+          }
+          audioEngine.requestReset();
+          // Update React state
+          setConfig(prev => ({
+            ...prev,
+            steps: snap.steps,
+            trigConditions: snap.trigConditions,
+            trackLengths: snap.trackLengths,
+            patternLength: snap.patternLength,
+          }));
+          setSelectedPatternId(
+            snap.selectedPatternId
+          );
+          setTempState('off');
+          tempStateRef.current = 'off';
+          setHomeSnapshot(null);
+          homeSnapshotRef.current = null;
+        }
+      }
     },
     []
   );
@@ -442,6 +575,29 @@ export function SequencerProvider({
 
   const togglePlay = useCallback(() => {
     if (isPlaying) {
+      // Revert temp if active
+      if (tempStateRef.current === 'active'
+          && homeSnapshotRef.current) {
+        const snap = homeSnapshotRef.current;
+        setConfig(prev => ({
+          ...prev,
+          steps: snap.steps,
+          trigConditions: snap.trigConditions,
+          trackLengths: snap.trackLengths,
+          patternLength: snap.patternLength,
+        }));
+        setSelectedPatternId(
+          snap.selectedPatternId
+        );
+      }
+      // Clear all pattern mode transient state
+      setTempState('off');
+      tempStateRef.current = 'off';
+      setHomeSnapshot(null);
+      homeSnapshotRef.current = null;
+      setPendingPattern(null);
+      pendingPatternRef.current = null;
+
       audioEngine.stop();
       setIsPlaying(false);
       stepRef.current = -1;
@@ -490,29 +646,114 @@ export function SequencerProvider({
     setConfig(prev => ({ ...prev, kitId: kit.id }));
   }, []);
 
-  const setPattern = useCallback((pattern: Pattern) => {
-    setConfig(prev => {
-      const newSteps = { ...pattern.steps };
-      for (const id of TRACK_IDS) {
-        const cur = newSteps[id] ?? '';
-        const len = prev.trackLengths[id];
-        if (cur.length < len) {
-          newSteps[id] = cur.padEnd(len, '0');
-        } else if (cur.length > len) {
-          newSteps[id] = cur.substring(0, len);
+  const applyPatternNow = useCallback(
+    (pattern: Pattern) => {
+      setConfig(prev => {
+        const newSteps = normalizePatternSteps(
+          pattern.steps, prev.trackLengths
+        );
+        return {
+          ...prev,
+          steps: newSteps,
+          trigConditions:
+            pattern.trigConditions ?? {},
+          parameterLocks:
+            pattern.parameterLocks ?? {},
+        };
+      });
+      setSelectedPatternId(pattern.id);
+    },
+    []
+  );
+
+  const setPattern = useCallback(
+    (pattern: Pattern) => {
+      // When stopped, always apply immediately
+      if (!isPlaying) {
+        applyPatternNow(pattern);
+        return;
+      }
+
+      const ts = tempStateRef.current;
+
+      // Temp armed: snapshot home, apply via mode,
+      // transition to active
+      if (ts === 'armed') {
+        setHomeSnapshot({
+          steps: { ...configRef.current.steps },
+          trigConditions: {
+            ...configRef.current.trigConditions,
+          },
+          selectedPatternId,
+          trackLengths: {
+            ...configRef.current.trackLengths,
+          },
+          patternLength:
+            configRef.current.patternLength,
+        });
+        homeSnapshotRef.current = {
+          steps: { ...configRef.current.steps },
+          trigConditions: {
+            ...configRef.current.trigConditions,
+          },
+          selectedPatternId,
+          trackLengths: {
+            ...configRef.current.trackLengths,
+          },
+          patternLength:
+            configRef.current.patternLength,
+        };
+        setTempState('active');
+        tempStateRef.current = 'active';
+      }
+
+      // Temp active: replace temp pattern, keep home
+      // (no additional snapshot needed)
+
+      // Apply based on current mode
+      switch (patternMode) {
+        case 'sequential': {
+          if (ts === 'armed' || ts === 'active') {
+            // Temp + sequential: still queue
+            setPendingPattern(pattern);
+            pendingPatternRef.current = pattern;
+          } else {
+            setPendingPattern(pattern);
+            pendingPatternRef.current = pattern;
+          }
+          break;
+        }
+        case 'direct-start': {
+          // Update ref synchronously for handleStep
+          const normalized = normalizePatternSteps(
+            pattern.steps,
+            configRef.current.trackLengths
+          );
+          patternRef.current = {
+            ...pattern,
+            steps: normalized,
+          };
+          audioEngine.requestReset();
+          applyPatternNow(pattern);
+          break;
+        }
+        case 'direct-jump': {
+          const normalized = normalizePatternSteps(
+            pattern.steps,
+            configRef.current.trackLengths
+          );
+          patternRef.current = {
+            ...pattern,
+            steps: normalized,
+          };
+          applyPatternNow(pattern);
+          break;
         }
       }
-      return {
-        ...prev,
-        steps: newSteps,
-        trigConditions:
-          pattern.trigConditions ?? {},
-        parameterLocks:
-          pattern.parameterLocks ?? {},
-      };
-    });
-    setSelectedPatternId(pattern.id);
-  }, []);
+    },
+    [isPlaying, patternMode, selectedPatternId,
+      applyPatternNow]
+  );
 
   const toggleStep = useCallback(
     (trackId: TrackId, stepIndex: number) => {
@@ -828,6 +1069,12 @@ export function SequencerProvider({
     setIsHeld(false);
     fillActiveRef.current = false;
     setSelectedPatternId('custom');
+    setTempState('off');
+    tempStateRef.current = 'off';
+    setHomeSnapshot(null);
+    homeSnapshotRef.current = null;
+    setPendingPattern(null);
+    pendingPatternRef.current = null;
   }, []);
 
   const clearTrack = useCallback(
@@ -1026,6 +1273,48 @@ export function SequencerProvider({
     []
   );
 
+  // ─── Pattern mode actions ────────────────────────
+
+  const toggleTemp = useCallback(() => {
+    if (!isPlaying) return;
+    setTempState(prev => {
+      const next = prev === 'off' ? 'armed' : 'off';
+      tempStateRef.current = next;
+      if (next === 'off') {
+        // Disarming cancels any pending queue
+        setPendingPattern(null);
+        pendingPatternRef.current = null;
+        setHomeSnapshot(null);
+        homeSnapshotRef.current = null;
+      }
+      return next;
+    });
+  }, [isPlaying]);
+
+  // ─── Temp keyboard shortcut (t key) ─────────────
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== 'KeyT' || e.repeat) return;
+      const tag =
+        (e.target as HTMLElement)?.tagName;
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT'
+      ) return;
+      e.preventDefault();
+      toggleTemp();
+    };
+    document.addEventListener(
+      'keydown', handleKeyDown
+    );
+    return () => {
+      document.removeEventListener(
+        'keydown', handleKeyDown
+      );
+    };
+  }, [toggleTemp]);
+
   // ─── Context value ────────────────────────────────
 
   const value: SequencerContextValue = {
@@ -1041,6 +1330,8 @@ export function SequencerProvider({
       swing: config.swing,
       isFillActive,
       fillMode,
+      patternMode,
+      tempState,
     },
     actions: {
       togglePlay,
@@ -1065,6 +1356,8 @@ export function SequencerProvider({
       clearTrigCondition,
       setParameterLock,
       clearParameterLock,
+      setPatternMode,
+      toggleTemp,
     },
     meta: { stepRef, totalStepsRef, config },
   };

--- a/src/app/TempoController.tsx
+++ b/src/app/TempoController.tsx
@@ -50,18 +50,6 @@ export default function TempoController({ bpm, setBpm }: TempoControllerProps) {
     btn.classList.add('tap-flash');
   }, []);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.code !== 'KeyT') return;
-      if (event.repeat) return;
-      const tag = (event.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-      handleTap();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [handleTap]);
-
   return (
     <div className="relative flex items-center">
       <label htmlFor="bpm-input" className="sr-only">BPM</label>

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -8,6 +8,7 @@ import TempoController from './TempoController';
 import SettingsPopover from './SettingsPopover';
 import GlobalControls from './GlobalControls';
 import FillButton from './FillButton';
+import PatternModeSelector from './PatternModeSelector';
 import { useSequencer } from './SequencerContext';
 import PatternPicker from './PatternPicker';
 import { getCategorizedPatterns } from './patternUtils';
@@ -60,8 +61,8 @@ function TransportControlsInner({
           <SettingsPopover />
         </div>
       </div>
-      {/* Row 2: Kit + Pattern */}
-      <div className="grid grid-cols-[1fr_1fr_1.5fr] gap-2 lg:gap-4 pt-2 lg:pt-0">
+      {/* Row 2: Global + Kit + Mode + Pattern */}
+      <div className="grid grid-cols-[1fr_1fr_auto_1.5fr] gap-2 lg:gap-4 pt-2 lg:pt-0">
         <GlobalControls />
         <div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
           <label
@@ -88,6 +89,7 @@ function TransportControlsInner({
             ))}
           </select>
         </div>
+        <PatternModeSelector />
         <div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
           <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
             Pattern

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,15 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   box-shadow: 0 0 0 3px #f97316;
 }
 
+@keyframes temp-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.animate-temp-blink {
+  animation: temp-blink 1s infinite;
+}
+
 @keyframes tap-pulse {
   0% {
     background-color: rgb(234 88 12 / 0.4);

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -92,6 +92,35 @@ export interface TrackMixerState {
 }
 
 /**
+ * Pattern change mode — controls when a new pattern
+ * takes effect during playback.
+ */
+export type PatternMode =
+  | 'sequential'
+  | 'direct-start'
+  | 'direct-jump';
+
+/**
+ * Temp button state machine.
+ */
+export type TempState = 'off' | 'armed' | 'active';
+
+/**
+ * Snapshot of config fields preserved for temp mode
+ * revert. Mixer state is excluded because setPattern
+ * does not modify it.
+ */
+export interface HomeSnapshot {
+  steps: Record<TrackId, string>;
+  trigConditions: Partial<
+    Record<TrackId, Record<number, StepConditions>>
+  >;
+  selectedPatternId: string;
+  trackLengths: Record<TrackId, number>;
+  patternLength: number;
+}
+
+/**
  * Complete serializable sequencer configuration.
  *
  * This is the single source of truth for all persistable


### PR DESCRIPTION
## Summary

- Add three pattern change modes: **sequential** (queue until end of pattern), **direct start** (immediate from step 0), **direct jump** (immediate from current step)
- Add **temp mode**: one-shot modifier that plays a pattern once then reverts to the original
- Add `PatternModeSelector` component with mode dropdown and blinking T button between Kit and Pattern in the header
- Add `AudioEngine.requestReset()` with `pendingReset` flag to safely reset step counter mid-playback
- Add T keyboard shortcut for temp toggle (replaces tap tempo shortcut)
- 19 new tests covering mode/temp state machine, pattern switching, and step boundary hooks

Closes #47

## Test plan

- [ ] Sequential mode: select pattern while playing, verify it changes at end of current pattern
- [ ] Direct Start: verify immediate switch from step 0
- [ ] Direct Jump: verify immediate switch keeping step position
- [ ] Temp armed: button blinks, selecting a pattern transitions to active (solid)
- [ ] Temp revert: after one cycle, reverts to original pattern from step 0
- [ ] Stop during temp: immediate revert to original
- [ ] Temp button disabled when stopped
- [ ] T key toggles temp arm/disarm
- [ ] Test with 16, 32, and 64 step patterns
