### PR TITLE
Arch audit: extract constants module

### DIFF
--- a/src/__tests__/__snapshots__/constants.test.ts.snap
+++ b/src/__tests__/__snapshots__/constants.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`constants snapshot 1`] = `
+{
+  "ACCENT_GAIN_MULTIPLIER": 2,
+  "BPM_MAX": 300,
+  "BPM_MIN": 20,
+  "CYCLE_PX_PER_STEP": 6,
+  "CYCLE_THRESHOLD_TOUCH_PX": 10,
+  "DEFAULT_BPM": 110,
+  "DEFAULT_TRACK_LENGTH": 16,
+  "DRAG_THRESHOLD_PX": 5,
+  "ENDBAR_LONG_PRESS_CANCEL_PX": 1,
+  "FEEDBACK_TIMEOUT_MS": 1500,
+  "GAIN_EXPONENT": 3,
+  "LONG_PRESS_CANCEL_PX": 5,
+  "LONG_PRESS_MS": 500,
+  "LOOKAHEAD_MS": 25,
+  "MAX_PATTERN_LENGTH": 64,
+  "SCHEDULE_AHEAD_S": 0.1,
+  "SWING_MAX": 100,
+  "TRIGGER_FLASH_MS": 150,
+}
+`;

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -1,0 +1,5 @@
+import * as constants from '../app/constants';
+
+test('constants snapshot', () => {
+  expect(constants).toMatchSnapshot();
+});

--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -7,6 +7,9 @@ import {
   LongPressEventType, useLongPress,
 } from 'use-long-press';
 import type { TrackId } from './types';
+import {
+  LONG_PRESS_MS, ENDBAR_LONG_PRESS_CANCEL_PX,
+} from './constants';
 import StepButton from './StepButton';
 import Knob from './Knob';
 import Tooltip from './Tooltip';
@@ -86,8 +89,8 @@ function AccentRowInner({
     },
     {
       detect: LongPressEventType.Touch,
-      threshold: 500,
-      cancelOnMovement: 1,
+      threshold: LONG_PRESS_MS,
+      cancelOnMovement: ENDBAR_LONG_PRESS_CANCEL_PX,
     }
   );
 

--- a/src/app/AudioEngine.ts
+++ b/src/app/AudioEngine.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { TrackId } from './types';
+import { LOOKAHEAD_MS, SCHEDULE_AHEAD_S } from './constants';
 
 // Minimal silent WAV (8-bit mono, 7 samples at 44100 Hz).
 // Playing this via an <audio> element forces iOS to switch
