### PR TITLE
Align accent knob with track volume knobs

### DIFF
--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -185,6 +185,9 @@ function AccentRowInner({
           >
             Accent
           </span>
+          {/* Spacer matching mute + solo toggle widths */}
+          <div className="w-6 h-6" />
+          <div className="w-6 h-6" />
           <Knob
             value={gain}
             onChange={handleGain}


### PR DESCRIPTION
## Summary
- Add spacer divs in AccentRow's desktop sidebar to match mute/solo toggle widths in TrackRow
- Aligns the accent intensity knob horizontally with volume knobs on other tracks

## Test plan
- [x] Lint passes
- [x] All tests pass (374)
- [x] Verified alignment visually via Playwright (DOM injection on main branch server)
