### PR TITLE
Add per-cell pan parameter locks

### DIFF
--- a/src/__tests__/SequencerContext.test.tsx
+++ b/src/__tests__/SequencerContext.test.tsx
@@ -1167,3 +1167,65 @@ describe('pattern switch logic', () => {
     ).toBe(home.tracks.bd.steps);
   });
 });
+
+// -------------------------------------------------
+// setParameterLock merging
+// -------------------------------------------------
+describe('setParameterLock merging', () => {
+  it('setting gain preserves existing pan lock', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setParameterLock(
+        'bd', 0, { pan: 0.3 }
+      );
+    });
+    act(() => {
+      result.current.actions.setParameterLock(
+        'bd', 0, { gain: 0.7 }
+      );
+    });
+    const locks =
+      result.current.meta.config.tracks.bd
+        .parameterLocks?.[0];
+    expect(locks).toEqual({ pan: 0.3, gain: 0.7 });
+  });
+
+  it('setting pan preserves existing gain lock', () => {
+    const { result } = renderSequencer();
+    act(() => {
+      result.current.actions.setParameterLock(
+        'bd', 0, { gain: 0.5 }
+      );
+    });
+    act(() => {
+      result.current.actions.setParameterLock(
+        'bd', 0, { pan: 0.8 }
+      );
+    });
+    const locks =
+      result.current.meta.config.tracks.bd
+        .parameterLocks?.[0];
+    expect(locks).toEqual({ gain: 0.5, pan: 0.8 });
+  });
+
+  it(
+    'clearParameterLock removes all locks for step',
+    () => {
+      const { result } = renderSequencer();
+      act(() => {
+        result.current.actions.setParameterLock(
+          'bd', 0, { gain: 0.5, pan: 0.3 }
+        );
+      });
+      act(() => {
+        result.current.actions.clearParameterLock(
+          'bd', 0
+        );
+      });
+      const locks =
+        result.current.meta.config.tracks.bd
+          .parameterLocks;
+      expect(locks).toBeUndefined();
+    }
+  );
+});

--- a/src/__tests__/handleStep.test.ts
+++ b/src/__tests__/handleStep.test.ts
@@ -66,6 +66,7 @@ async function setupAndTrigger(
     soloTracks?: TrackId[];
     muteTracks?: TrackId[];
     gains?: Partial<Record<TrackId, number>>;
+    pans?: Partial<Record<TrackId, number>>;
     parameterLocks?: Partial<
       Record<TrackId, Record<number, StepLocks>>
     >;
@@ -77,6 +78,7 @@ async function setupAndTrigger(
     soloTracks = [],
     muteTracks = [],
     gains = {},
+    pans = {},
     parameterLocks = {},
   } = options;
 
@@ -120,6 +122,9 @@ async function setupAndTrigger(
     }
     for (const [id, value] of Object.entries(gains)) {
       result.current.actions.setGain(id as TrackId, value);
+    }
+    for (const [id, value] of Object.entries(pans)) {
+      result.current.actions.setPan(id as TrackId, value);
     }
     for (const [trackId, stepMap] of
       Object.entries(parameterLocks)) {
@@ -979,6 +984,41 @@ describe('handleStep parameter locks', () => {
     expect(mp).toHaveBeenCalledTimes(1);
     const gainArg = mp.mock.calls[0][2];
     expect(gainArg).toBeCloseTo(0);
+  });
+
+  it('pan lock overrides mixer pan', async () => {
+    // bd mixer pan = 0.8, but lock = 0.2
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      pans: { bd: 0.8 },
+      parameterLocks: { bd: { 0: { pan: 0.2 } } },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const panArg = mp.mock.calls[0][3];
+    expect(panArg).toBeCloseTo(0.2);
+  });
+
+  it('pan lock at center produces 0.5', async () => {
+    // bd mixer pan = 1.0, lock = 0.5
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      pans: { bd: 1.0 },
+      parameterLocks: { bd: { 0: { pan: 0.5 } } },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const panArg = mp.mock.calls[0][3];
+    expect(panArg).toBeCloseTo(0.5);
+  });
+
+  it('no pan lock falls back to mixer pan', async () => {
+    // bd mixer pan = 0.3, no lock
+    const { mockPlaySound: mp } = await setupAndTrigger({
+      activeTracks: ['bd'],
+      pans: { bd: 0.3 },
+    });
+    expect(mp).toHaveBeenCalledTimes(1);
+    const panArg = mp.mock.calls[0][3];
+    expect(panArg).toBeCloseTo(0.3);
   });
 });
 