@@ -38,8 +39,8 @@ class AudioEngine {
   // Scheduler Configuration
   private bpm: number = 110;
   private patternLength: number = 16;
-  private lookahead: number = 25.0;       // How often to call the scheduler (ms)
-  private scheduleAheadTime: number = 0.1; // How far ahead to schedule audio (s)
+  private lookahead: number = LOOKAHEAD_MS;
+  private scheduleAheadTime: number = SCHEDULE_AHEAD_S;
 
   /**
    * Callback triggered when a step passes.

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -16,6 +16,11 @@ import { audioEngine } from './AudioEngine';
 import { midiEngine } from './MidiEngine';
 import { defaultConfig, decodeConfig } from './configCodec';
 import { evaluateCondition } from './trigConditions';
+import {
+  ACCENT_GAIN_MULTIPLIER,
+  GAIN_EXPONENT,
+  MAX_PATTERN_LENGTH,
+} from './constants';
 import { TRACK_IDS, getPatternLength } from './types';
 import type {
   HomeSnapshot,
@@ -433,10 +438,10 @@ export function SequencerProvider({
             cfg.tracks[track.id]
               .parameterLocks?.[effectiveStep];
           const baseGain = locks?.gain ?? st.gain;
-          const cubic = baseGain ** 3;
+          const cubic = baseGain ** GAIN_EXPONENT;
           const gain =
             isAccented
-              ? cubic * (1 + states.ac.gain * 2)
+              ? cubic * (1 + states.ac.gain * ACCENT_GAIN_MULTIPLIER)
               : cubic;
           const pan = locks?.pan ?? st.pan;
           audioEngine.playSound(
@@ -764,7 +769,7 @@ export function SequencerProvider({
   const setPatternLength = useCallback(
     (length: number) => {
       const clamped =
-        Math.max(1, Math.min(64, length));
+        Math.max(1, Math.min(MAX_PATTERN_LENGTH, length));
       setConfig(prev => {
         const currentMax =
           getPatternLength(prev.tracks);
@@ -1177,7 +1182,7 @@ export function SequencerProvider({
   const playPreview = useCallback(
     (trackId: TrackId) => {
       const st = trackStatesRef.current[trackId];
-      const cubic = st.gain ** 3;
+      const cubic = st.gain ** GAIN_EXPONENT;
       audioEngine.playSound(
         trackId,
         audioEngine.getCurrentTime(),

--- a/src/app/SettingsPopover.tsx
+++ b/src/app/SettingsPopover.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { useSequencer } from './SequencerContext';
 import { encodeConfig } from './configCodec';
+import { FEEDBACK_TIMEOUT_MS } from './constants';
 import Tooltip from './Tooltip';
 import SettingsModal from './SettingsModal';
 
@@ -66,10 +67,10 @@ export default function SettingsPopover() {
       );
       await navigator.clipboard.writeText(url);
       setFeedback('Copied!');
-      setTimeout(() => setFeedback(''), 1500);
+      setTimeout(() => setFeedback(''), FEEDBACK_TIMEOUT_MS);
     } catch {
       setFeedback('Failed');
-      setTimeout(() => setFeedback(''), 1500);
+      setTimeout(() => setFeedback(''), FEEDBACK_TIMEOUT_MS);
     }
   }, [meta.config]);
 

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
 import { useLongPress } from 'use-long-press';
 import type { StepConditions, TrackId } from './types';
+import { LONG_PRESS_MS, LONG_PRESS_CANCEL_PX } from './constants';
 import Tooltip from './Tooltip';
 
 interface StepButtonProps {
@@ -94,8 +95,8 @@ function StepButtonInner({
       openPopover();
     },
     {
-      threshold: 500,
-      cancelOnMovement: 5,
+      threshold: LONG_PRESS_MS,
+      cancelOnMovement: LONG_PRESS_CANCEL_PX,
     }
   );
 

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -12,6 +12,7 @@ import { useDragPaint } from './useDragPaint';
 import { useSelection } from './useSelection';
 import type { TrackId, TrackPattern } from './types';
 import { getPatternLength } from './types';
+import { TRIGGER_FLASH_MS } from './constants';
 import trackPatternData from './data/trackPatterns.json';
 
 const TRACK_PATTERNS: TrackPattern[] =
@@ -137,7 +138,7 @@ export default function StepGrid({
       if (tracks.size > 0) {
         triggerTimerRef.current = setTimeout(
           () => setTriggeredTracks(new Set()),
-          150
+          TRIGGER_FLASH_MS
         );
       }
     },

--- a/src/app/TempoController.tsx
+++ b/src/app/TempoController.tsx
@@ -2,9 +2,10 @@
 
 import { useCallback, useRef } from 'react';
 import Tooltip from './Tooltip';
+import { BPM_MIN, BPM_MAX } from './constants';
 
-export const MIN_BPM = 20;
-export const MAX_BPM = 300;
+export const MIN_BPM = BPM_MIN;
+export const MAX_BPM = BPM_MAX;
 
 interface TempoControllerProps {
   bpm: number;

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -10,6 +10,9 @@ import {
 import type {
   StepConditions, StepLocks, TrackId,
 } from './types';
+import {
+  LONG_PRESS_MS, ENDBAR_LONG_PRESS_CANCEL_PX,
+} from './constants';
 import TrackToggle from './TrackToggle';
 import StepButton from './StepButton';
 import Knob from './Knob';
@@ -277,8 +280,8 @@ function TrackRowInner({
     },
     {
       detect: LongPressEventType.Touch,
-      threshold: 500,
-      cancelOnMovement: 1,
+      threshold: LONG_PRESS_MS,
+      cancelOnMovement: ENDBAR_LONG_PRESS_CANCEL_PX,
     }
   );
 

--- a/src/app/configCodec.ts
+++ b/src/app/configCodec.ts
@@ -11,13 +11,16 @@ import type {
   TrackMixerState,
 } from './types';
 import { TRACK_IDS } from './types';
+import {
+  BPM_MIN,
+  BPM_MAX,
+  DEFAULT_BPM,
+  DEFAULT_TRACK_LENGTH,
+  SWING_MAX,
+} from './constants';
 
 const CONFIG_VERSION = 4;
 const DEFAULT_KIT_ID = '808';
-const BPM_MIN = 20;
-const BPM_MAX = 300;
-const DEFAULT_BPM = 110;
-const DEFAULT_TRACK_LENGTH = 16;
 
 /**
  * Build the default config from the first kit and pattern.
@@ -235,7 +238,7 @@ function validateBpm(value: unknown): number {
 }
 
 const SWING_MIN = 0;
-const SWING_MAX = 100;
+
 const DEFAULT_SWING = 0;
 
 function validateSwing(value: unknown): number {

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -1,0 +1,51 @@
+/**
+ * Centralized constants for the XOX sequencer.
+ *
+ * ALL timing, threshold, and tuning values live here.
+ * Import from this file instead of using inline literals.
+ */
+
+// ── Audio scheduling ────────────────────────────────
+/** How often to call the look-ahead scheduler (ms). */
+export const LOOKAHEAD_MS = 25.0;
+/** How far ahead to schedule audio events (seconds). */
+export const SCHEDULE_AHEAD_S = 0.1;
+
+// ── Gesture thresholds ──────────────────────────────
+/** Duration before a press becomes a long-press (ms). */
+export const LONG_PRESS_MS = 500;
+/** Movement tolerance for StepButton long-press (px). */
+export const LONG_PRESS_CANCEL_PX = 5;
+/** Movement tolerance for TrackEndBar long-press (px). */
+export const ENDBAR_LONG_PRESS_CANCEL_PX = 1;
+/** Minimum pointer movement before starting a drag (px). */
+export const DRAG_THRESHOLD_PX = 5;
+/** Touch distance to start cycle mode (px). */
+export const CYCLE_THRESHOLD_TOUCH_PX = 10;
+/** Vertical px per step when cycling patterns. */
+export const CYCLE_PX_PER_STEP = 6;
+
+// ── Sequencer limits ────────────────────────────────
+/** Maximum steps a pattern can have. */
+export const MAX_PATTERN_LENGTH = 64;
+/** Default track length for new configs. */
+export const DEFAULT_TRACK_LENGTH = 16;
+
+// ── Gain / mixing ───────────────────────────────────
+/** Multiplier applied when accent track is active. */
+export const ACCENT_GAIN_MULTIPLIER = 2;
+/** Exponent for cubic gain curve (perceived loudness). */
+export const GAIN_EXPONENT = 3;
+
+// ── UI timing ───────────────────────────────────────
+/** Duration of the triggered-track flash highlight (ms). */
+export const TRIGGER_FLASH_MS = 150;
+/** Duration of copy/export feedback messages (ms). */
+export const FEEDBACK_TIMEOUT_MS = 1500;
+
+// ── Tempo ───────────────────────────────────────────
+export const BPM_MIN = 20;
+export const BPM_MAX = 300;
+export const DEFAULT_BPM = 110;
+/** Maximum swing amount. */
+export const SWING_MAX = 100;

--- a/src/app/useDragPaint.ts
+++ b/src/app/useDragPaint.ts
@@ -3,6 +3,11 @@
 import { useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
 import type { TrackConfig, TrackId, TrackPattern } from './types';
+import {
+  DRAG_THRESHOLD_PX,
+  CYCLE_THRESHOLD_TOUCH_PX,
+  CYCLE_PX_PER_STEP,
+} from './constants';
 
 interface UseDragPaintOptions {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -51,9 +56,9 @@ interface DragState {
   selectionHit: CellHit | null;
 }
 
-const DRAG_THRESHOLD = 5;
-const CYCLE_THRESHOLD_TOUCH = 10;
-const CYCLE_PX_PER_STEP = 6;
+// Local aliases for brevity in gesture logic
+const DRAG_THRESHOLD = DRAG_THRESHOLD_PX;
+const CYCLE_THRESHOLD_TOUCH = CYCLE_THRESHOLD_TOUCH_PX;
 
 /**
  * Find the track and step under a point using


### PR DESCRIPTION
## Summary

- Create `src/app/constants.ts` centralizing all magic numbers (timing, thresholds, tuning values)
- Update 10 consumer files to import from constants instead of using inline literals
- Add snapshot test to catch accidental value changes

Part of the architecture audit (Phase 1 of 11).

## Test plan

- [x] `npm test` — 452 tests pass
- [x] `npm run lint` — zero errors
- [x] `npm run build` — static export succeeds
- [x] Pre-push hook passes
