### PR TITLE
Add ESLint rule for conditional border classes

### DIFF
--- a/eslint-rules/no-conditional-border.mjs
+++ b/eslint-rules/no-conditional-border.mjs
@@ -1,0 +1,94 @@
+/**
+ * ESLint rule: no-conditional-border
+ *
+ * Flags string literals containing "border" inside
+ * conditional expressions (ternaries) when the other
+ * branch does not also contain "border". Conditional
+ * borders cause 1px layout shift — always apply border
+ * unconditionally and toggle the color instead.
+ */
+
+const BORDER_RE = /\bborder\b/;
+
+/** Check if a node is a string-like literal. */
+function isStringLike(node) {
+  return (
+    (node.type === 'Literal'
+      && typeof node.value === 'string')
+    || (node.type === 'TemplateLiteral')
+  );
+}
+
+/** Extract raw text from a string literal or template. */
+function getText(node) {
+  if (node.type === 'Literal') return node.value;
+  if (node.type === 'TemplateLiteral') {
+    return node.quasis.map(q => q.value.raw).join('');
+  }
+  return '';
+}
+
+/**
+ * Collect all string content reachable from a node via
+ * binary `+` concatenation, template literals, or nested
+ * conditionals (both branches).
+ */
+function collectStrings(node) {
+  if (!node) return '';
+  if (isStringLike(node)) return getText(node);
+  if (
+    node.type === 'BinaryExpression'
+    && node.operator === '+'
+  ) {
+    return (
+      collectStrings(node.left)
+      + collectStrings(node.right)
+    );
+  }
+  if (node.type === 'ConditionalExpression') {
+    return (
+      collectStrings(node.consequent)
+      + ' '
+      + collectStrings(node.alternate)
+    );
+  }
+  return '';
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow "border" in only one branch of a'
+        + ' conditional — causes layout shift',
+    },
+    messages: {
+      conditionalBorder:
+        '"border" appears in only one branch of this'
+        + ' conditional. Apply border unconditionally'
+        + ' and toggle the color instead'
+        + ' (e.g., border-transparent).',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ConditionalExpression(node) {
+        const consText = collectStrings(node.consequent);
+        const altText = collectStrings(node.alternate);
+        const consHas = BORDER_RE.test(consText);
+        const altHas = BORDER_RE.test(altText);
+
+        if (consHas !== altHas) {
+          context.report({
+            node,
+            messageId: 'conditionalBorder',
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,23 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import noConditionalBorder from "./eslint-rules/no-conditional-border.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    plugins: {
+      'xox': {
+        rules: {
+          'no-conditional-border': noConditionalBorder,
+        },
+      },
+    },
+    rules: {
+      'xox/no-conditional-border': 'error',
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -104,9 +104,10 @@ function StepButtonInner({
         className={
           sizeClass + ' ' + radiusClass
           + ' bg-neutral-900/20 cursor-not-allowed'
+          + ' border-l-2'
           + (isBeat && !mini
-            ? ' border-l-2 border-neutral-800/30'
-            : '')
+            ? ' border-neutral-800/30'
+            : ' border-transparent')
         }
       />
     );
@@ -188,9 +189,10 @@ function StepButtonInner({
           + ' focus-visible:ring-2'
           + ' focus-visible:ring-orange-500 '
           + color
+          + ' border-l-2'
           + (isBeat && !mini
-            ? ' border-l-2 border-neutral-700'
-            : '')
+            ? ' border-neutral-700'
+            : ' border-transparent')
         }
       >
         {!mini && isActive


### PR DESCRIPTION
## Summary

- Add custom ESLint rule `xox/no-conditional-border` that flags `border` appearing in only one branch of a ternary expression
- Conditional borders cause 1px layout shift — the rule enforces always applying `border` unconditionally and toggling the color instead (e.g., `border-transparent`)
- Fix two preexisting violations in StepButton where beat-boundary left borders were conditional
- Rule handles nested ternaries, string concatenation, and template literals

## Test plan

- [x] `npm run lint` passes with zero errors
- [x] 407 tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)
- [ ] Verify step grid beat markers still render correctly in browser
