### PR TITLE
Rename Mode label to Pattern Change Mode

### DIFF
--- a/src/app/PatternModeSelector.tsx
+++ b/src/app/PatternModeSelector.tsx
@@ -32,9 +32,9 @@ export default function PatternModeSelector() {
   return (
     <div className="bg-neutral-900/50 p-2 border border-neutral-800 rounded-lg lg:rounded-xl shadow-inner">
       <span className="text-[8px] lg:text-[10px] uppercase tracking-widest text-neutral-500 mb-1 block font-bold">
-        Mode
+        Pattern Change Mode
       </span>
-      <div className="flex gap-1 items-stretch">
+      <div className="flex gap-2 items-stretch">
         <Tooltip tooltipKey="mode" position="bottom">
         <select
           id="mode-select"


### PR DESCRIPTION
## Summary
- Rename the "Mode" section header to "Pattern Change Mode" for clarity
- Increase spacing between the mode dropdown and Temp button (`gap-1` → `gap-2`)

## Test plan
- [ ] Verify "Pattern Change Mode" label displays correctly on desktop
- [ ] Verify label fits on mobile viewports
- [ ] Verify spacing between dropdown and T button looks balanced