### PR TITLE
Remove spurious orange focus ring from step buttons

### DIFF
--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -207,9 +207,8 @@ function StepButtonInner({
           + ' ' + sizeClass + ' ' + radiusClass
           + ' transition-colors duration-100'
           + ' motion-safe:transition-transform'
-          + ' focus-visible:outline-none'
-          + ' focus-visible:ring-2'
-          + ' focus-visible:ring-orange-500 '
+          + ' focus:outline-none'
+          + ' focus-visible:outline-none '
           + color
           + ' border-l-2'
           + (isBeat && !mini


### PR DESCRIPTION
## Summary

- Remove `focus-visible:ring-2 focus-visible:ring-orange-500` from step buttons
- Browsers activate `:focus-visible` when modifier keys (Shift, Ctrl) are held during a click, causing an unwanted orange outline
- Step buttons already communicate state through background color changes, making the ring redundant

## Test plan

- [ ] Click a step button to enable it, press Shift — no orange outline appears
- [ ] Shift+click a cell — no orange outline
- [ ] Ctrl+click a cell — no orange outline
- [ ] Tab through step buttons with keyboard — no visible outline (suppressed intentionally; buttons have clear active/current color states)