### PR TITLE
Use two-letter track labels with Orbitron font

### DIFF
--- a/src/__tests__/AccentRow.test.tsx
+++ b/src/__tests__/AccentRow.test.tsx
@@ -163,7 +163,7 @@ describe('AccentRow', () => {
   it('renders intensity knob', () => {
     render(<AccentRow {...base} />);
     expect(
-      screen.getAllByLabelText('Volume Accent')
+      screen.getAllByLabelText('Volume ACCENT')
         .length
     ).toBeGreaterThanOrEqual(1);
   });

--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -67,9 +67,9 @@ describe('derived state', () => {
   it('trackStates names match expected values', () => {
     const { result } = renderSequencer();
     const states = result.current.state.trackStates;
-    expect(states.bd.name).toBe('Kick');
-    expect(states.sd.name).toBe('Snare');
-    expect(states.ac.name).toBe('Accent');
+    expect(states.bd.name).toBe('BD');
+    expect(states.sd.name).toBe('SD');
+    expect(states.ac.name).toBe('ACCENT');
   });
 });
 

--- a/src/__tests__/StepButton.test.tsx
+++ b/src/__tests__/StepButton.test.tsx
@@ -5,7 +5,7 @@ import StepButton from '../app/StepButton';
 
 const base = {
   trackId: 'bd' as const,
-  trackName: 'Kick',
+  trackName: 'BD',
   stepIndex: 0,
   isActive: true,
   isCurrent: false,

--- a/src/__tests__/TrackEndBar.test.tsx
+++ b/src/__tests__/TrackEndBar.test.tsx
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 const base = {
   trackId: 'bd' as const,
-  trackName: 'Kick',
+  trackName: 'BD',
   steps: '1010101010101010',
   trackLength: 16,
   patternLength: 16,
@@ -38,7 +38,7 @@ describe('TrackEndBar', () => {
   it('right-click calls onToggleFreeRun', () => {
     render(<TrackRow {...base} />);
     const slider = screen.getByRole('slider', {
-      name: 'Kick length',
+      name: 'BD length',
     });
     fireEvent.contextMenu(slider);
     expect(base.onToggleFreeRun).toHaveBeenCalledWith(
@@ -52,7 +52,7 @@ describe('TrackEndBar', () => {
     () => {
       render(<TrackRow {...base} />);
       const slider = screen.getByRole('slider', {
-        name: 'Kick length',
+        name: 'BD length',
       });
       // Start a drag via pointerDown
       fireEvent.pointerDown(slider, {
@@ -123,11 +123,11 @@ describe('TrackEndBar', () => {
         <TrackRow {...base} trackLength={12} />
       );
       const slider = screen.getByRole('slider', {
-      name: 'Kick length',
+      name: 'BD length',
     });
       expect(
         slider.getAttribute('aria-label')
-      ).toBe('Kick length');
+      ).toBe('BD length');
       expect(
         slider.getAttribute('aria-valuemin')
       ).toBe('1');

--- a/src/__tests__/TrackRow.test.tsx
+++ b/src/__tests__/TrackRow.test.tsx
@@ -8,7 +8,7 @@ const noop = vi.fn();
 function renderTrackRow(overrides = {}) {
   const defaults = {
     trackId: 'bd' as TrackId,
-    trackName: 'Kick',
+    trackName: 'BD',
     steps: '1010101010101010'
       + '0101010101010101',
     trackLength: 32,
@@ -36,7 +36,7 @@ describe('TrackRow with pageOffset', () => {
   it('page 1 shows first 16 steps', () => {
     renderTrackRow({ pageOffset: 0 });
     const buttons = screen.getAllByRole('button', {
-      name: /Kick step/,
+      name: /BD step/,
     });
     // steps[0]='1', so first button is pressed
     expect(
@@ -51,7 +51,7 @@ describe('TrackRow with pageOffset', () => {
   it('page 2 shows steps 17-32', () => {
     renderTrackRow({ pageOffset: 16 });
     const buttons = screen.getAllByRole('button', {
-      name: /Kick step/,
+      name: /BD step/,
     });
     // steps[16]='0' (from second half '0101...')
     expect(
@@ -69,7 +69,7 @@ describe('TrackRow with pageOffset', () => {
       pageOffset: 16,
     });
     const allSteps = screen.getAllByLabelText(
-      /Kick step/
+      /BD step/
     );
     expect(allSteps.length).toBe(16);
     // Step 25 (index 8) should be inactive

--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -166,19 +166,20 @@ function AccentRowInner({
             'text-[10px] font-bold uppercase'
             + ' tracking-wider bg-transparent'
             + ' border-none cursor-pointer'
+            + ' font-[family-name:var(--font-orbitron)]'
             + (isFreeRun
               ? ' text-orange-400'
               : ' text-neutral-400')
           }
         >
-          Accent
+          ACCENT
         </button>
         <div className="ml-auto">
           <Tooltip tooltipKey="accentIntensity" position="bottom">
             <Knob
               value={gain}
               onChange={handleGain}
-              trackName="Accent"
+              trackName="ACCENT"
               size={20}
               defaultValue={0.5}
             />
@@ -198,12 +199,13 @@ function AccentRowInner({
               'w-16 truncate text-xs text-left'
               + ' font-bold uppercase tracking-wider'
               + ' bg-transparent border-none cursor-pointer'
+              + ' font-[family-name:var(--font-orbitron)]'
               + (isFreeRun
                 ? ' text-orange-400'
                 : ' text-neutral-400')
             }
           >
-            Accent
+            ACCENT
           </button>
           {/* Spacer matching mute + solo toggle widths */}
           <div className="w-6 h-6" />
@@ -212,7 +214,7 @@ function AccentRowInner({
             <Knob
               value={gain}
               onChange={handleGain}
-              trackName="Accent"
+              trackName="ACCENT"
               defaultValue={0.5}
             />
           </Tooltip>

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -35,33 +35,33 @@ import type {
  * Track definitions for the sequencer grid (excludes accent).
  */
 export const TRACKS: { id: TrackId; name: string }[] = [
-  { id: 'bd', name: 'Kick' },
-  { id: 'sd', name: 'Snare' },
-  { id: 'ch', name: 'C-Hat' },
-  { id: 'oh', name: 'O-Hat' },
-  { id: 'cy', name: 'Cymbal' },
-  { id: 'ht', name: 'Hi-Tom' },
-  { id: 'mt', name: 'Mid-Tom' },
-  { id: 'lt', name: 'Low-Tom' },
-  { id: 'rs', name: 'Rimshot' },
-  { id: 'cp', name: 'Clap' },
-  { id: 'cb', name: 'Cowbell' },
+  { id: 'bd', name: 'BD' },
+  { id: 'sd', name: 'SD' },
+  { id: 'ch', name: 'CH' },
+  { id: 'oh', name: 'OH' },
+  { id: 'cy', name: 'CY' },
+  { id: 'ht', name: 'HT' },
+  { id: 'mt', name: 'MT' },
+  { id: 'lt', name: 'LT' },
+  { id: 'rs', name: 'RS' },
+  { id: 'cp', name: 'CP' },
+  { id: 'cb', name: 'CB' },
 ];
 
 /** Map of TrackId to display name (includes accent). */
 const TRACK_NAMES: Record<TrackId, string> = {
-  ac: 'Accent',
-  bd: 'Kick',
-  sd: 'Snare',
-  ch: 'C-Hat',
-  oh: 'O-Hat',
-  cy: 'Cymbal',
-  ht: 'Hi-Tom',
-  mt: 'Mid-Tom',
-  lt: 'Low-Tom',
-  rs: 'Rimshot',
-  cp: 'Clap',
-  cb: 'Cowbell',
+  ac: 'ACCENT',
+  bd: 'BD',
+  sd: 'SD',
+  ch: 'CH',
+  oh: 'OH',
+  cy: 'CY',
+  ht: 'HT',
+  mt: 'MT',
+  lt: 'LT',
+  rs: 'RS',
+  cp: 'CP',
+  cb: 'CB',
 };
 
 // ─── Interfaces ──────────────────────────────────────

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -84,9 +84,9 @@ function TrackNameButtonInner({
           }}
           className={
             (size === 'sm'
-              ? 'text-[10px]'
-              : 'w-16 truncate text-xs text-left')
-            + ' font-bold uppercase tracking-wider'
+              ? 'text-sm'
+              : 'w-16 truncate text-base text-left')
+            + ' font-bold uppercase tracking-wider font-[family-name:var(--font-orbitron)]'
             + ' rounded px-1 py-0.5 transition-colors'
             + (isFreeRun
               ? ' text-orange-400 bg-orange-400/10'


### PR DESCRIPTION
## Summary

- Replace long track names (Kick, Snare, C-Hat, etc.) with uppercase two-letter abbreviations (BD, SD, CH, etc.) matching internal track IDs
- Keep accent label as full "ACCENT"
- Apply Orbitron typeface to all track name labels for consistent futuristic styling
- Increase track label font size (text-sm on mobile, text-base on desktop)

## Test plan

- [ ] Verify track labels display as uppercase two-letter codes in Orbitron font
- [ ] Verify accent row displays "ACCENT" in Orbitron font
- [ ] Check mobile and desktop layouts
- [ ] Confirm aria-labels use the new abbreviated names