### PR TITLE
Polish accent row: circles and stronger gain

### DIFF
--- a/src/__tests__/AccentRow.test.tsx
+++ b/src/__tests__/AccentRow.test.tsx
@@ -136,15 +136,16 @@ describe('AccentRow', () => {
     expect(toggle).toHaveBeenCalledWith('ac', 16);
   });
 
-  it('renders mini-height buttons', () => {
+  it('renders circle buttons', () => {
     const { container } = render(
       <AccentRow {...base} />
     );
     const btn = container.querySelector(
       '[data-step] button, button[data-step]'
     ) ?? container.querySelector('button');
-    expect(btn?.className).toContain('h-2.5');
-    expect(btn?.className).toContain('lg:h-3');
+    expect(btn?.className).toContain('rounded-full');
+    expect(btn?.className).toContain('w-4');
+    expect(btn?.className).toContain('h-4');
   });
 
   it('shows running light on current step', () => {

--- a/src/__tests__/StepButton.test.tsx
+++ b/src/__tests__/StepButton.test.tsx
@@ -123,13 +123,14 @@ describe('StepButton indicators', () => {
 });
 
 describe('StepButton mini variant', () => {
-  it('renders at reduced height', () => {
+  it('renders as circle', () => {
     const { container } = render(
       <StepButton {...base} mini />
     );
     const btn = container.querySelector('button');
-    expect(btn?.className).toContain('h-2.5');
-    expect(btn?.className).toContain('lg:h-3');
+    expect(btn?.className).toContain('rounded-full');
+    expect(btn?.className).toContain('w-4');
+    expect(btn?.className).toContain('h-4');
     expect(btn?.className).not.toContain('h-8');
   });
 
@@ -171,7 +172,7 @@ describe('StepButton mini variant', () => {
     expect(btn?.className).not.toContain('shadow');
   });
 
-  it('disabled mini renders at mini height', () => {
+  it('disabled mini renders as circle', () => {
     const { container } = render(
       <StepButton
         {...base}
@@ -182,7 +183,8 @@ describe('StepButton mini variant', () => {
     const el = container.querySelector(
       '[data-step]'
     );
-    expect(el?.className).toContain('h-2.5');
+    expect(el?.className).toContain('rounded-full');
+    expect(el?.className).toContain('w-4');
   });
 });
 

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -244,16 +244,16 @@ describe('handleStep', () => {
     expect(playedIds).not.toContain('sd');
   });
 
-  it('accent step: gain multiplied by 1.5', async () => {
+  it('accent step: gain multiplied by 2.0', async () => {
     const { mockPlaySound: mp } = await setupAndTrigger({
       activeTracks: ['bd'],
       accentStep0: true,
       gains: { bd: 1.0 },
     });
     expect(mp).toHaveBeenCalledTimes(1);
-    // gain = 1.0^3 * 1.5 = 1.5
+    // gain = 1.0^3 * (1 + 0.5*2) = 2.0
     const gainArg = mp.mock.calls[0][2];
-    expect(gainArg).toBeCloseTo(1.5);
+    expect(gainArg).toBeCloseTo(2.0);
   });
 
   it('non-accent step: gain is cubic only', async () => {
@@ -933,7 +933,7 @@ describe('handleStep parameter locks', () => {
 
   it('accent stacks on locked gain', async () => {
     // bd mixer gain = 1.0, lock = 0.5, accented
-    // Expected: 0.5^3 * 1.5 = 0.1875
+    // Expected: 0.5^3 * (1 + 0.5*2) = 0.25
     const { mockPlaySound: mp } = await setupAndTrigger({
       activeTracks: ['bd'],
       accentStep0: true,
@@ -942,7 +942,7 @@ describe('handleStep parameter locks', () => {
     });
     expect(mp).toHaveBeenCalledTimes(1);
     const gainArg = mp.mock.calls[0][2];
-    expect(gainArg).toBeCloseTo(0.1875);
+    expect(gainArg).toBeCloseTo(0.25);
   });
 
   it('no lock falls back to mixer gain', async () => {

--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -30,6 +30,7 @@ interface AccentRowProps {
   onSetGain: (
     trackId: TrackId, value: number
   ) => void;
+  onClearTrack: (trackId: TrackId) => void;
 }
 
 /**
@@ -51,6 +52,7 @@ function AccentRowInner({
   onSetTrackLength,
   onToggleFreeRun,
   onSetGain,
+  onClearTrack,
 }: AccentRowProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -63,6 +65,11 @@ function AccentRowInner({
   const handleGain = useCallback(
     (v: number) => onSetGain('ac', v),
     [onSetGain]
+  );
+
+  const handleClear = useCallback(
+    () => onClearTrack('ac'),
+    [onClearTrack]
   );
 
   const handleToggleStep = useCallback(
@@ -150,17 +157,22 @@ function AccentRowInner({
     <div>
       {/* Mobile: label + knob above grid */}
       <div className="flex items-center gap-2 mb-1 lg:hidden">
-        <span
+        <button
+          type="button"
+          onClick={(e) => {
+            if (e.shiftKey) handleClear();
+          }}
           className={
             'text-[10px] font-bold uppercase'
-            + ' tracking-wider'
+            + ' tracking-wider bg-transparent'
+            + ' border-none cursor-pointer'
             + (isFreeRun
               ? ' text-orange-400'
               : ' text-neutral-400')
           }
         >
           Accent
-        </span>
+        </button>
         <div className="ml-auto">
           <Tooltip tooltipKey="accentIntensity" position="bottom">
             <Knob
@@ -177,17 +189,22 @@ function AccentRowInner({
       <div className="flex gap-4 items-center">
         {/* Desktop: sidebar with label + knob */}
         <div className="hidden lg:flex w-48 items-center gap-2">
-          <span
+          <button
+            type="button"
+            onClick={(e) => {
+              if (e.shiftKey) handleClear();
+            }}
             className={
               'w-16 truncate text-xs text-left'
               + ' font-bold uppercase tracking-wider'
+              + ' bg-transparent border-none cursor-pointer'
               + (isFreeRun
                 ? ' text-orange-400'
                 : ' text-neutral-400')
             }
           >
             Accent
-          </span>
+          </button>
           {/* Spacer matching mute + solo toggle widths */}
           <div className="w-6 h-6" />
           <div className="w-6 h-6" />

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -473,7 +473,7 @@ export function SequencerProvider({
           const cubic = baseGain ** 3;
           const gain =
             isAccented
-              ? cubic * (1 + states.ac.gain)
+              ? cubic * (1 + states.ac.gain * 2)
               : cubic;
           audioEngine.playSound(
             track.id, scheduledTime, gain

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -89,11 +89,12 @@ function StepButtonInner({
     }
   }, [longPressActiveRef]);
 
-  const heightClass = mini
-    ? 'h-2.5 lg:h-3' : 'h-8 lg:h-12';
+  const sizeClass = mini
+    ? 'w-4 h-4 lg:w-5 lg:h-5' : 'h-8 lg:h-12';
+  const radiusClass = mini ? 'rounded-full' : 'rounded-sm';
 
   if (isDisabled) {
-    return (
+    const disabledEl = (
       <div
         data-step={stepIndex}
         aria-label={
@@ -101,14 +102,22 @@ function StepButtonInner({
           + ' (inactive)'
         }
         className={
-          heightClass + ' rounded-sm'
+          sizeClass + ' ' + radiusClass
           + ' bg-neutral-900/20 cursor-not-allowed'
-          + (isBeat
+          + (isBeat && !mini
             ? ' border-l-2 border-neutral-800/30'
             : '')
         }
       />
     );
+    if (mini) {
+      return (
+        <div className="flex items-center justify-center">
+          {disabledEl}
+        </div>
+      );
+    }
+    return disabledEl;
   }
 
   let color: string;
@@ -132,7 +141,7 @@ function StepButtonInner({
 
   const longPressHandlers = longPress();
 
-  return (
+  const btn = (
     <Tooltip tooltipKey="step" position="bottom">
       <button
         ref={buttonRef}
@@ -172,14 +181,14 @@ function StepButtonInner({
         }}
         className={
           'relative overflow-hidden'
-          + ' ' + heightClass + ' rounded-sm'
+          + ' ' + sizeClass + ' ' + radiusClass
           + ' transition-colors duration-100'
           + ' motion-safe:transition-transform'
           + ' focus-visible:outline-none'
           + ' focus-visible:ring-2'
           + ' focus-visible:ring-orange-500 '
           + color
-          + (isBeat
+          + (isBeat && !mini
             ? ' border-l-2 border-neutral-700'
             : '')
         }
@@ -242,6 +251,15 @@ function StepButtonInner({
       </button>
     </Tooltip>
   );
+
+  if (mini) {
+    return (
+      <div className="flex items-center justify-center">
+        {btn}
+      </div>
+    );
+  }
+  return btn;
 }
 
 const StepButton = memo(StepButtonInner);

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -186,6 +186,7 @@ export default function StepGrid({
           onSetTrackLength={setTrackLength}
           onToggleFreeRun={toggleFreeRun}
           onSetGain={setGain}
+          onClearTrack={clearTrack}
         />
       </div>
       {openPopover !== null ? (


### PR DESCRIPTION
## Summary

- Render accent step buttons as circles (`rounded-full`) instead of short rectangles for better visual distinction from regular track steps
- Widen accent gain multiplier range from 1x–2x to 1x–3x (`1 + gain * 2`) so the intensity knob has more headroom
- Update tests for new circle styling and gain math