--- a/src/app/PanSlider.tsx
+++ b/src/app/PanSlider.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useRef, useCallback, useEffect } from 'react';
+
+interface PanSliderProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+function formatPan(v: number): string {
+  const pct = Math.round((v - 50) * 2);
+  if (pct === 0) return 'C';
+  return pct < 0 ? `L${-pct}` : `R${pct}`;
+}
+
+/**
+ * Horizontal pan slider with center-fill bar.
+ * Range is 0–100 (0 = full left, 50 = center,
+ * 100 = full right). Fill bar expands from the
+ * midpoint toward the current value.
+ */
+export default function PanSlider({
+  value,
+  onChange,
+}: PanSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{
+    startX: number;
+    startValue: number;
+  } | null>(null);
+  const valueRef = useRef(value);
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const clamp = useCallback(
+    (v: number) =>
+      Math.max(0, Math.min(100, Math.round(v))),
+    []
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      (e.target as Element).setPointerCapture(
+        e.pointerId
+      );
+      dragRef.current = {
+        startX: e.clientX,
+        startValue: valueRef.current,
+      };
+    },
+    []
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current || !trackRef.current) {
+        return;
+      }
+      const width = trackRef.current.offsetWidth;
+      if (width === 0) return;
+      const delta =
+        ((e.clientX - dragRef.current.startX)
+          / width) * 100;
+      onChange(
+        clamp(dragRef.current.startValue + delta)
+      );
+    },
+    [onChange, clamp]
+  );
+
+  const release = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const v = valueRef.current;
+      let next = v;
+      const step = e.shiftKey ? 10 : 1;
+      if (
+        e.key === 'ArrowRight'
+        || e.key === 'ArrowUp'
+      ) {
+        next = clamp(v + step);
+      } else if (
+        e.key === 'ArrowLeft'
+        || e.key === 'ArrowDown'
+      ) {
+        next = clamp(v - step);
+      } else if (e.key === 'Home') {
+        next = 0;
+      } else if (e.key === 'End') {
+        next = 100;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      onChange(next);
+    },
+    [onChange, clamp]
+  );
+
+  // Center-fill: bar expands from 50% toward value.
+  const offset = value < 50 ? value : 50;
+  const barWidth = Math.abs(value - 50);
+  const offsetPct = (offset / 100) * 100;
+  const widthPct = (barWidth / 100) * 100;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={0}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={value}
+        aria-label="Pan"
+        className={
+          'relative h-6 flex-1 rounded'
+          + ' bg-neutral-700 cursor-ew-resize'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500'
+        }
+        style={{ touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={release}
+        onLostPointerCapture={release}
+        onKeyDown={onKeyDown}
+      >
+        {widthPct > 0 && (
+          <div
+            className={
+              'absolute inset-y-0 rounded'
+              + ' bg-orange-600'
+            }
+            style={{
+              left: `${offsetPct}%`,
+              width: `${widthPct}%`,
+            }}
+          />
+        )}
+      </div>
+      <span className={
+        'text-xs font-mono text-neutral-300'
+        + ' w-10 text-right tabular-nums'
+      }>
+        {formatPan(value)}
+      </span>
+    </div>
+  );
+}

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -1086,7 +1086,11 @@ export function SequencerProvider({
             ...prev.tracks[trackId],
             parameterLocks: {
               ...prev.tracks[trackId].parameterLocks,
-              [stepIndex]: locks,
+              [stepIndex]: {
+                ...prev.tracks[trackId]
+                  .parameterLocks?.[stepIndex],
+                ...locks,
+              },
             },
           },
         },

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -19,6 +19,7 @@ interface StepButtonProps {
     trackId: TrackId, stepIndex: number
   ) => void;
   gainLock?: number;
