### PR TITLE
Change default pattern mode to direct-jump

### DIFF
--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -860,11 +860,11 @@ describe('URL hash import', () => {
 // H. Pattern mode state
 // -------------------------------------------------------
 describe('pattern mode state', () => {
-  it('initial patternMode is sequential', () => {
+  it('initial patternMode is direct-jump', () => {
     const { result } = renderSequencer();
     expect(
       result.current.state.patternMode
-    ).toBe('sequential');
+    ).toBe('direct-jump');
   });
 
   it('initial tempState is off', () => {

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -250,7 +250,7 @@ export function SequencerProvider({
 
   // ─── Pattern mode state ─────────────────────────────
   const [patternMode, setPatternMode] =
-    useState<PatternMode>('sequential');
+    useState<PatternMode>('direct-jump');
   const [tempState, setTempState] =
     useState<TempState>('off');
   const [homeSnapshot, setHomeSnapshot] =


### PR DESCRIPTION
Changes the default pattern mode from sequential to direct-jump for more intuitive live use. Pattern changes take effect immediately at the current step position instead of waiting for the next loop.