### PR TITLE
Defer MIDI permission prompt until user enables it

### DIFF
--- a/src/app/MidiContext.tsx
+++ b/src/app/MidiContext.tsx
@@ -17,7 +17,9 @@ interface MidiContextValue {
   initialized: boolean;
   config: MidiConfig;
   outputs: MIDIOutput[];
-  updateConfig: (partial: Partial<MidiConfig>) => void;
+  updateConfig: (
+    partial: Partial<MidiConfig>
+  ) => void | Promise<void>;
 }
 
 const MidiContext = createContext<
@@ -44,35 +46,40 @@ export function MidiProvider({
     []
   );
 
-  useEffect(() => {
-    let mounted = true;
-
+  const initMidi = useCallback(async () => {
+    if (initialized) return;
     midiEngine.setOnDeviceChange((newOutputs) => {
-      if (mounted) setOutputs(newOutputs);
+      setOutputs(newOutputs);
     });
+    const ok = await midiEngine.init();
+    setAvailable(ok);
+    setInitialized(true);
+    if (ok) {
+      setConfig(midiEngine.getConfig());
+      setOutputs(midiEngine.getOutputs());
+    }
+  }, [initialized]);
 
-    midiEngine.init().then((ok) => {
-      if (!mounted) return;
-      setAvailable(ok);
-      setInitialized(true);
-      if (ok) {
-        setConfig(midiEngine.getConfig());
-        setOutputs(midiEngine.getOutputs());
-      }
-    });
-
+  useEffect(() => {
     return () => {
-      mounted = false;
       midiEngine.setOnDeviceChange(null);
     };
   }, []);
 
   const updateConfig = useCallback(
-    (partial: Partial<MidiConfig>) => {
+    async (partial: Partial<MidiConfig>) => {
+      if (partial.enabled && !initialized) {
+        await initMidi();
+        // If MIDI isn't available after init, don't
+        // persist the enabled flag
+        if (!midiEngine.isAvailable()) {
+          return;
+        }
+      }
       midiEngine.updateConfig(partial);
       setConfig(midiEngine.getConfig());
     },
-    []
+    [initialized, initMidi]
   );
 
   return (

--- a/src/app/MidiEngine.ts
+++ b/src/app/MidiEngine.ts
@@ -102,6 +102,10 @@ export class MidiEngine {
     }
   };
 
+  isAvailable(): boolean {
+    return this.access !== null;
+  }
+
   getOutputs(): MIDIOutput[] {
     if (!this.access) return [];
     return Array.from(this.access.outputs.values());

--- a/src/app/MidiSettings.tsx
+++ b/src/app/MidiSettings.tsx
@@ -71,13 +71,11 @@ export default function MidiSettings({
   } = midi;
 
   const disabled = !available;
-  const statusMsg = !initialized
-    ? null
-    : !available
-      ? 'MIDI not available'
-      : outputs.length === 0
-        ? 'No MIDI devices detected'
-        : null;
+  const statusMsg = initialized && !available
+    ? 'MIDI not available in this browser'
+    : available && outputs.length === 0
+      ? 'No MIDI devices detected'
+      : null;
 
   return (
     <dialog
@@ -111,7 +109,6 @@ export default function MidiSettings({
           <input
             type="checkbox"
             checked={config.enabled}
-            disabled={disabled}
             onChange={(e) =>
               updateConfig({
                 enabled: e.target.checked,


### PR DESCRIPTION
## Summary

- Defers `requestMIDIAccess` until the user toggles "Enable MIDI output"
  in MIDI Settings, so casual visitors are never prompted for MIDI permission.
- If the browser doesn't support MIDI, the enabled flag is not persisted and
  a "MIDI not available" message is shown.
- The enable checkbox is no longer disabled before init — it serves as the
  trigger for lazy initialization.

## Changed files

- `MidiContext.tsx` — replaced eager `init()` on mount with lazy init on enable toggle
- `MidiEngine.ts` — added `isAvailable()` accessor
- `MidiSettings.tsx` — enable toggle always clickable; simplified status messages

## Out of scope

Other MIDI settings controls (device picker, channel, note length, track
mapping) remain disabled until MIDI is initialized and available — only the
enable toggle was changed.

## Test plan

- [x] `npm test` — 402 tests pass
- [x] `npm run build` — static export succeeds
- [ ] Load app fresh — verify no MIDI permission prompt on page load
- [ ] Open MIDI Settings → toggle "Enable MIDI output" → verify browser prompts for MIDI access
- [ ] Deny MIDI access → verify toggle stays off, "MIDI not available" shown
- [ ] Grant MIDI access → verify device list populates and settings are functional