+  panLock?: number;
   conditions?: StepConditions;
   onOpenPopover?: (
     trackId: TrackId,
@@ -45,6 +46,7 @@ function StepButtonInner({
   mini,
   onToggle,
   gainLock,
+  panLock,
   conditions,
   onOpenPopover,
   longPressActiveRef,
@@ -208,6 +210,45 @@ function StepButtonInner({
                 background: 'rgba(255,255,255,0.85)',
               }}
             />
+          ) : null}
+        {!mini && isActive
+          && panLock !== undefined
+          ? (
+            panLock === 0.5
+              ? (
+                <span
+                  data-testid="pan-bar"
+                  className="absolute top-0 h-[2px]"
+                  style={{
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    width: '2px',
+                    background:
+                      'rgba(255,255,255,0.85)',
+                  }}
+                />
+              )
+              : (
+                <span
+                  data-testid="pan-bar"
+                  className="absolute top-0 h-[2px]"
+                  style={{
+                    ...(panLock < 0.5
+                      ? {
+                        right: '50%',
+                        width:
+                          `${(0.5 - panLock) * 100}%`,
+                      }
+                      : {
+                        left: '50%',
+                        width:
+                          `${(panLock - 0.5) * 100}%`,
+                      }),
+                    background:
+                      'rgba(255,255,255,0.85)',
+                  }}
+                />
+              )
           ) : null}
         {!mini && isActive && conditions?.fill
           ? (

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -8,6 +8,7 @@ import { useSequencer } from './SequencerContext';
 import { CYCLE_OPTIONS } from './trigConditions';
 import ProbabilitySlider from './ProbabilitySlider';
 import RangeSlider from './RangeSlider';
+import PanSlider from './PanSlider';
 import type {
   StepConditions, StepLocks, TrackId,
 } from './types';
@@ -63,6 +64,13 @@ export default function StepPopover({
       : 100
   );
   const gainTouched = useRef(false);
+
+  const [panValue, setPanValue] = useState(
+    locks?.pan !== undefined
+      ? Math.round(locks.pan * 100)
+      : 50
+  );
+  const panTouched = useRef(false);
 
   const updateConditions = useCallback(
     (
@@ -129,6 +137,19 @@ export default function StepPopover({
         trackId,
         stepIndex,
         { gain: v / 100 }
+      );
+    },
+    [actions, trackId, stepIndex]
+  );
+
+  const handlePanChange = useCallback(
+    (v: number) => {
+      setPanValue(v);
+      panTouched.current = true;
+      actions.setParameterLock(
+        trackId,
+        stepIndex,
+        { pan: v / 100 }
       );
     },
     [actions, trackId, stepIndex]
@@ -371,6 +392,8 @@ export default function StepPopover({
             );
             setGainValue(100);
             gainTouched.current = false;
+            setPanValue(50);
+            panTouched.current = false;
           }}
           disabled={locks === undefined}
           className={
@@ -403,6 +426,19 @@ export default function StepPopover({
           max={100}
           onChange={handleGainChange}
           label="Gain"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <div className={
+          'text-[10px] uppercase tracking-wider'
+          + ' text-neutral-500'
+        }>
+          Pan
+        </div>
+        <PanSlider
+          value={panValue}
+          onChange={handlePanChange}
         />
       </div>
 

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -483,6 +483,10 @@ function TrackRowInner({
                       parameterLocks?.[globalIdx]
                         ?.gain
                     }
+                    panLock={
+                      parameterLocks?.[globalIdx]
+                        ?.pan
+                    }
                     onOpenPopover={handleOpenPopover}
                     longPressActiveRef={
                       longPressActiveRef


### PR DESCRIPTION
## Summary

- Add per-cell pan parameter locks that override track-level pan for individual steps
- New `PanSlider` component with center-fill bar and L/R/C display format
- White bar indicator on step buttons showing pan direction (expanding from center)
- Fix `setParameterLock` to merge locks instead of replacing the entire object

## Details

The backend infrastructure (types, playback logic, serialization) already supported pan locks — this PR adds the UI and fixes a merge bug.

**Pan indicator on step buttons:** A 2px white bar at the top edge expands left or right from center to show pan direction. A center lock shows a tiny 2px dot. Only appears for explicit per-step locks, not track-level pan.

**setParameterLock merge fix:** Previously setting `{ pan: 0.3 }` would clobber an existing `{ gain: 0.5 }` on the same step. Now merges with existing locks.

## Out of scope

- Per-parameter reset (only "Reset locks" clears all locks for a step)
- Track-level pan visualization on step buttons
- Other future lock parameters (pitch, decay, filter)

## Test plan

- [x] `npm test` — 424 tests pass (includes new pan lock and merge tests)
- [x] `npm run lint` — zero errors
- [x] `npm run build` — clean build
- [ ] Browser: open step popover, drag pan slider, hear panned playback
- [ ] Browser: set both gain and pan locks on same step — both persist
- [ ] Browser: white bar appears at top of cell matching pan direction
- [ ] Browser: center lock shows tiny center dot
- [ ] Browser: "Reset locks" clears both gain and pan
