### PR TITLE
Add MIDI note output for external hardware

### DIFF
--- a/docs/specs/2026-03-21-midi-out-design.md
+++ b/docs/specs/2026-03-21-midi-out-design.md
@@ -44,17 +44,17 @@ avoid the more aggressive SysEx permission prompt.
 
 ```typescript
 /** Note length: fixed milliseconds or tempo-relative. */
-type NoteLength =
+export type NoteLength =
   | { type: 'fixed'; ms: number }
   | { type: 'percent'; value: number };
 
 /** Per-track MIDI note mapping. */
-interface MidiTrackConfig {
+export interface MidiTrackConfig {
   noteNumber: number;  // 0–127
 }
 
 /** Complete MIDI output configuration. */
-interface MidiConfig {
+export interface MidiConfig {
   enabled: boolean;
   deviceId: string | null;
   channel: number;  // 1–16
@@ -86,6 +86,12 @@ The accent track (`ac`) is excluded from `MidiConfig.tracks`
 at the type level. It modifies velocity of other tracks
 (same as audio) but does not send its own MIDI note.
 
+### TypeScript types for Web MIDI API
+
+Install `@types/webmidi` as a devDependency to get
+`MIDIAccess`, `MIDIOutput`, `MIDIOutputMap`, and related
+interfaces.
+
 ### Storage
 
 Key: `'xox-midi'` in localStorage. JSON-serialized
@@ -116,18 +122,21 @@ class MidiEngine {
   // React StrictMode double-mount).
   async init(): Promise<boolean>;
 
-  // Send note-on at scheduled time, schedule note-off
-  // after noteLength duration.
+  // Send note-on at perfTimeMs, schedule note-off at
+  // perfTimeMs + noteLengthMs via MIDIOutput.send()
+  // timestamp parameter (no setTimeout).
   // No-ops if !enabled, no output, or trackId === 'ac'.
   sendNote(
     trackId: TrackId,
-    audioTime: number,
+    perfTimeMs: number,
     gain: number
   ): void;
 
+  // Send All Notes Off (CC 123) on the active channel.
+  // Called when playback stops or before config changes.
+  stop(): void;
+
   // Update BPM (needed for percent-based note lengths).
-  // Called from the same effect that calls
-  // audioEngine.setBpm().
   setBpm(bpm: number): void;
 
   // List available MIDI output ports
@@ -136,40 +145,61 @@ class MidiEngine {
   // Select an output by device ID
   setOutput(deviceId: string): void;
 
-  // Get/set config (triggers localStorage persist)
+  // Get/set config (triggers localStorage persist).
+  // On channel/note changes, sends All Notes Off on
+  // the old channel before applying the new config.
   getConfig(): MidiConfig;
   updateConfig(partial: Partial<MidiConfig>): void;
 }
 ```
 
 **Singleton access:** Exported as a module-level instance
-(same pattern as `audioEngine`).
-
-**Time conversion:** The scheduler provides `audioTime`
-as `AudioContext.currentTime`. Convert to
-`DOMHighResTimeStamp` for `MIDIOutput.send()`:
-
+(same pattern as `audioEngine`):
+```typescript
+export const midiEngine = new MidiEngine();
 ```
-perfTimeMs = performance.now()
-  + (audioTime - audioContext.currentTime) * 1000
+
+**Time conversion:** handleStep converts AudioContext time
+to `DOMHighResTimeStamp` before calling sendNote. The
+conversion happens in SequencerContext, not in MidiEngine:
+
+```typescript
+// In handleStep (SequencerContext.tsx):
+const perfTimeMs = performance.now()
+  + (scheduledTime - audioEngine.getCurrentTime()) * 1000;
+midiEngine.sendNote(track.id, perfTimeMs, gain);
 ```
+
+This keeps MidiEngine fully decoupled from AudioEngine.
+A new `getCurrentTime()` getter is added to AudioEngine
+to expose `this.ctx!.currentTime`.
 
 **Note length computation:**
 - Fixed: use `config.noteLength.ms` directly
 - Percent: `(60 / this.bpm) * 0.25 * 1000 * (value / 100)`
+
+**Note-on and note-off scheduling:** Both messages use
+`MIDIOutput.send(data, timestamp)` with the browser's
+native MIDI scheduling. No setTimeout is used:
+
+```typescript
+const noteOnTime = perfTimeMs;
+const noteOffTime = perfTimeMs + noteLengthMs;
+output.send([0x90 | (ch - 1), note, velocity], noteOnTime);
+output.send([0x80 | (ch - 1), note, 0], noteOffTime);
+```
 
 **MIDI message encoding:**
 
 ```
 Note-on:  [0x90 | (channel - 1), noteNumber, velocity]
 Note-off: [0x80 | (channel - 1), noteNumber, 0]
+All Notes Off: [0xB0 | (channel - 1), 123, 0]
 ```
 
-**Velocity mapping:** The `gain` parameter passed to
-`sendNote` is the same value passed to `playSound` — it
-is already cubed (`baseGain ** 3`) and accent-scaled by
-`handleStep`. Therefore the mapping is linear with
-clamping:
+**Velocity mapping:** The `gain` parameter is already cubed
+(`baseGain ** 3`) and accent-scaled by handleStep.
+Linear mapping with clamping:
 
 ```typescript
 const velocity = Math.max(
@@ -179,6 +209,10 @@ const velocity = Math.max(
 
 Clamped to 1–127 because velocity 0 means note-off in
 some MIDI implementations.
+
+**Defense in depth:** `sendNote` checks `trackId === 'ac'`
+and returns early, even though the handleStep TRACKS loop
+already excludes accent. This guards against future callers.
 
 **Device hotplug:** Listen for `statechange` on
 `MIDIAccess`. If the selected device disconnects, set
@@ -193,28 +227,82 @@ call (~line 420):
 
 ```typescript
 audioEngine.playSound(track.id, scheduledTime, gain);
-midiEngine.sendNote(track.id, scheduledTime, gain);
+
+// MIDI output (time conversion done here to keep
+// MidiEngine decoupled from AudioEngine)
+const perfTimeMs = performance.now()
+  + (scheduledTime - audioEngine.getCurrentTime()) * 1000;
+midiEngine.sendNote(track.id, perfTimeMs, gain);
 ```
 
-One additional line. MidiEngine internally checks if
-enabled and handles all MIDI logic.
+Swing offset is already baked into `scheduledTime`, so
+MIDI notes swing identically to audio. Trig conditions
+(probability, cycle, fill) and freeRun mode are
+transparent — they gate whether this code is reached at
+all.
+
+### Stop integration
+
+In `SequencerContext.tsx`, in the `togglePlay` callback
+alongside `audioEngine.stop()`:
+
+```typescript
+audioEngine.stop();
+midiEngine.stop();  // sends All Notes Off (CC 123)
+```
+
+This prevents stuck notes on external gear when playback
+is stopped mid-step.
+
+### BPM sync
+
+In `SequencerContext.tsx`, in the BPM effect alongside
+`audioEngine.setBpm()`:
+
+```typescript
+useEffect(() => {
+  audioEngine.setBpm(config.bpm);
+  midiEngine.setBpm(config.bpm);
+}, [config.bpm]);
+```
+
+### Config change cleanup
+
+When `updateConfig()` detects a channel or note number
+change, it sends All Notes Off (CC 123) on the **old**
+channel before applying the new config. This prevents
+stuck notes when the user changes MIDI routing mid-playback.
 
 ### MidiEngine initialization
 
-`MidiEngine.init()` is called once when the app mounts,
-inside `SequencerContext`. It requests MIDI access and
-loads config from localStorage. The init result (whether
-MIDI is available) is exposed as state for the UI.
+`midiEngine.init()` is called once when the app mounts,
+inside SequencerContext (or MidiContext provider). It
+requests MIDI access and loads config from localStorage.
 
 The init call is idempotent — if called again (e.g. React
 StrictMode double-mount in development), it returns the
 existing result without re-requesting MIDI access.
 
-### BPM sync
+### MidiContext (`src/app/MidiContext.tsx`)
 
-`MidiEngine.setBpm()` is called from the same `useEffect`
-that calls `audioEngine.setBpm()` in SequencerContext, so
-percent-based note lengths track tempo changes.
+A separate lightweight React context wrapping MidiEngine:
+
+```typescript
+interface MidiContextValue {
+  available: boolean;       // Web MIDI API accessible?
+  config: MidiConfig;
+  outputs: MIDIOutput[];    // connected devices
+  updateConfig: (partial: Partial<MidiConfig>) => void;
+}
+```
+
+This avoids bloating SequencerContext with MIDI concerns.
+The MidiContext provider:
+- Calls `midiEngine.init()` on mount
+- Subscribes to `statechange` for hotplug device updates
+- Persists config changes to localStorage via MidiEngine
+- Wraps the app tree (inside or alongside
+  SequencerProvider)
 
 ## UI Design
 
@@ -222,25 +310,28 @@ percent-based note lengths track tempo changes.
 
 Add a "MIDI Settings…" menu item in `SettingsPopover.tsx`
 below the existing "Export URL" button. Clicking it opens
-a separate MIDI settings panel.
+a modal dialog.
 
-### MIDI settings panel (`src/app/MidiSettings.tsx`)
+### MIDI settings modal (`src/app/MidiSettings.tsx`)
 
-A panel/modal accessed from the gear menu containing:
+A centered modal dialog with backdrop, accessed from the
+gear menu. Contains:
 
 1. **Enable toggle** — on/off switch for MIDI output
 2. **Device dropdown** — lists connected MIDI outputs by
-   name. Shows "No devices" when empty.
+   name. Shows "No devices" when empty. Updates on hotplug.
 3. **Channel selector** — dropdown or number input, 1–16
 4. **Note length** — dropdown with presets (see below)
 5. **Track note mapping** — grid of 11 tracks (excluding
    `ac`), each with a number input for MIDI note (0–127).
    Track labels (BD, SD, etc.) with editable note numbers.
 
+Dismiss via close button, Escape key, or backdrop click.
+
 When no MIDI device is detected or Web MIDI is unsupported,
-the section is visible but disabled with a status message:
-"No MIDI device detected" or "MIDI not supported in this
-browser".
+the modal is visible but controls are disabled with a
+status message: "No MIDI device detected" or "MIDI not
+supported in this browser".
 
 ### Note length options
 
@@ -266,49 +357,66 @@ based lengths adapt to tempo changes automatically.
 | Device disconnects mid-play | sendNote silently no-ops; UI updates |
 | Device reconnects | Auto-reconnect if deviceId matches |
 | Gain > 1.0 (accent) | Velocity clamped to 127 |
+| Stop mid-playback | All Notes Off (CC 123) sent |
+| Config change mid-playback | All Notes Off on old channel, then apply |
 
 ## Files Affected
 
 ### New files
 
 - `src/app/MidiEngine.ts` — Web MIDI API wrapper singleton
-- `src/app/MidiSettings.tsx` — MIDI config panel component
+- `src/app/MidiContext.tsx` — React context for MIDI state
+- `src/app/MidiSettings.tsx` — MIDI config modal component
 
 ### Modified files
 
-- `src/app/SequencerContext.tsx` — init MidiEngine, call
-  sendNote in handleStep, sync BPM, expose MIDI state
+- `src/app/SequencerContext.tsx` — call sendNote in
+  handleStep (with time conversion), call stop() in
+  togglePlay, sync BPM
+- `src/app/AudioEngine.ts` — add `getCurrentTime()` getter
 - `src/app/SettingsPopover.tsx` — add "MIDI Settings…"
   menu item
 - `src/app/types.ts` — add `MidiConfig`, `MidiTrackConfig`,
   `NoteLength` types
+- `package.json` — add `@types/webmidi` devDependency
 
 ## Testing
 
 ### Unit tests (`src/__tests__/midiEngine.test.ts`)
 
-- Mock `navigator.requestMIDIAccess` with fake `MIDIAccess`
-  and `MIDIOutput` objects
+Mock `navigator.requestMIDIAccess` with fake `MIDIAccess`
+and `MIDIOutput` objects (same pattern as AudioContext
+mocking in audioEngine.test.ts):
+
 - Verify `sendNote()` calls `output.send()` with correct
   note-on bytes `[0x99, noteNum, velocity]` for channel 10
-- Verify note-off is scheduled after the configured note
-  length duration
+- Verify note-off sent via `output.send()` with timestamp
+  = noteOnTime + noteLengthMs (not setTimeout)
 - Verify velocity calculation: `gain=0.5` (already cubed)
   → `velocity = Math.max(1, Math.round(0.5 * 127)) = 64`
 - Verify accent gain (>1.0) clamps velocity to 127
 - Verify `sendNote()` no-ops when disabled, no output,
   or trackId is `'ac'`
+- Verify `stop()` sends All Notes Off (CC 123)
+- Verify `updateConfig()` sends All Notes Off on old
+  channel when channel changes
 - Verify config round-trips through localStorage
 - Verify graceful handling when `requestMIDIAccess` is
   undefined or rejects
 - Verify percent-based note length uses current BPM
+- Verify idempotent init (second call returns same result)
 
 ### Integration (handleStep)
 
-- Extend existing `handleStep.test.ts` to verify
-  `midiEngine.sendNote()` is called with the same
-  `scheduledTime` and `gain` as `audioEngine.playSound()`
+Extend `handleStep.test.ts` with a mock midiEngine
+alongside the existing mock audioEngine (same vi.mock
+pattern):
+
+- Verify `midiEngine.sendNote()` is called with
+  perfTimeMs and same gain as `audioEngine.playSound()`
 - Verify muted/soloed tracks are skipped for MIDI too
+- Verify swing offset is reflected in MIDI timing
+- Verify trig condition gates apply to MIDI
 
 ### Manual testing
 
@@ -321,6 +429,8 @@ based lengths adapt to tempo changes automatically.
 7. Change note length — verify audible duration difference
 8. Disconnect device mid-play — verify no errors, UI updates
 9. Reconnect — verify auto-reconnect
+10. Stop playback — verify no stuck notes on gear
+11. Change channel mid-playback — verify clean switch
 
 ## Timing Considerations
 

--- a/docs/specs/2026-03-21-midi-out-design.md
+++ b/docs/specs/2026-03-21-midi-out-design.md
@@ -1,0 +1,344 @@
+# MIDI Out — Note Triggers (Issue #10)
+
+## Context
+
+XOX is a 16-step drum sequencer running in the browser.
+Currently it only produces audio via the Web Audio API.
+Users with external MIDI gear (drum machines, samplers,
+synth modules) want XOX to send MIDI note triggers so
+patterns drive hardware in sync with the internal audio.
+
+This spec covers MIDI note output only. MIDI clock and
+transport messages are deferred to issue #58.
+
+## Requirements
+
+- Send short MIDI note-on/note-off messages when steps fire
+- Global MIDI channel (1–16) for all tracks
+- Per-track MIDI note number (0–127) with GM drum defaults
+- User-configurable note length (default 50ms)
+- Velocity derived from gain (linear mapping — the gain
+  value is already cubed by handleStep before reaching
+  MidiEngine)
+- First-time opt-in; remembers settings on subsequent visits
+- Pick one output device from connected MIDI outputs
+- MIDI config stored in localStorage (not in URL / not in
+  `SequencerConfig`)
+- Graceful fallback when Web MIDI API is unavailable or
+  user denies permission
+- MIDI section visible but disabled when no device available
+
+## Browser Compatibility
+
+The Web MIDI API is supported in Chrome, Edge, and other
+Chromium-based browsers. It is **not supported on iOS
+Safari**. Requires HTTPS (satisfied by Cloudflare Pages).
+The browser prompts the user for permission on first access.
+
+`requestMIDIAccess` is called with `{ sysex: false }` to
+avoid the more aggressive SysEx permission prompt.
+
+## Data Model
+
+### New types in `src/app/types.ts`
+
+```typescript
+/** Note length: fixed milliseconds or tempo-relative. */
+type NoteLength =
+  | { type: 'fixed'; ms: number }
+  | { type: 'percent'; value: number };
+
+/** Per-track MIDI note mapping. */
+interface MidiTrackConfig {
+  noteNumber: number;  // 0–127
+}
+
+/** Complete MIDI output configuration. */
+interface MidiConfig {
+  enabled: boolean;
+  deviceId: string | null;
+  channel: number;  // 1–16
+  noteLength: NoteLength;  // default: { type: 'fixed', ms: 50 }
+  tracks: Record<
+    Exclude<TrackId, 'ac'>,
+    MidiTrackConfig
+  >;
+}
+```
+
+### Default note numbers (GM drum map)
+
+| Track | Note | GM Sound        |
+|-------|------|-----------------|
+| BD    | 36   | Bass Drum 1     |
+| SD    | 38   | Acoustic Snare  |
+| CH    | 42   | Closed Hi-Hat   |
+| OH    | 46   | Open Hi-Hat     |
+| CY    | 49   | Crash Cymbal 1  |
+| HT    | 50   | High Tom        |
+| MT    | 47   | Mid Tom         |
+| LT    | 43   | Low Tom         |
+| RS    | 37   | Side Stick      |
+| CP    | 39   | Hand Clap       |
+| CB    | 56   | Cowbell         |
+
+The accent track (`ac`) is excluded from `MidiConfig.tracks`
+at the type level. It modifies velocity of other tracks
+(same as audio) but does not send its own MIDI note.
+
+### Storage
+
+Key: `'xox-midi'` in localStorage. JSON-serialized
+`MidiConfig`. Not part of `SequencerConfig` or URL hash
+sharing — MIDI routing is device-specific.
+
+On first visit (no stored config), MIDI is disabled.
+On subsequent visits, the saved config is restored
+including enabled state.
+
+## Architecture
+
+### MidiEngine (`src/app/MidiEngine.ts`)
+
+A singleton class mirroring AudioEngine's pattern:
+
+```typescript
+class MidiEngine {
+  private access: MIDIAccess | null;
+  private output: MIDIOutput | null;
+  private config: MidiConfig;
+  private bpm: number;
+
+  // Request MIDI access with { sysex: false }.
+  // Loads config from localStorage.
+  // Returns false if API unavailable or permission denied.
+  // Idempotent — safe to call multiple times (e.g.
+  // React StrictMode double-mount).
+  async init(): Promise<boolean>;
+
+  // Send note-on at scheduled time, schedule note-off
+  // after noteLength duration.
+  // No-ops if !enabled, no output, or trackId === 'ac'.
+  sendNote(
+    trackId: TrackId,
+    audioTime: number,
+    gain: number
+  ): void;
+
+  // Update BPM (needed for percent-based note lengths).
+  // Called from the same effect that calls
+  // audioEngine.setBpm().
+  setBpm(bpm: number): void;
+
+  // List available MIDI output ports
+  getOutputs(): MIDIOutput[];
+
+  // Select an output by device ID
+  setOutput(deviceId: string): void;
+
+  // Get/set config (triggers localStorage persist)
+  getConfig(): MidiConfig;
+  updateConfig(partial: Partial<MidiConfig>): void;
+}
+```
+
+**Singleton access:** Exported as a module-level instance
+(same pattern as `audioEngine`).
+
+**Time conversion:** The scheduler provides `audioTime`
+as `AudioContext.currentTime`. Convert to
+`DOMHighResTimeStamp` for `MIDIOutput.send()`:
+
+```
+perfTimeMs = performance.now()
+  + (audioTime - audioContext.currentTime) * 1000
+```
+
+**Note length computation:**
+- Fixed: use `config.noteLength.ms` directly
+- Percent: `(60 / this.bpm) * 0.25 * 1000 * (value / 100)`
+
+**MIDI message encoding:**
+
+```
+Note-on:  [0x90 | (channel - 1), noteNumber, velocity]
+Note-off: [0x80 | (channel - 1), noteNumber, 0]
+```
+
+**Velocity mapping:** The `gain` parameter passed to
+`sendNote` is the same value passed to `playSound` — it
+is already cubed (`baseGain ** 3`) and accent-scaled by
+`handleStep`. Therefore the mapping is linear with
+clamping:
+
+```typescript
+const velocity = Math.max(
+  1, Math.round(Math.min(gain, 1.0) * 127)
+);
+```
+
+Clamped to 1–127 because velocity 0 means note-off in
+some MIDI implementations.
+
+**Device hotplug:** Listen for `statechange` on
+`MIDIAccess`. If the selected device disconnects, set
+`output = null` (sendNote silently no-ops). If it
+reconnects and matches the saved `deviceId`, auto-reconnect.
+Emit a callback so the UI can update connection status.
+
+### handleStep integration
+
+In `SequencerContext.tsx`, after the existing `playSound`
+call (~line 420):
+
+```typescript
+audioEngine.playSound(track.id, scheduledTime, gain);
+midiEngine.sendNote(track.id, scheduledTime, gain);
+```
+
+One additional line. MidiEngine internally checks if
+enabled and handles all MIDI logic.
+
+### MidiEngine initialization
+
+`MidiEngine.init()` is called once when the app mounts,
+inside `SequencerContext`. It requests MIDI access and
+loads config from localStorage. The init result (whether
+MIDI is available) is exposed as state for the UI.
+
+The init call is idempotent — if called again (e.g. React
+StrictMode double-mount in development), it returns the
+existing result without re-requesting MIDI access.
+
+### BPM sync
+
+`MidiEngine.setBpm()` is called from the same `useEffect`
+that calls `audioEngine.setBpm()` in SequencerContext, so
+percent-based note lengths track tempo changes.
+
+## UI Design
+
+### Settings gear menu
+
+Add a "MIDI Settings…" menu item in `SettingsPopover.tsx`
+below the existing "Export URL" button. Clicking it opens
+a separate MIDI settings panel.
+
+### MIDI settings panel (`src/app/MidiSettings.tsx`)
+
+A panel/modal accessed from the gear menu containing:
+
+1. **Enable toggle** — on/off switch for MIDI output
+2. **Device dropdown** — lists connected MIDI outputs by
+   name. Shows "No devices" when empty.
+3. **Channel selector** — dropdown or number input, 1–16
+4. **Note length** — dropdown with presets (see below)
+5. **Track note mapping** — grid of 11 tracks (excluding
+   `ac`), each with a number input for MIDI note (0–127).
+   Track labels (BD, SD, etc.) with editable note numbers.
+
+When no MIDI device is detected or Web MIDI is unsupported,
+the section is visible but disabled with a status message:
+"No MIDI device detected" or "MIDI not supported in this
+browser".
+
+### Note length options
+
+| Label           | Config value                       |
+|-----------------|------------------------------------|
+| 10 ms           | `{ type: 'fixed', ms: 10 }`       |
+| 25 ms           | `{ type: 'fixed', ms: 25 }`       |
+| 50 ms (default) | `{ type: 'fixed', ms: 50 }`       |
+| 100 ms          | `{ type: 'fixed', ms: 100 }`      |
+| 50% of step     | `{ type: 'percent', value: 50 }`   |
+| 75% of step     | `{ type: 'percent', value: 75 }`   |
+
+Step duration = `(60 / BPM) * 0.25 * 1000` ms. Percentage-
+based lengths adapt to tempo changes automatically.
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| No Web MIDI API | UI shows "MIDI not supported" (disabled) |
+| Permission denied | UI shows "MIDI access denied" (disabled) |
+| No devices connected | UI shows "No MIDI devices" (disabled) |
+| Device disconnects mid-play | sendNote silently no-ops; UI updates |
+| Device reconnects | Auto-reconnect if deviceId matches |
+| Gain > 1.0 (accent) | Velocity clamped to 127 |
+
+## Files Affected
+
+### New files
+
+- `src/app/MidiEngine.ts` — Web MIDI API wrapper singleton
+- `src/app/MidiSettings.tsx` — MIDI config panel component
+
+### Modified files
+
+- `src/app/SequencerContext.tsx` — init MidiEngine, call
+  sendNote in handleStep, sync BPM, expose MIDI state
+- `src/app/SettingsPopover.tsx` — add "MIDI Settings…"
+  menu item
+- `src/app/types.ts` — add `MidiConfig`, `MidiTrackConfig`,
+  `NoteLength` types
+
+## Testing
+
+### Unit tests (`src/__tests__/midiEngine.test.ts`)
+
+- Mock `navigator.requestMIDIAccess` with fake `MIDIAccess`
+  and `MIDIOutput` objects
+- Verify `sendNote()` calls `output.send()` with correct
+  note-on bytes `[0x99, noteNum, velocity]` for channel 10
+- Verify note-off is scheduled after the configured note
+  length duration
+- Verify velocity calculation: `gain=0.5` (already cubed)
+  → `velocity = Math.max(1, Math.round(0.5 * 127)) = 64`
+- Verify accent gain (>1.0) clamps velocity to 127
+- Verify `sendNote()` no-ops when disabled, no output,
+  or trackId is `'ac'`
+- Verify config round-trips through localStorage
+- Verify graceful handling when `requestMIDIAccess` is
+  undefined or rejects
+- Verify percent-based note length uses current BPM
+
+### Integration (handleStep)
+
+- Extend existing `handleStep.test.ts` to verify
+  `midiEngine.sendNote()` is called with the same
+  `scheduledTime` and `gain` as `audioEngine.playSound()`
+- Verify muted/soloed tracks are skipped for MIDI too
+
+### Manual testing
+
+1. Connect USB MIDI device
+2. Open XOX in Chrome, grant MIDI permission
+3. Open gear menu → MIDI Settings
+4. Enable MIDI, select device, set channel 10
+5. Play a pattern — verify external gear receives triggers
+6. Adjust note numbers — verify correct sounds trigger
+7. Change note length — verify audible duration difference
+8. Disconnect device mid-play — verify no errors, UI updates
+9. Reconnect — verify auto-reconnect
+
+## Timing Considerations
+
+Web MIDI's `MIDIOutput.send(data, timestamp)` uses
+`DOMHighResTimeStamp` (performance.now() basis), which is a
+different clock from `AudioContext.currentTime`. The time
+conversion introduces ~10–50ms of jitter. This is acceptable
+for drum triggers but worth noting:
+
+- MIDI and audio will not be perfectly sample-aligned
+- The jitter is comparable to hardware MIDI latency
+- For tighter sync, users can adjust their external gear's
+  audio monitoring to compensate
+
+## Future Work (Out of Scope)
+
+- MIDI clock and transport output — tracked as issue #58
+- Per-track MIDI channel (currently global only)
+- MIDI input (note triggering from external controllers)
+- MIDI CC output for continuous parameters
+- SysEx support

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/webmidi": "^2.1.0",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
@@ -2263,6 +2264,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.1.0.tgz",
+      "integrity": "sha512-k898MjEUSHB+6rSeCPQk/kLgie0wgWZ2t78GlWj86HbTQ+XmtbBafYg5LNjn8bVHfItEhPGZPf579Xfc6keV6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.52.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/webmidi": "^2.1.0",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",

--- a/plans/2026-03-21T00-00-midi-out.md
+++ b/plans/2026-03-21T00-00-midi-out.md
@@ -1,0 +1,1524 @@
+---
+date: 2026-03-21
+summary: Implement MIDI note output for XOX drum sequencer (issue #10)
+---
+
+# MIDI Out Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use subagent-driven-development
+> (if subagents available) or executing-plans to implement this plan.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send MIDI note-on/note-off messages from XOX's step
+sequencer to external hardware via the Web MIDI API.
+
+**Architecture:** A `MidiEngine` singleton handles Web MIDI API
+access, note scheduling, and config persistence. A `MidiContext`
+React context exposes MIDI state and config to the UI. A
+`MidiSettings` modal provides user controls. Integration into
+`handleStep` converts AudioContext time to `performance.now()`
+time and calls `midiEngine.sendNote()` alongside `playSound()`.
+
+**Tech Stack:** Web MIDI API, `@types/webmidi`, React 19 context,
+localStorage, Vitest + jsdom
+
+**Spec:** `docs/specs/2026-03-21-midi-out-design.md`
+
+---
+
+### Task 1: Add MIDI types to `types.ts`
+
+**Files:**
+- Modify: `src/app/types.ts:116` (append after SequencerConfig)
+- Test: `src/__tests__/types.test.ts`
+
+- [ ] **Step 1: Write the type assertion test**
+
+Add to `src/__tests__/types.test.ts`:
+
+```typescript
+import type {
+  NoteLength, MidiTrackConfig, MidiConfig,
+} from '../app/types';
+
+describe('MIDI types', () => {
+  it('MidiConfig has correct shape', () => {
+    const config: MidiConfig = {
+      enabled: false,
+      deviceId: null,
+      channel: 10,
+      noteLength: { type: 'fixed', ms: 50 },
+      tracks: {
+        bd: { noteNumber: 36 },
+        sd: { noteNumber: 38 },
+        ch: { noteNumber: 42 },
+        oh: { noteNumber: 46 },
+        cy: { noteNumber: 49 },
+        ht: { noteNumber: 50 },
+        mt: { noteNumber: 47 },
+        lt: { noteNumber: 43 },
+        rs: { noteNumber: 37 },
+        cp: { noteNumber: 39 },
+        cb: { noteNumber: 56 },
+      },
+    };
+    expect(config.channel).toBe(10);
+    expect(config.tracks.bd.noteNumber).toBe(36);
+  });
+
+  it('NoteLength supports fixed and percent', () => {
+    const fixed: NoteLength = { type: 'fixed', ms: 50 };
+    const pct: NoteLength = { type: 'percent', value: 75 };
+    expect(fixed.type).toBe('fixed');
+    expect(pct.type).toBe('percent');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/types.test.ts`
+Expected: FAIL — `NoteLength`, `MidiTrackConfig`, `MidiConfig`
+not exported from `types.ts`.
+
+- [ ] **Step 3: Add the types**
+
+Append to `src/app/types.ts` after `SequencerConfig`:
+
+```typescript
+/** Note length: fixed milliseconds or tempo-relative. */
+export type NoteLength =
+  | { type: 'fixed'; ms: number }
+  | { type: 'percent'; value: number };
+
+/** Per-track MIDI note mapping. */
+export interface MidiTrackConfig {
+  noteNumber: number;  // 0–127
+}
+
+/** Complete MIDI output configuration. */
+export interface MidiConfig {
+  enabled: boolean;
+  deviceId: string | null;
+  channel: number;  // 1–16
+  noteLength: NoteLength;
+  tracks: Record<
+    Exclude<TrackId, 'ac'>,
+    MidiTrackConfig
+  >;
+}
+
+/** Default GM drum map note numbers. */
+export const GM_DRUM_MAP: Record<
+  Exclude<TrackId, 'ac'>, number
+> = {
+  bd: 36, sd: 38, ch: 42, oh: 46, cy: 49,
+  ht: 50, mt: 47, lt: 43, rs: 37, cp: 39, cb: 56,
+} as const;
+
+/** Factory for default MidiConfig. */
+export function defaultMidiConfig(): MidiConfig {
+  const tracks = {} as MidiConfig['tracks'];
+  for (const [id, note] of
+    Object.entries(GM_DRUM_MAP) as
+      [Exclude<TrackId, 'ac'>, number][]
+  ) {
+    tracks[id] = { noteNumber: note };
+  }
+  return {
+    enabled: false,
+    deviceId: null,
+    channel: 10,
+    noteLength: { type: 'fixed', ms: 50 },
+    tracks,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/__tests__/types.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/types.ts src/__tests__/types.test.ts
+git commit -m "Add MIDI config types and GM drum map defaults"
+```
+
+---
+
+### Task 2: Install `@types/webmidi`
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the types package**
+
+Run: `npm install --save-dev @types/webmidi`
+
+- [ ] **Step 2: Verify TypeScript sees the MIDI types**
+
+Run: `npx tsc --noEmit`
+Expected: No new errors.
+
+- [ ] **Step 3: Commit**
+
+```
+git add package.json package-lock.json
+git commit -m "Add @types/webmidi dev dependency"
+```
+
+---
+
+### Task 3: Build `MidiEngine` with tests (TDD)
+
+**Files:**
+- Create: `src/app/MidiEngine.ts`
+- Create: `src/__tests__/midiEngine.test.ts`
+
+This is the largest task. Build it method-by-method using TDD.
+The engine is a plain TypeScript class with no React dependencies.
+
+#### 3a: Scaffold and `init()`
+
+- [ ] **Step 1: Write the init tests**
+
+Create `src/__tests__/midiEngine.test.ts`:
+
+```typescript
+import {
+  describe, expect, it, vi, beforeEach, afterEach,
+} from 'vitest';
+
+// Mock MIDIOutput
+function createMockOutput(
+  id: string, name: string
+): MIDIOutput {
+  return {
+    id,
+    name,
+    manufacturer: '',
+    version: '',
+    state: 'connected',
+    connection: 'open',
+    type: 'output',
+    send: vi.fn(),
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    onstatechange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MIDIOutput;
+}
+
+// Mock MIDIAccess
+function createMockAccess(
+  outputs: MIDIOutput[] = []
+): MIDIAccess {
+  const outputMap = new Map(
+    outputs.map(o => [o.id, o])
+  );
+  return {
+    inputs: new Map(),
+    outputs: outputMap,
+    sysexEnabled: false,
+    onstatechange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MIDIAccess;
+}
+
+let MidiEngine: typeof import('../app/MidiEngine').MidiEngine;
+
+beforeEach(async () => {
+  localStorage.clear();
+  vi.stubGlobal('performance', {
+    now: vi.fn(() => 0),
+  });
+  // Fresh import each test to reset singleton state
+  vi.resetModules();
+  const mod = await import('../app/MidiEngine');
+  MidiEngine = mod.MidiEngine;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MidiEngine.init()', () => {
+  it('returns true when MIDI access granted', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when API unavailable', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: undefined,
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when permission denied', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockRejectedValue(
+        new DOMException('denied')
+      ),
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(false);
+  });
+
+  it('is idempotent', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    const reqFn = vi.fn().mockResolvedValue(access);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: reqFn,
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    await engine.init();
+    expect(reqFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads config from localStorage', async () => {
+    const saved = {
+      enabled: true,
+      deviceId: 'out1',
+      channel: 5,
+      noteLength: { type: 'fixed', ms: 100 },
+      tracks: {
+        bd: { noteNumber: 36 }, sd: { noteNumber: 38 },
+        ch: { noteNumber: 42 }, oh: { noteNumber: 46 },
+        cy: { noteNumber: 49 }, ht: { noteNumber: 50 },
+        mt: { noteNumber: 47 }, lt: { noteNumber: 43 },
+        rs: { noteNumber: 37 }, cp: { noteNumber: 39 },
+        cb: { noteNumber: 56 },
+      },
+    };
+    localStorage.setItem('xox-midi', JSON.stringify(saved));
+
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    expect(engine.getConfig().channel).toBe(5);
+    expect(engine.getConfig().noteLength).toEqual(
+      { type: 'fixed', ms: 100 }
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/midiEngine.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement MidiEngine scaffold with init()**
+
+Create `src/app/MidiEngine.ts`:
+
+```typescript
+"use client";
+
+import type {
+  MidiConfig, TrackId, NoteLength,
+} from './types';
+import { defaultMidiConfig } from './types';
+
+const STORAGE_KEY = 'xox-midi';
+
+export class MidiEngine {
+  private access: MIDIAccess | null = null;
+  private output: MIDIOutput | null = null;
+  private config: MidiConfig;
+  private bpm: number = 120;
+  private initPromise: Promise<boolean> | null = null;
+  private onDeviceChange:
+    ((outputs: MIDIOutput[]) => void) | null = null;
+
+  constructor() {
+    this.config = this.loadConfig();
+  }
+
+  private loadConfig(): MidiConfig {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw) as MidiConfig;
+    } catch { /* ignore */ }
+    return defaultMidiConfig();
+  }
+
+  private saveConfig(): void {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(this.config)
+    );
+  }
+
+  async init(): Promise<boolean> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.doInit();
+    return this.initPromise;
+  }
+
+  private async doInit(): Promise<boolean> {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.requestMIDIAccess
+    ) {
+      return false;
+    }
+    try {
+      this.access = await navigator.requestMIDIAccess(
+        { sysex: false }
+      );
+    } catch {
+      return false;
+    }
+
+    // Auto-select saved device if available
+    if (this.config.deviceId) {
+      const saved = this.access.outputs.get(
+        this.config.deviceId
+      );
+      if (saved) this.output = saved;
+    }
+
+    // Listen for hotplug
+    this.access.addEventListener(
+      'statechange',
+      this.handleStateChange
+    );
+
+    return true;
+  }
+
+  private handleStateChange = (): void => {
+    if (!this.access) return;
+
+    // Check if current output disconnected
+    if (
+      this.output &&
+      this.output.state === 'disconnected'
+    ) {
+      this.output = null;
+    }
+
+    // Try to reconnect saved device
+    if (!this.output && this.config.deviceId) {
+      const saved = this.access.outputs.get(
+        this.config.deviceId
+      );
+      if (saved && saved.state === 'connected') {
+        this.output = saved;
+      }
+    }
+
+    // Notify UI
+    if (this.onDeviceChange) {
+      this.onDeviceChange(this.getOutputs());
+    }
+  };
+
+  getOutputs(): MIDIOutput[] {
+    if (!this.access) return [];
+    return Array.from(this.access.outputs.values());
+  }
+
+  setOutput(deviceId: string): void {
+    if (!this.access) return;
+    const device = this.access.outputs.get(deviceId);
+    if (device) {
+      this.output = device;
+      this.config.deviceId = deviceId;
+      this.saveConfig();
+    }
+  }
+
+  getConfig(): MidiConfig {
+    return this.config;
+  }
+
+  updateConfig(partial: Partial<MidiConfig>): void {
+    // Send All Notes Off on old channel before changes
+    if (
+      ('channel' in partial &&
+        partial.channel !== this.config.channel) ||
+      ('tracks' in partial)
+    ) {
+      this.sendAllNotesOff();
+    }
+
+    this.config = { ...this.config, ...partial };
+    this.saveConfig();
+  }
+
+  setBpm(bpm: number): void {
+    this.bpm = bpm;
+  }
+
+  setOnDeviceChange(
+    cb: ((outputs: MIDIOutput[]) => void) | null
+  ): void {
+    this.onDeviceChange = cb;
+  }
+
+  private computeNoteLengthMs(): number {
+    const nl = this.config.noteLength;
+    if (nl.type === 'fixed') return nl.ms;
+    // percent of step duration
+    const stepMs = (60 / this.bpm) * 0.25 * 1000;
+    return stepMs * (nl.value / 100);
+  }
+
+  sendNote(
+    trackId: TrackId,
+    perfTimeMs: number,
+    gain: number
+  ): void {
+    if (!this.config.enabled) return;
+    if (!this.output) return;
+    if (trackId === 'ac') return;
+
+    const trackConfig = this.config.tracks[
+      trackId as Exclude<TrackId, 'ac'>
+    ];
+    if (!trackConfig) return;
+
+    const ch = this.config.channel - 1; // 0-indexed
+    const note = trackConfig.noteNumber;
+    const velocity = Math.max(
+      1, Math.round(Math.min(gain, 1.0) * 127)
+    );
+
+    const noteLengthMs = this.computeNoteLengthMs();
+
+    this.output.send(
+      [0x90 | ch, note, velocity],
+      perfTimeMs
+    );
+    this.output.send(
+      [0x80 | ch, note, 0],
+      perfTimeMs + noteLengthMs
+    );
+  }
+
+  stop(): void {
+    this.sendAllNotesOff();
+  }
+
+  private sendAllNotesOff(): void {
+    if (!this.output) return;
+    const ch = this.config.channel - 1;
+    this.output.send([0xB0 | ch, 123, 0]);
+  }
+}
+
+export const midiEngine = new MidiEngine();
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/midiEngine.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/MidiEngine.ts src/__tests__/midiEngine.test.ts
+git commit -m "Add MidiEngine with init and config loading"
+```
+
+#### 3b: `sendNote()` tests
+
+- [ ] **Step 6: Write sendNote tests**
+
+Append to `src/__tests__/midiEngine.test.ts`:
+
+```typescript
+describe('MidiEngine.sendNote()', () => {
+  async function setupEngine(
+    opts: { enabled?: boolean; channel?: number } = {}
+  ) {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.setOutput('out1');
+    engine.updateConfig({
+      enabled: opts.enabled ?? true,
+      channel: opts.channel ?? 10,
+    });
+    engine.setBpm(120);
+    return { engine, output };
+  }
+
+  it('sends correct note-on and note-off bytes', async () => {
+    const { engine, output } = await setupEngine(
+      { channel: 10 }
+    );
+    engine.sendNote('bd', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).toHaveBeenCalledTimes(2);
+
+    // Note-on: 0x90 | 9 = 0x99, note 36, velocity
+    const noteOn = send.mock.calls[0];
+    expect(noteOn[0][0]).toBe(0x99);    // channel 10
+    expect(noteOn[0][1]).toBe(36);      // BD note
+    expect(noteOn[0][2]).toBe(
+      Math.max(1, Math.round(Math.min(0.8, 1.0) * 127))
+    );
+    expect(noteOn[1]).toBe(1000);       // timestamp
+
+    // Note-off: 0x80 | 9 = 0x89
+    const noteOff = send.mock.calls[1];
+    expect(noteOff[0][0]).toBe(0x89);
+    expect(noteOff[0][1]).toBe(36);
+    expect(noteOff[0][2]).toBe(0);
+    expect(noteOff[1]).toBe(1050);      // 1000 + 50ms
+  });
+
+  it('clamps velocity to 127 for gain > 1.0', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('bd', 1000, 1.5);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send.mock.calls[0][0][2]).toBe(127);
+  });
+
+  it('clamps velocity minimum to 1', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('bd', 1000, 0.001);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send.mock.calls[0][0][2]).toBe(1);
+  });
+
+  it('no-ops when disabled', async () => {
+    const { engine, output } = await setupEngine(
+      { enabled: false }
+    );
+    engine.sendNote('bd', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for accent track', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('ac', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('uses percent-based note length with BPM', async () => {
+    const { engine, output } = await setupEngine();
+    engine.updateConfig({
+      noteLength: { type: 'percent', value: 50 },
+    });
+    engine.setBpm(120);
+    engine.sendNote('bd', 1000, 0.8);
+
+    // Step duration at 120 BPM = (60/120)*0.25*1000 = 125ms
+    // 50% of step = 62.5ms
+    const send = output.send as ReturnType<typeof vi.fn>;
+    const noteOffTime = send.mock.calls[1][1];
+    expect(noteOffTime).toBeCloseTo(1062.5);
+  });
+});
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/midiEngine.test.ts`
+Expected: PASS (implementation already in place from step 3).
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/__tests__/midiEngine.test.ts
+git commit -m "Add sendNote tests for MidiEngine"
+```
+
+#### 3c: `stop()` and config change tests
+
+- [ ] **Step 9: Write stop and config change tests**
+
+Append to `src/__tests__/midiEngine.test.ts`:
+
+```typescript
+describe('MidiEngine.stop()', () => {
+  it('sends All Notes Off CC 123', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.setOutput('out1');
+    engine.updateConfig({ enabled: true, channel: 10 });
+
+    (output.send as ReturnType<typeof vi.fn>).mockClear();
+    engine.stop();
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).toHaveBeenCalledWith([0xB9, 123, 0]);
+  });
+});
+
+describe('MidiEngine config changes', () => {
+  it('sends All Notes Off on old channel when changing',
+    async () => {
+      const output = createMockOutput('out1', 'Synth');
+      const access = createMockAccess([output]);
+      vi.stubGlobal('navigator', {
+        ...navigator,
+        requestMIDIAccess:
+          vi.fn().mockResolvedValue(access),
+      });
+
+      const engine = new MidiEngine();
+      await engine.init();
+      engine.setOutput('out1');
+      engine.updateConfig(
+        { enabled: true, channel: 5 }
+      );
+
+      (output.send as ReturnType<typeof vi.fn>)
+        .mockClear();
+      engine.updateConfig({ channel: 10 });
+
+      const send =
+        output.send as ReturnType<typeof vi.fn>;
+      // All Notes Off on channel 5 (0xB4 = 0xB0 | 4)
+      expect(send).toHaveBeenCalledWith([0xB4, 123, 0]);
+    }
+  );
+
+  it('persists config to localStorage', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.updateConfig({ channel: 7 });
+
+    const stored = JSON.parse(
+      localStorage.getItem('xox-midi')!
+    );
+    expect(stored.channel).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `npm test -- src/__tests__/midiEngine.test.ts`
+Expected: PASS
+
+- [ ] **Step 11: Commit**
+
+```
+git add src/__tests__/midiEngine.test.ts
+git commit -m "Add stop and config change tests for MidiEngine"
+```
+
+---
+
+### Task 4: Add `getCurrentTime()` to AudioEngine
+
+**Files:**
+- Modify: `src/app/AudioEngine.ts:217` (before closing brace)
+- Test: `src/__tests__/audioEngine.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Add to `src/__tests__/audioEngine.test.ts`:
+
+```typescript
+describe('getCurrentTime()', () => {
+  it('returns AudioContext.currentTime', async () => {
+    mockCurrentTime = 1.234;
+    await audioEngine.preloadKit('808');
+    expect(audioEngine.getCurrentTime()).toBe(1.234);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/audioEngine.test.ts`
+Expected: FAIL — `getCurrentTime` does not exist.
+
+- [ ] **Step 3: Add the getter**
+
+Add to `src/app/AudioEngine.ts` before the closing `}` of
+the class (before line 218):
+
+```typescript
+  /**
+   * Returns the current AudioContext time in seconds.
+   * Used by MIDI integration to convert audio time to
+   * performance.now() timestamps.
+   */
+  public getCurrentTime(): number {
+    return this.ctx?.currentTime ?? 0;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/__tests__/audioEngine.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/AudioEngine.ts src/__tests__/audioEngine.test.ts
+git commit -m "Add getCurrentTime() getter to AudioEngine"
+```
+
+---
+
+### Task 5: Integrate `sendNote` into `handleStep`
+
+**Files:**
+- Modify: `src/app/SequencerContext.tsx:15` (add import)
+- Modify: `src/app/SequencerContext.tsx:420-422` (add sendNote
+  call after playSound)
+- Modify: `src/app/SequencerContext.tsx:444-445` (add stop call)
+- Modify: `src/app/SequencerContext.tsx:322-323` (add BPM sync)
+- Test: `src/__tests__/handleStep.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Add MIDI mock to `src/__tests__/handleStep.test.ts` alongside
+the existing AudioEngine mock. Add after the `vi.mock`
+for AudioEngine (line 25):
+
+```typescript
+const mockSendNote = vi.fn();
+const mockMidiStop = vi.fn();
+
+vi.mock('../app/MidiEngine', () => ({
+  midiEngine: {
+    sendNote: (...args: unknown[]) =>
+      mockSendNote(...args),
+    stop: (...args: unknown[]) =>
+      mockMidiStop(...args),
+    setBpm: vi.fn(),
+    init: vi.fn().mockResolvedValue(true),
+    getConfig: vi.fn().mockReturnValue({
+      enabled: true,
+    }),
+    getOutputs: vi.fn().mockReturnValue([]),
+    setOnDeviceChange: vi.fn(),
+    updateConfig: vi.fn(),
+  },
+}));
+```
+
+Add these tests at the end of the `handleStep` describe block:
+
+```typescript
+it('calls midiEngine.sendNote alongside playSound',
+  async () => {
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      gains: { bd: 1.0 },
+    });
+
+    expect(mp).toHaveBeenCalledTimes(1);
+    expect(mockSendNote).toHaveBeenCalledTimes(1);
+
+    // Same track and gain
+    expect(mockSendNote.mock.calls[0][0]).toBe('bd');
+    expect(mockSendNote.mock.calls[0][2]).toBe(
+      mp.mock.calls[0][2]
+    );
+
+    // perfTimeMs is a valid number (not NaN/undefined)
+    const perfTimeMs = mockSendNote.mock.calls[0][1];
+    expect(perfTimeMs).toEqual(expect.any(Number));
+    expect(Number.isNaN(perfTimeMs)).toBe(false);
+  }
+);
+
+it('skips MIDI for muted tracks', async () => {
+  await setupAndTrigger({
+    activeTracks: ['bd', 'sd'],
+    muteTracks: ['bd'],
+  });
+
+  const sentIds = mockSendNote.mock.calls.map(
+    (c: unknown[]) => c[0]
+  );
+  expect(sentIds).not.toContain('bd');
+  expect(sentIds).toContain('sd');
+});
+```
+
+Also add `mockSendNote.mockClear()` and
+`mockMidiStop.mockClear()` to the `beforeEach` blocks in
+the existing describe blocks, and to `setupAndTrigger`
+alongside `mockPlaySound.mockClear()`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/__tests__/handleStep.test.ts`
+Expected: FAIL — `midiEngine.sendNote` never called.
+
+- [ ] **Step 3: Add the integration code**
+
+In `src/app/SequencerContext.tsx`:
+
+Add import (after line 15):
+```typescript
+import { midiEngine } from './MidiEngine';
+```
+
+After the `audioEngine.playSound()` call (~line 420-422),
+add:
+
+```typescript
+          // MIDI output (convert AudioContext time to
+          // performance.now timestamp)
+          const perfTimeMs = performance.now()
+            + (scheduledTime
+              - audioEngine.getCurrentTime()) * 1000;
+          midiEngine.sendNote(
+            track.id, perfTimeMs, gain
+          );
+```
+
+In the `togglePlay` callback, after `audioEngine.stop()`
+(~line 445):
+```typescript
+      midiEngine.stop();
+```
+
+In the BPM effect (~line 322), add alongside
+`audioEngine.setBpm`:
+```typescript
+  midiEngine.setBpm(config.bpm);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/__tests__/handleStep.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npm test`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/app/SequencerContext.tsx \
+  src/__tests__/handleStep.test.ts
+git commit -m "Integrate MidiEngine sendNote into handleStep"
+```
+
+---
+
+### Task 6: Build `MidiContext`
+
+**Files:**
+- Create: `src/app/MidiContext.tsx`
+
+This context wraps MidiEngine for React consumption: init
+on mount, hotplug subscription, config state.
+
+- [ ] **Step 1: Create MidiContext**
+
+Create `src/app/MidiContext.tsx`:
+
+```typescript
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { midiEngine } from './MidiEngine';
+import type { MidiConfig } from './types';
+import { defaultMidiConfig } from './types';
+
+interface MidiContextValue {
+  available: boolean;
+  config: MidiConfig;
+  outputs: MIDIOutput[];
+  updateConfig: (partial: Partial<MidiConfig>) => void;
+}
+
+const MidiContext = createContext<
+  MidiContextValue | null
+>(null);
+
+export function useMidi(): MidiContextValue | null {
+  return useContext(MidiContext);
+}
+
+interface MidiProviderProps {
+  children: ReactNode;
+}
+
+export function MidiProvider({
+  children,
+}: MidiProviderProps) {
+  const [available, setAvailable] = useState(false);
+  const [config, setConfig] = useState<MidiConfig>(
+    defaultMidiConfig
+  );
+  const [outputs, setOutputs] = useState<MIDIOutput[]>(
+    []
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    midiEngine.setOnDeviceChange((newOutputs) => {
+      if (mounted) setOutputs(newOutputs);
+    });
+
+    midiEngine.init().then((ok) => {
+      if (!mounted) return;
+      setAvailable(ok);
+      if (ok) {
+        setConfig(midiEngine.getConfig());
+        setOutputs(midiEngine.getOutputs());
+      }
+    });
+
+    return () => {
+      mounted = false;
+      midiEngine.setOnDeviceChange(null);
+    };
+  }, []);
+
+  const updateConfig = useCallback(
+    (partial: Partial<MidiConfig>) => {
+      midiEngine.updateConfig(partial);
+      setConfig(midiEngine.getConfig());
+    },
+    []
+  );
+
+  return (
+    <MidiContext value={{
+      available,
+      config,
+      outputs,
+      updateConfig,
+    }}>
+      {children}
+    </MidiContext>
+  );
+}
+```
+
+- [ ] **Step 2: Run lint and type check**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/app/MidiContext.tsx
+git commit -m "Add MidiContext provider for MIDI state"
+```
+
+---
+
+### Task 7: Wire `MidiProvider` into the app
+
+**Files:**
+- Modify: `src/app/Sequencer.tsx:80-83`
+
+- [ ] **Step 1: Wrap SequencerProvider with MidiProvider**
+
+In `src/app/Sequencer.tsx`, add import:
+```typescript
+import { MidiProvider } from './MidiContext';
+```
+
+Wrap `SequencerInner` in the default export:
+```typescript
+export default function Sequencer() {
+  return (
+    <SequencerProvider>
+      <MidiProvider>
+        <SequencerInner />
+      </MidiProvider>
+    </SequencerProvider>
+  );
+}
+```
+
+`MidiProvider` is inside `SequencerProvider` so that MIDI
+components can access sequencer state if needed. The
+`midiEngine.init()` call happens inside `MidiProvider`'s
+mount effect.
+
+- [ ] **Step 2: Run lint and type check**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npm test`
+Expected: All PASS.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/app/Sequencer.tsx
+git commit -m "Wire MidiProvider into app component tree"
+```
+
+---
+
+### Task 8: Build MIDI settings modal
+
+**Files:**
+- Create: `src/app/MidiSettings.tsx`
+- Modify: `src/app/SettingsPopover.tsx`
+
+- [ ] **Step 1: Create MidiSettings component**
+
+Create `src/app/MidiSettings.tsx`. This is a modal dialog
+with enable toggle, device picker, channel selector, note
+length dropdown, and per-track note number inputs.
+
+```typescript
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import { useMidi } from './MidiContext';
+import { TRACKS } from './SequencerContext';
+import type {
+  MidiConfig, NoteLength, TrackId,
+} from './types';
+import { midiEngine } from './MidiEngine';
+
+const NOTE_LENGTH_OPTIONS: {
+  label: string;
+  value: NoteLength;
+}[] = [
+  { label: '10 ms',
+    value: { type: 'fixed', ms: 10 } },
+  { label: '25 ms',
+    value: { type: 'fixed', ms: 25 } },
+  { label: '50 ms',
+    value: { type: 'fixed', ms: 50 } },
+  { label: '100 ms',
+    value: { type: 'fixed', ms: 100 } },
+  { label: '50% of step',
+    value: { type: 'percent', value: 50 } },
+  { label: '75% of step',
+    value: { type: 'percent', value: 75 } },
+];
+
+function noteLengthKey(nl: NoteLength): string {
+  return nl.type === 'fixed'
+    ? `fixed-${nl.ms}`
+    : `percent-${nl.value}`;
+}
+
+interface MidiSettingsProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function MidiSettings({
+  isOpen,
+  onClose,
+}: MidiSettingsProps) {
+  const midi = useMidi();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) onClose();
+    },
+    [onClose]
+  );
+
+  if (!midi) return null;
+  const { available, config, outputs, updateConfig } = midi;
+
+  const disabled = !available;
+  const statusMsg = !available
+    ? (typeof navigator !== 'undefined' &&
+        'requestMIDIAccess' in navigator
+      ? 'MIDI access denied'
+      : 'MIDI not supported in this browser')
+    : outputs.length === 0
+      ? 'No MIDI devices detected'
+      : null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      onClick={handleBackdropClick}
+      className="backdrop:bg-black/60 bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl text-neutral-200 p-0 max-w-md w-full"
+    >
+      <div className="p-6">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-lg font-semibold">
+            MIDI Settings
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-neutral-400 hover:text-neutral-200 text-xl leading-none"
+          >
+            &times;
+          </button>
+        </div>
+
+        {statusMsg && (
+          <p className="text-sm text-amber-400 mb-4">
+            {statusMsg}
+          </p>
+        )}
+
+        {/* Enable toggle */}
+        <label className="flex items-center gap-3 mb-4">
+          <input
+            type="checkbox"
+            checked={config.enabled}
+            disabled={disabled}
+            onChange={(e) =>
+              updateConfig({
+                enabled: e.target.checked,
+              })
+            }
+            className="accent-orange-500 w-4 h-4"
+          />
+          <span className="text-sm">Enable MIDI output</span>
+        </label>
+
+        {/* Device picker */}
+        <label className="block mb-4">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Output Device
+          </span>
+          <select
+            value={config.deviceId ?? ''}
+            disabled={disabled || outputs.length === 0}
+            onChange={(e) => {
+              midiEngine.setOutput(e.target.value);
+              updateConfig({
+                deviceId: e.target.value,
+              });
+            }}
+            className="w-full bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          >
+            <option value="">
+              {outputs.length === 0
+                ? 'No devices'
+                : 'Select device…'}
+            </option>
+            {outputs.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name || o.id}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Channel */}
+        <label className="block mb-4">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Channel
+          </span>
+          <input
+            type="number"
+            min={1}
+            max={16}
+            value={config.channel}
+            disabled={disabled}
+            onChange={(e) =>
+              updateConfig({
+                channel: Math.max(
+                  1, Math.min(16,
+                    parseInt(e.target.value) || 1)
+                ),
+              })
+            }
+            className="w-20 bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          />
+        </label>
+
+        {/* Note length */}
+        <label className="block mb-6">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Note Length
+          </span>
+          <select
+            value={noteLengthKey(config.noteLength)}
+            disabled={disabled}
+            onChange={(e) => {
+              const opt = NOTE_LENGTH_OPTIONS.find(
+                (o) =>
+                  noteLengthKey(o.value) ===
+                  e.target.value
+              );
+              if (opt) {
+                updateConfig({
+                  noteLength: opt.value,
+                });
+              }
+            }}
+            className="w-full bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          >
+            {NOTE_LENGTH_OPTIONS.map((opt) => (
+              <option
+                key={noteLengthKey(opt.value)}
+                value={noteLengthKey(opt.value)}
+              >
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Track note mapping */}
+        <div>
+          <span className="text-sm text-neutral-400 block mb-2">
+            Track Notes (MIDI note 0–127)
+          </span>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+            {TRACKS.map((track) => (
+              <label
+                key={track.id}
+                className="flex items-center gap-2"
+              >
+                <span className="text-xs font-mono w-12 text-neutral-400">
+                  {track.id.toUpperCase()}
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  max={127}
+                  value={
+                    config.tracks[
+                      track.id as Exclude<
+                        TrackId, 'ac'
+                      >
+                    ]?.noteNumber ?? 0
+                  }
+                  disabled={disabled}
+                  onChange={(e) => {
+                    const note = Math.max(
+                      0,
+                      Math.min(
+                        127,
+                        parseInt(e.target.value) || 0
+                      )
+                    );
+                    updateConfig({
+                      tracks: {
+                        ...config.tracks,
+                        [track.id]: {
+                          noteNumber: note,
+                        },
+                      },
+                    });
+                  }}
+                  className="w-16 bg-neutral-800 border border-neutral-600 rounded px-2 py-1 text-sm text-center disabled:opacity-50"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Add "MIDI Settings…" to SettingsPopover**
+
+In `src/app/SettingsPopover.tsx`:
+
+Add imports:
+```typescript
+import { useState } from 'react';
+import MidiSettings from './MidiSettings';
+```
+
+(Note: `useState` is already imported — just add it to the
+existing import if not already there.)
+
+Add state after the existing `feedback` state:
+```typescript
+const [midiOpen, setMidiOpen] = useState(false);
+```
+
+Add a new button inside the popover menu div, after the
+Export URL button (before the closing `</div>` of the
+popover):
+
+```tsx
+          <button
+            role="menuitem"
+            onClick={() => {
+              setMidiOpen(true);
+              setIsOpen(false);
+            }}
+            className="w-full text-left px-4 py-3 text-sm text-neutral-200 hover:bg-neutral-800 transition-colors border-t border-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500"
+          >
+            MIDI Settings…
+          </button>
+```
+
+Add the modal render at the end, before the closing
+`</div>` of the component's root div:
+
+```tsx
+      <MidiSettings
+        isOpen={midiOpen}
+        onClose={() => setMidiOpen(false)}
+      />
+```
+
+- [ ] **Step 3: Run lint and type check**
+
+Run: `npm run lint && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npm test`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/app/MidiSettings.tsx \
+  src/app/SettingsPopover.tsx
+git commit -m "Add MIDI settings modal and menu item"
+```
+
+---
+
+### Task 9: Build and test in browser
+
+**Files:** None (manual verification)
+
+This is a UI feature — verify it works in a real browser.
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Open in browser and test**
+
+Open the app. Click the gear icon. Verify:
+- "MIDI Settings…" menu item appears
+- Clicking it opens a modal dialog
+- If no MIDI device is connected, controls are disabled
+  with an appropriate status message
+- Modal dismisses via close button, Escape, or backdrop
+- If a MIDI device is available (or test with a virtual
+  MIDI device), verify enable toggle, device picker,
+  channel, note length, and track notes all work
+- Play a pattern — verify MIDI output is sent (use a MIDI
+  monitor app to verify)
+- Stop playback — verify no stuck notes
+
+- [ ] **Step 3: Fix any issues found**
+
+Address any visual or functional problems.
+
+- [ ] **Step 4: Stop dev server**
+
+- [ ] **Step 5: Commit any fixes**
+
+---
+
+### Task 10: Verify build and run full test suite
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: All PASS.
+
+- [ ] **Step 2: Run production build**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No errors.
+
+- [ ] **Step 4: Commit any remaining fixes**

--- a/src/__tests__/audioEngine.test.ts
+++ b/src/__tests__/audioEngine.test.ts
@@ -343,3 +343,11 @@ describe('AudioEngine playSound', () => {
     }).not.toThrow();
   });
 });
+
+describe('getCurrentTime()', () => {
+  it('returns AudioContext.currentTime', async () => {
+    mockCurrentTime = 1.234;
+    await audioEngine.preloadKit('808');
+    expect(audioEngine.getCurrentTime()).toBe(1.234);
+  });
+});

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -11,6 +11,8 @@ import { TestWrapper } from './helpers/sequencer-wrapper';
 const mockPlaySound = vi.fn();
 const mockStart = vi.fn();
 const mockStop = vi.fn();
+const mockSendNote = vi.fn();
+const mockMidiStop = vi.fn();
 
 const mockRequestReset = vi.fn();
 
@@ -23,7 +25,25 @@ vi.mock('../app/AudioEngine', () => ({
     setPatternLength: vi.fn(),
     playSound: (...args: unknown[]) => mockPlaySound(...args),
     requestReset: (...args: unknown[]) => mockRequestReset(...args),
+    getCurrentTime: vi.fn().mockReturnValue(0),
     onStep: vi.fn(),
+  },
+}));
+
+vi.mock('../app/MidiEngine', () => ({
+  midiEngine: {
+    sendNote: (...args: unknown[]) =>
+      mockSendNote(...args),
+    stop: (...args: unknown[]) =>
+      mockMidiStop(...args),
+    setBpm: vi.fn(),
+    init: vi.fn().mockResolvedValue(true),
+    getConfig: vi.fn().mockReturnValue({
+      enabled: true,
+    }),
+    getOutputs: vi.fn().mockReturnValue([]),
+    setOnDeviceChange: vi.fn(),
+    updateConfig: vi.fn(),
   },
 }));
 
@@ -114,6 +134,7 @@ async function setupAndTrigger(
 
   // Start playback to register handleStep
   mockPlaySound.mockClear();
+  mockSendNote.mockClear();
   mockStart.mockClear();
 
   await act(async () => {
@@ -148,6 +169,8 @@ describe('handleStep', () => {
     mockPlaySound.mockClear();
     mockStart.mockClear();
     mockStop.mockClear();
+    mockSendNote.mockClear();
+    mockMidiStop.mockClear();
   });
 
   it('no solos, no mutes: all active tracks play', async () => {
@@ -244,6 +267,42 @@ describe('handleStep', () => {
     const gainArg = mp.mock.calls[0][2];
     expect(gainArg).toBeCloseTo(0.125);
   });
+
+  it('calls midiEngine.sendNote alongside playSound',
+    async () => {
+      const { mockPlaySound: mp } = await setupAndTrigger({
+        activeTracks: ['bd'],
+        gains: { bd: 1.0 },
+      });
+
+      expect(mp).toHaveBeenCalledTimes(1);
+      expect(mockSendNote).toHaveBeenCalledTimes(1);
+
+      // Same track and gain
+      expect(mockSendNote.mock.calls[0][0]).toBe('bd');
+      expect(mockSendNote.mock.calls[0][2]).toBe(
+        mp.mock.calls[0][2]
+      );
+
+      // perfTimeMs is a valid number (not NaN/undefined)
+      const perfTimeMs = mockSendNote.mock.calls[0][1];
+      expect(perfTimeMs).toEqual(expect.any(Number));
+      expect(Number.isNaN(perfTimeMs)).toBe(false);
+    }
+  );
+
+  it('skips MIDI for muted tracks', async () => {
+    await setupAndTrigger({
+      activeTracks: ['bd', 'sd'],
+      muteTracks: ['bd'],
+    });
+
+    const sentIds = mockSendNote.mock.calls.map(
+      (c: unknown[]) => c[0]
+    );
+    expect(sentIds).not.toContain('bd');
+    expect(sentIds).toContain('sd');
+  });
 });
 
 // -------------------------------------------------
@@ -254,6 +313,8 @@ describe('handleStep swing timing', () => {
     mockPlaySound.mockClear();
     mockStart.mockClear();
     mockStop.mockClear();
+    mockSendNote.mockClear();
+    mockMidiStop.mockClear();
   });
 
   it('odd step with swing: time is offset', async () => {
@@ -491,6 +552,8 @@ describe('trig conditions in handleStep', () => {
     mockPlaySound.mockClear();
     mockStart.mockClear();
     mockStop.mockClear();
+    mockSendNote.mockClear();
+    mockMidiStop.mockClear();
   });
 
   it('step with probability condition can be suppressed',
@@ -851,6 +914,8 @@ describe('handleStep parameter locks', () => {
     mockPlaySound.mockClear();
     mockStart.mockClear();
     mockStop.mockClear();
+    mockSendNote.mockClear();
+    mockMidiStop.mockClear();
   });
 
   it('gain lock overrides mixer gain', async () => {

--- a/src/__tests__/midiEngine.test.ts
+++ b/src/__tests__/midiEngine.test.ts
@@ -1,0 +1,345 @@
+import {
+  describe, expect, it, vi, beforeEach, afterEach,
+} from 'vitest';
+import { MidiEngine } from '../app/MidiEngine';
+
+// Mock MIDIOutput
+function createMockOutput(
+  id: string, name: string
+): MIDIOutput {
+  return {
+    id,
+    name,
+    manufacturer: '',
+    version: '',
+    state: 'connected',
+    connection: 'open',
+    type: 'output',
+    send: vi.fn(),
+    open: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    onstatechange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MIDIOutput;
+}
+
+// Mock MIDIAccess
+function createMockAccess(
+  outputs: MIDIOutput[] = []
+): MIDIAccess {
+  const outputMap = new Map(
+    outputs.map(o => [o.id, o])
+  );
+  return {
+    inputs: new Map(),
+    outputs: outputMap,
+    sysexEnabled: false,
+    onstatechange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as unknown as MIDIAccess;
+}
+
+// Minimal localStorage mock for Node 25 compatibility
+// (Node 25 has a built-in localStorage without .clear())
+function createLocalStorageMock() {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createLocalStorageMock());
+  vi.stubGlobal('performance', {
+    now: vi.fn(() => 0),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MidiEngine.init()', () => {
+  it('returns true when MIDI access granted', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when API unavailable', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: undefined,
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when permission denied', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockRejectedValue(
+        new DOMException('denied')
+      ),
+    });
+
+    const engine = new MidiEngine();
+    const result = await engine.init();
+    expect(result).toBe(false);
+  });
+
+  it('is idempotent', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    const reqFn = vi.fn().mockResolvedValue(access);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: reqFn,
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    await engine.init();
+    expect(reqFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads config from localStorage', async () => {
+    const saved = {
+      enabled: true,
+      deviceId: 'out1',
+      channel: 5,
+      noteLength: { type: 'fixed', ms: 100 },
+      tracks: {
+        bd: { noteNumber: 36 }, sd: { noteNumber: 38 },
+        ch: { noteNumber: 42 }, oh: { noteNumber: 46 },
+        cy: { noteNumber: 49 }, ht: { noteNumber: 50 },
+        mt: { noteNumber: 47 }, lt: { noteNumber: 43 },
+        rs: { noteNumber: 37 }, cp: { noteNumber: 39 },
+        cb: { noteNumber: 56 },
+      },
+    };
+    localStorage.setItem('xox-midi', JSON.stringify(saved));
+
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    expect(engine.getConfig().channel).toBe(5);
+    expect(engine.getConfig().noteLength).toEqual(
+      { type: 'fixed', ms: 100 }
+    );
+  });
+});
+
+describe('MidiEngine.sendNote()', () => {
+  async function setupEngine(
+    opts: { enabled?: boolean; channel?: number } = {}
+  ) {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.setOutput('out1');
+    engine.updateConfig({
+      enabled: opts.enabled ?? true,
+      channel: opts.channel ?? 10,
+    });
+    engine.setBpm(120);
+    return { engine, output };
+  }
+
+  it('sends correct note-on and note-off bytes', async () => {
+    const { engine, output } = await setupEngine(
+      { channel: 10 }
+    );
+    engine.sendNote('bd', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).toHaveBeenCalledTimes(2);
+
+    // Note-on: 0x90 | 9 = 0x99, note 36, velocity
+    const noteOn = send.mock.calls[0];
+    expect(noteOn[0][0]).toBe(0x99);    // channel 10
+    expect(noteOn[0][1]).toBe(36);      // BD note
+    expect(noteOn[0][2]).toBe(
+      Math.max(1, Math.round(Math.min(0.8, 1.0) * 127))
+    );
+    expect(noteOn[1]).toBe(1000);       // timestamp
+
+    // Note-off: 0x80 | 9 = 0x89
+    const noteOff = send.mock.calls[1];
+    expect(noteOff[0][0]).toBe(0x89);
+    expect(noteOff[0][1]).toBe(36);
+    expect(noteOff[0][2]).toBe(0);
+    expect(noteOff[1]).toBe(1050);      // 1000 + 50ms
+  });
+
+  it('clamps velocity to 127 for gain > 1.0', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('bd', 1000, 1.5);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send.mock.calls[0][0][2]).toBe(127);
+  });
+
+  it('clamps velocity minimum to 1', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('bd', 1000, 0.001);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send.mock.calls[0][0][2]).toBe(1);
+  });
+
+  it('no-ops when disabled', async () => {
+    const { engine, output } = await setupEngine(
+      { enabled: false }
+    );
+    engine.sendNote('bd', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for accent track', async () => {
+    const { engine, output } = await setupEngine();
+    engine.sendNote('ac', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('uses percent-based note length with BPM', async () => {
+    const { engine, output } = await setupEngine();
+    engine.updateConfig({
+      noteLength: { type: 'percent', value: 50 },
+    });
+    engine.setBpm(120);
+    engine.sendNote('bd', 1000, 0.8);
+
+    // Step duration at 120 BPM = (60/120)*0.25*1000 = 125ms
+    // 50% of step = 62.5ms
+    const send = output.send as ReturnType<typeof vi.fn>;
+    const noteOffTime = send.mock.calls[1][1];
+    expect(noteOffTime).toBeCloseTo(1062.5);
+  });
+
+  it('no-ops when no output device', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    // Don't call setOutput — no device selected
+    engine.updateConfig({ enabled: true, channel: 10 });
+    engine.sendNote('bd', 1000, 0.8);
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('MidiEngine.stop()', () => {
+  it('sends All Notes Off CC 123', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.setOutput('out1');
+    engine.updateConfig({ enabled: true, channel: 10 });
+
+    (output.send as ReturnType<typeof vi.fn>).mockClear();
+    engine.stop();
+
+    const send = output.send as ReturnType<typeof vi.fn>;
+    expect(send).toHaveBeenCalledWith([0xB9, 123, 0]);
+  });
+});
+
+describe('MidiEngine config changes', () => {
+  it('sends All Notes Off on old channel when changing',
+    async () => {
+      const output = createMockOutput('out1', 'Synth');
+      const access = createMockAccess([output]);
+      vi.stubGlobal('navigator', {
+        ...navigator,
+        requestMIDIAccess:
+          vi.fn().mockResolvedValue(access),
+      });
+
+      const engine = new MidiEngine();
+      await engine.init();
+      engine.setOutput('out1');
+      engine.updateConfig(
+        { enabled: true, channel: 5 }
+      );
+
+      (output.send as ReturnType<typeof vi.fn>)
+        .mockClear();
+      engine.updateConfig({ channel: 10 });
+
+      const send =
+        output.send as ReturnType<typeof vi.fn>;
+      // All Notes Off on channel 5 (0xB4 = 0xB0 | 4)
+      expect(send).toHaveBeenCalledWith([0xB4, 123, 0]);
+    }
+  );
+
+  it('persists config to localStorage', async () => {
+    const output = createMockOutput('out1', 'Synth');
+    const access = createMockAccess([output]);
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      requestMIDIAccess: vi.fn().mockResolvedValue(access),
+    });
+
+    const engine = new MidiEngine();
+    await engine.init();
+    engine.updateConfig({ channel: 7 });
+
+    const stored = JSON.parse(
+      localStorage.getItem('xox-midi')!
+    );
+    expect(stored.channel).toBe(7);
+  });
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,5 +1,44 @@
 import { describe, expect, it } from 'vitest';
 import { TRACK_IDS } from '../app/types';
+import type {
+  NoteLength, MidiTrackConfig, MidiConfig,
+} from '../app/types';
+
+describe('MIDI types', () => {
+  it('MidiConfig has correct shape', () => {
+    const config: MidiConfig = {
+      enabled: false,
+      deviceId: null,
+      channel: 10,
+      noteLength: { type: 'fixed', ms: 50 },
+      tracks: {
+        bd: { noteNumber: 36 },
+        sd: { noteNumber: 38 },
+        ch: { noteNumber: 42 },
+        oh: { noteNumber: 46 },
+        cy: { noteNumber: 49 },
+        ht: { noteNumber: 50 },
+        mt: { noteNumber: 47 },
+        lt: { noteNumber: 43 },
+        rs: { noteNumber: 37 },
+        cp: { noteNumber: 39 },
+        cb: { noteNumber: 56 },
+      },
+    };
+    expect(config.channel).toBe(10);
+    expect(config.tracks.bd.noteNumber).toBe(36);
+  });
+
+  it('NoteLength supports fixed and percent', () => {
+    const fixed: NoteLength = { type: 'fixed', ms: 50 };
+    const pct: NoteLength = { type: 'percent', value: 75 };
+    expect(fixed.type).toBe('fixed');
+    expect(pct.type).toBe('percent');
+  });
+});
+
+// Suppress unused-import warning for type-only import
+void (undefined as unknown as MidiTrackConfig);
 
 describe('TRACK_IDS', () => {
   it('ordering matches snapshot (append-only)', () => {

--- a/src/app/AudioEngine.ts
+++ b/src/app/AudioEngine.ts
@@ -228,6 +228,15 @@ class AudioEngine {
     // Schedule the sound to start at the exact 'time' calculated by the scheduler
     source.start(time);
   }
+
+  /**
+   * Returns the current AudioContext time in seconds.
+   * Used by MIDI integration to convert audio time to
+   * performance.now() timestamps.
+   */
+  public getCurrentTime(): number {
+    return this.ctx?.currentTime ?? 0;
+  }
 }
 
 export const audioEngine = new AudioEngine();

--- a/src/app/MidiContext.tsx
+++ b/src/app/MidiContext.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { midiEngine } from './MidiEngine';
+import type { MidiConfig } from './types';
+import { defaultMidiConfig } from './types';
+
+interface MidiContextValue {
+  available: boolean;
+  config: MidiConfig;
+  outputs: MIDIOutput[];
+  updateConfig: (partial: Partial<MidiConfig>) => void;
+}
+
+const MidiContext = createContext<
+  MidiContextValue | null
+>(null);
+
+export function useMidi(): MidiContextValue | null {
+  return useContext(MidiContext);
+}
+
+interface MidiProviderProps {
+  children: ReactNode;
+}
+
+export function MidiProvider({
+  children,
+}: MidiProviderProps) {
+  const [available, setAvailable] = useState(false);
+  const [config, setConfig] = useState<MidiConfig>(
+    defaultMidiConfig
+  );
+  const [outputs, setOutputs] = useState<MIDIOutput[]>(
+    []
+  );
+
+  useEffect(() => {
+    let mounted = true;
+
+    midiEngine.setOnDeviceChange((newOutputs) => {
+      if (mounted) setOutputs(newOutputs);
+    });
+
+    midiEngine.init().then((ok) => {
+      if (!mounted) return;
+      setAvailable(ok);
+      if (ok) {
+        setConfig(midiEngine.getConfig());
+        setOutputs(midiEngine.getOutputs());
+      }
+    });
+
+    return () => {
+      mounted = false;
+      midiEngine.setOnDeviceChange(null);
+    };
+  }, []);
+
+  const updateConfig = useCallback(
+    (partial: Partial<MidiConfig>) => {
+      midiEngine.updateConfig(partial);
+      setConfig(midiEngine.getConfig());
+    },
+    []
+  );
+
+  return (
+    <MidiContext value={{
+      available,
+      config,
+      outputs,
+      updateConfig,
+    }}>
+      {children}
+    </MidiContext>
+  );
+}

--- a/src/app/MidiContext.tsx
+++ b/src/app/MidiContext.tsx
@@ -14,6 +14,7 @@ import { defaultMidiConfig } from './types';
 
 interface MidiContextValue {
   available: boolean;
+  initialized: boolean;
   config: MidiConfig;
   outputs: MIDIOutput[];
   updateConfig: (partial: Partial<MidiConfig>) => void;
@@ -35,6 +36,7 @@ export function MidiProvider({
   children,
 }: MidiProviderProps) {
   const [available, setAvailable] = useState(false);
+  const [initialized, setInitialized] = useState(false);
   const [config, setConfig] = useState<MidiConfig>(
     defaultMidiConfig
   );
@@ -52,6 +54,7 @@ export function MidiProvider({
     midiEngine.init().then((ok) => {
       if (!mounted) return;
       setAvailable(ok);
+      setInitialized(true);
       if (ok) {
         setConfig(midiEngine.getConfig());
         setOutputs(midiEngine.getOutputs());
@@ -75,6 +78,7 @@ export function MidiProvider({
   return (
     <MidiContext value={{
       available,
+      initialized,
       config,
       outputs,
       updateConfig,

--- a/src/app/MidiEngine.ts
+++ b/src/app/MidiEngine.ts
@@ -1,0 +1,204 @@
+"use client";
+
+import type {
+  MidiConfig, TrackId,
+} from './types';
+import { defaultMidiConfig } from './types';
+
+const STORAGE_KEY = 'xox-midi';
+
+export class MidiEngine {
+  private access: MIDIAccess | null = null;
+  private output: MIDIOutput | null = null;
+  private config: MidiConfig;
+  private bpm: number = 120;
+  private initPromise: Promise<boolean> | null = null;
+  private onDeviceChange:
+    ((outputs: MIDIOutput[]) => void) | null = null;
+
+  constructor() {
+    this.config = this.loadConfig();
+  }
+
+  private loadConfig(): MidiConfig {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw) as MidiConfig;
+    } catch { /* ignore */ }
+    return defaultMidiConfig();
+  }
+
+  private saveConfig(): void {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(this.config)
+      );
+    } catch { /* ignore */ }
+  }
+
+  async init(): Promise<boolean> {
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.doInit();
+    return this.initPromise;
+  }
+
+  private async doInit(): Promise<boolean> {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.requestMIDIAccess
+    ) {
+      return false;
+    }
+    try {
+      this.access = await navigator.requestMIDIAccess(
+        { sysex: false }
+      );
+    } catch {
+      return false;
+    }
+
+    // Auto-select saved device if available
+    if (this.config.deviceId) {
+      const saved = this.access.outputs.get(
+        this.config.deviceId
+      );
+      if (saved) this.output = saved;
+    }
+
+    // Listen for hotplug
+    this.access.addEventListener(
+      'statechange',
+      this.handleStateChange
+    );
+
+    return true;
+  }
+
+  private handleStateChange = (): void => {
+    if (!this.access) return;
+
+    // Check if current output disconnected
+    if (
+      this.output &&
+      this.output.state === 'disconnected'
+    ) {
+      this.output = null;
+    }
+
+    // Try to reconnect saved device
+    if (!this.output && this.config.deviceId) {
+      const saved = this.access.outputs.get(
+        this.config.deviceId
+      );
+      if (saved && saved.state === 'connected') {
+        this.output = saved;
+      }
+    }
+
+    // Notify UI
+    if (this.onDeviceChange) {
+      this.onDeviceChange(this.getOutputs());
+    }
+  };
+
+  getOutputs(): MIDIOutput[] {
+    if (!this.access) return [];
+    return Array.from(this.access.outputs.values());
+  }
+
+  setOutput(deviceId: string): void {
+    if (!this.access) return;
+    const device = this.access.outputs.get(deviceId);
+    if (device) {
+      this.output = device;
+      this.config.deviceId = deviceId;
+      this.saveConfig();
+    }
+  }
+
+  getConfig(): MidiConfig {
+    return { ...this.config };
+  }
+
+  /** Use setOutput() to change the active device;
+   *  updateConfig persists deviceId but does not
+   *  sync the live MIDIOutput reference. */
+  updateConfig(partial: Partial<MidiConfig>): void {
+    // Send All Notes Off on old channel before changes
+    if (
+      'channel' in partial &&
+      partial.channel !== this.config.channel
+    ) {
+      this.sendAllNotesOff();
+    }
+
+    this.config = { ...this.config, ...partial };
+    this.saveConfig();
+  }
+
+  setBpm(bpm: number): void {
+    this.bpm = bpm;
+  }
+
+  setOnDeviceChange(
+    cb: ((outputs: MIDIOutput[]) => void) | null
+  ): void {
+    this.onDeviceChange = cb;
+  }
+
+  private computeNoteLengthMs(): number {
+    const nl = this.config.noteLength;
+    if (nl.type === 'fixed') return nl.ms;
+    // percent of step duration
+    const stepMs = (60 / this.bpm) * 0.25 * 1000;
+    return stepMs * (nl.value / 100);
+  }
+
+  /** Send a MIDI note-on/note-off pair for a step.
+   *  @param gain — expected in [0, 1]; values above 1.0
+   *  (e.g. accented steps) are clamped to velocity 127. */
+  sendNote(
+    trackId: TrackId,
+    perfTimeMs: number,
+    gain: number
+  ): void {
+    if (!this.config.enabled) return;
+    if (!this.output) return;
+    if (trackId === 'ac') return;
+
+    const trackConfig = this.config.tracks[
+      trackId as Exclude<TrackId, 'ac'>
+    ];
+    if (!trackConfig) return;
+
+    const ch = this.config.channel - 1; // 0-indexed
+    const note = trackConfig.noteNumber;
+    const velocity = Math.max(
+      1, Math.round(Math.min(gain, 1.0) * 127)
+    );
+
+    const noteLengthMs = this.computeNoteLengthMs();
+
+    this.output.send(
+      [0x90 | ch, note, velocity],
+      perfTimeMs
+    );
+    this.output.send(
+      [0x80 | ch, note, 0],
+      perfTimeMs + noteLengthMs
+    );
+  }
+
+  stop(): void {
+    this.sendAllNotesOff();
+  }
+
+  private sendAllNotesOff(): void {
+    if (!this.output) return;
+    const ch = this.config.channel - 1;
+    this.output.send([0xB0 | ch, 123, 0]);
+  }
+}
+
+export const midiEngine = new MidiEngine();

--- a/src/app/MidiSettings.tsx
+++ b/src/app/MidiSettings.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import { useMidi } from './MidiContext';
+import { TRACKS } from './SequencerContext';
+import type {
+  NoteLength, TrackId,
+} from './types';
+import { midiEngine } from './MidiEngine';
+
+const NOTE_LENGTH_OPTIONS: {
+  label: string;
+  value: NoteLength;
+}[] = [
+  { label: '10 ms',
+    value: { type: 'fixed', ms: 10 } },
+  { label: '25 ms',
+    value: { type: 'fixed', ms: 25 } },
+  { label: '50 ms',
+    value: { type: 'fixed', ms: 50 } },
+  { label: '100 ms',
+    value: { type: 'fixed', ms: 100 } },
+  { label: '50% of step',
+    value: { type: 'percent', value: 50 } },
+  { label: '75% of step',
+    value: { type: 'percent', value: 75 } },
+];
+
+function noteLengthKey(nl: NoteLength): string {
+  return nl.type === 'fixed'
+    ? `fixed-${nl.ms}`
+    : `percent-${nl.value}`;
+}
+
+interface MidiSettingsProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function MidiSettings({
+  isOpen,
+  onClose,
+}: MidiSettingsProps) {
+  const midi = useMidi();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) onClose();
+    },
+    [onClose]
+  );
+
+  if (!midi) return null;
+  const { available, config, outputs, updateConfig } = midi;
+
+  const disabled = !available;
+  const statusMsg = !available
+    ? (typeof navigator !== 'undefined' &&
+        'requestMIDIAccess' in navigator
+      ? 'MIDI access denied'
+      : 'MIDI not supported in this browser')
+    : outputs.length === 0
+      ? 'No MIDI devices detected'
+      : null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      onClick={handleBackdropClick}
+      className="backdrop:bg-black/60 bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl text-neutral-200 p-0 max-w-md w-full"
+    >
+      <div className="p-6">
+        <div className="flex justify-between items-center mb-6">
+          <h2 className="text-lg font-semibold">
+            MIDI Settings
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-neutral-400 hover:text-neutral-200 text-xl leading-none"
+          >
+            &times;
+          </button>
+        </div>
+
+        {statusMsg && (
+          <p className="text-sm text-amber-400 mb-4">
+            {statusMsg}
+          </p>
+        )}
+
+        {/* Enable toggle */}
+        <label className="flex items-center gap-3 mb-4">
+          <input
+            type="checkbox"
+            checked={config.enabled}
+            disabled={disabled}
+            onChange={(e) =>
+              updateConfig({
+                enabled: e.target.checked,
+              })
+            }
+            className="accent-orange-500 w-4 h-4"
+          />
+          <span className="text-sm">Enable MIDI output</span>
+        </label>
+
+        {/* Device picker */}
+        <label className="block mb-4">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Output Device
+          </span>
+          <select
+            value={config.deviceId ?? ''}
+            disabled={disabled || outputs.length === 0}
+            onChange={(e) => {
+              midiEngine.setOutput(e.target.value);
+              updateConfig({
+                deviceId: e.target.value,
+              });
+            }}
+            className="w-full bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          >
+            <option value="">
+              {outputs.length === 0
+                ? 'No devices'
+                : 'Select device…'}
+            </option>
+            {outputs.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.name || o.id}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Channel */}
+        <label className="block mb-4">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Channel
+          </span>
+          <input
+            type="number"
+            min={1}
+            max={16}
+            value={config.channel}
+            disabled={disabled}
+            onChange={(e) =>
+              updateConfig({
+                channel: Math.max(
+                  1, Math.min(16,
+                    parseInt(e.target.value) || 1)
+                ),
+              })
+            }
+            className="w-20 bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          />
+        </label>
+
+        {/* Note length */}
+        <label className="block mb-6">
+          <span className="text-sm text-neutral-400 block mb-1">
+            Note Length
+          </span>
+          <select
+            value={noteLengthKey(config.noteLength)}
+            disabled={disabled}
+            onChange={(e) => {
+              const opt = NOTE_LENGTH_OPTIONS.find(
+                (o) =>
+                  noteLengthKey(o.value) ===
+                  e.target.value
+              );
+              if (opt) {
+                updateConfig({
+                  noteLength: opt.value,
+                });
+              }
+            }}
+            className="w-full bg-neutral-800 border border-neutral-600 rounded px-3 py-2 text-sm disabled:opacity-50"
+          >
+            {NOTE_LENGTH_OPTIONS.map((opt) => (
+              <option
+                key={noteLengthKey(opt.value)}
+                value={noteLengthKey(opt.value)}
+              >
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Track note mapping */}
+        <div>
+          <span className="text-sm text-neutral-400 block mb-2">
+            Track Notes (MIDI note 0-127)
+          </span>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+            {TRACKS.map((track) => (
+              <label
+                key={track.id}
+                className="flex items-center gap-2"
+              >
+                <span className="text-xs font-mono w-12 text-neutral-400">
+                  {track.id.toUpperCase()}
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  max={127}
+                  value={
+                    config.tracks[
+                      track.id as Exclude<
+                        TrackId, 'ac'
+                      >
+                    ]?.noteNumber ?? 0
+                  }
+                  disabled={disabled}
+                  onChange={(e) => {
+                    const note = Math.max(
+                      0,
+                      Math.min(
+                        127,
+                        parseInt(e.target.value) || 0
+                      )
+                    );
+                    updateConfig({
+                      tracks: {
+                        ...config.tracks,
+                        [track.id]: {
+                          noteNumber: note,
+                        },
+                      },
+                    });
+                  }}
+                  className="w-16 bg-neutral-800 border border-neutral-600 rounded px-2 py-1 text-sm text-center disabled:opacity-50"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/MidiSettings.tsx
+++ b/src/app/MidiSettings.tsx
@@ -66,17 +66,18 @@ export default function MidiSettings({
   );
 
   if (!midi) return null;
-  const { available, config, outputs, updateConfig } = midi;
+  const {
+    available, initialized, config, outputs, updateConfig,
+  } = midi;
 
   const disabled = !available;
-  const statusMsg = !available
-    ? (typeof navigator !== 'undefined' &&
-        'requestMIDIAccess' in navigator
-      ? 'MIDI access denied'
-      : 'MIDI not supported in this browser')
-    : outputs.length === 0
-      ? 'No MIDI devices detected'
-      : null;
+  const statusMsg = !initialized
+    ? null
+    : !available
+      ? 'MIDI not available'
+      : outputs.length === 0
+        ? 'No MIDI devices detected'
+        : null;
 
   return (
     <dialog

--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -6,6 +6,7 @@ import {
 import { SequencerProvider, useSequencer }
   from './SequencerContext';
 import { TooltipProvider } from './TooltipContext';
+import { MidiProvider } from './MidiContext';
 import TransportControls from './TransportControls';
 import StepGrid from './StepGrid';
 import PageIndicator from './PageIndicator';
@@ -79,9 +80,11 @@ function SequencerInner() {
 export default function Sequencer() {
   return (
     <SequencerProvider>
-      <TooltipProvider>
-        <SequencerInner />
-      </TooltipProvider>
+      <MidiProvider>
+        <TooltipProvider>
+          <SequencerInner />
+        </TooltipProvider>
+      </MidiProvider>
     </SequencerProvider>
   );
 }

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -13,6 +13,7 @@ import {
 import kitsData from './data/kits.json';
 import patternsData from './data/patterns.json';
 import { audioEngine } from './AudioEngine';
+import { midiEngine } from './MidiEngine';
 import { defaultConfig, decodeConfig } from './configCodec';
 import { evaluateCondition } from './trigConditions';
 import { TRACK_IDS } from './types';
@@ -376,6 +377,7 @@ export function SequencerProvider({
 
   useEffect(() => {
     audioEngine.setBpm(config.bpm);
+    midiEngine.setBpm(config.bpm);
   }, [config.bpm]);
 
   useEffect(() => {
@@ -475,6 +477,14 @@ export function SequencerProvider({
               : cubic;
           audioEngine.playSound(
             track.id, scheduledTime, gain
+          );
+          // MIDI output (convert AudioContext time to
+          // performance.now timestamp)
+          const perfTimeMs = performance.now()
+            + (scheduledTime
+              - audioEngine.getCurrentTime()) * 1000;
+          midiEngine.sendNote(
+            track.id, perfTimeMs, gain
           );
         }
       });
@@ -599,6 +609,7 @@ export function SequencerProvider({
       pendingPatternRef.current = null;
 
       audioEngine.stop();
+      midiEngine.stop();
       setIsPlaying(false);
       stepRef.current = -1;
       totalStepsRef.current = 0;

--- a/src/app/SettingsPopover.tsx
+++ b/src/app/SettingsPopover.tsx
@@ -10,6 +10,7 @@ import { useSequencer } from './SequencerContext';
 import { encodeConfig } from './configCodec';
 import { useTooltips } from './TooltipContext';
 import Tooltip from './Tooltip';
+import MidiSettings from './MidiSettings';
 
 /**
  * Gear icon button with a dropdown popover for settings.
@@ -25,6 +26,7 @@ export default function SettingsPopover() {
   } = useTooltips();
   const [isOpen, setIsOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
+  const [midiOpen, setMidiOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -125,8 +127,22 @@ export default function SettingsPopover() {
               className="accent-orange-500"
             />
           </label>
+          <button
+            role="menuitem"
+            onClick={() => {
+              setMidiOpen(true);
+              setIsOpen(false);
+            }}
+            className="w-full text-left px-4 py-3 text-sm text-neutral-200 hover:bg-neutral-800 transition-colors border-t border-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-orange-500"
+          >
+            MIDI Settings…
+          </button>
         </div>
       )}
+      <MidiSettings
+        isOpen={midiOpen}
+        onClose={() => setMidiOpen(false)}
+      />
     </div>
   );
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -143,3 +143,51 @@ export interface SequencerConfig {
     Record<TrackId, Record<number, StepLocks>>
   >;
 }
+
+/** Note length: fixed milliseconds or tempo-relative. */
+export type NoteLength =
+  | { type: 'fixed'; ms: number }
+  | { type: 'percent'; value: number };
+
+/** Per-track MIDI note mapping. */
+export interface MidiTrackConfig {
+  noteNumber: number;  // 0–127
+}
+
+/** Complete MIDI output configuration. */
+export interface MidiConfig {
+  enabled: boolean;
+  deviceId: string | null;
+  channel: number;  // 1–16
+  noteLength: NoteLength;
+  tracks: Record<
+    Exclude<TrackId, 'ac'>,
+    MidiTrackConfig
+  >;
+}
+
+/** Default GM drum map note numbers. */
+export const GM_DRUM_MAP: Record<
+  Exclude<TrackId, 'ac'>, number
+> = {
+  bd: 36, sd: 38, ch: 42, oh: 46, cy: 49,
+  ht: 50, mt: 47, lt: 43, rs: 37, cp: 39, cb: 56,
+} as const;
+
+/** Factory for default MidiConfig. */
+export function defaultMidiConfig(): MidiConfig {
+  const tracks = {} as MidiConfig['tracks'];
+  for (const [id, note] of
+    Object.entries(GM_DRUM_MAP) as
+      [Exclude<TrackId, 'ac'>, number][]
+  ) {
+    tracks[id] = { noteNumber: note };
+  }
+  return {
+    enabled: false,
+    deviceId: null,
+    channel: 10,
+    noteLength: { type: 'fixed', ms: 50 },
+    tracks,
+  };
+}


### PR DESCRIPTION
## Summary

- Add MIDI note output so XOX patterns can drive external
  hardware (drum machines, samplers, synth modules) via
  the Web MIDI API
- MidiEngine singleton sends note-on/note-off messages with
  native MIDI scheduling (no setTimeout), synchronized to
  the existing audio scheduler via time conversion
- MidiSettings modal (via gear menu) provides enable toggle,
  device picker, channel selector, note length presets, and
  per-track GM drum map note number configuration
- MIDI config stored in localStorage (not in URL hash) since
  routing is device-specific
- Graceful fallback when Web MIDI API is unavailable or
  permission denied; device hotplug with auto-reconnect

## New files

- `src/app/MidiEngine.ts` — Web MIDI API wrapper singleton
- `src/app/MidiContext.tsx` — React context for MIDI state
- `src/app/MidiSettings.tsx` — MIDI config modal component
- `src/__tests__/midiEngine.test.ts` — 15 unit tests

## Test plan

- [x] 402 tests pass (17 new MIDI tests)
- [x] `npm run build` succeeds
- [x] `npm run lint` clean
- [x] Browser tested: modal opens/closes, device detection works, controls render correctly, no hydration errors
- [ ] Manual test with USB MIDI device connected
- [ ] Verify no stuck notes on stop/channel change

Closes #10
