### PR TITLE
Arch audit: extract gridUtils from useDragPaint

### DIFF
--- a/src/__tests__/gridUtils.test.ts
+++ b/src/__tests__/gridUtils.test.ts
@@ -1,0 +1,131 @@
+import { bresenham, cellFromPoint } from '../app/gridUtils';
+
+describe('bresenham', () => {
+  it('yields a single point when start equals end', () => {
+    const points = [...bresenham(3, 3, 3, 3)];
+    expect(points).toEqual([[3, 3]]);
+  });
+
+  it('yields a horizontal line', () => {
+    const points = [...bresenham(0, 0, 4, 0)];
+    expect(points).toEqual([
+      [0, 0], [1, 0], [2, 0], [3, 0], [4, 0],
+    ]);
+  });
+
+  it('yields a vertical line', () => {
+    const points = [...bresenham(2, 0, 2, 3)];
+    expect(points).toEqual([
+      [2, 0], [2, 1], [2, 2], [2, 3],
+    ]);
+  });
+
+  it('yields a diagonal line', () => {
+    const points = [...bresenham(0, 0, 3, 3)];
+    expect(points).toEqual([
+      [0, 0], [1, 1], [2, 2], [3, 3],
+    ]);
+  });
+
+  it('yields a negative-slope line', () => {
+    const points = [...bresenham(3, 3, 0, 0)];
+    expect(points).toEqual([
+      [3, 3], [2, 2], [1, 1], [0, 0],
+    ]);
+  });
+
+  it('yields correct points for a steep line', () => {
+    const points = [...bresenham(0, 0, 1, 4)];
+    expect(points.length).toBeGreaterThanOrEqual(5);
+    expect(points[0]).toEqual([0, 0]);
+    expect(points[points.length - 1]).toEqual([1, 4]);
+  });
+
+  it('yields correct points for a shallow line', () => {
+    const points = [...bresenham(0, 0, 4, 1)];
+    expect(points.length).toBeGreaterThanOrEqual(5);
+    expect(points[0]).toEqual([0, 0]);
+    expect(points[points.length - 1]).toEqual([4, 1]);
+  });
+});
+
+describe('cellFromPoint', () => {
+  beforeEach(() => {
+    // jsdom does not implement elementFromPoint
+    if (!document.elementFromPoint) {
+      document.elementFromPoint = () => null;
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when elementFromPoint returns null', () => {
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(null);
+    expect(cellFromPoint(10, 20)).toBeNull();
+  });
+
+  it('returns null when element has no data-step', () => {
+    const el = document.createElement('div');
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(el);
+    expect(cellFromPoint(10, 20)).toBeNull();
+  });
+
+  it('returns null when element has data-step but no data-track', () => {
+    const el = document.createElement('div');
+    el.dataset.step = '5';
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(el);
+    expect(cellFromPoint(10, 20)).toBeNull();
+  });
+
+  it('returns CellHit when element has both attributes', () => {
+    const el = document.createElement('div');
+    el.dataset.step = '3';
+    el.dataset.track = 'bd';
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(el);
+
+    expect(cellFromPoint(10, 20)).toEqual({
+      trackId: 'bd',
+      stepIndex: 3,
+    });
+  });
+
+  it('walks up from nested element to find data-step', () => {
+    const parent = document.createElement('div');
+    parent.dataset.step = '7';
+    parent.dataset.track = 'sd';
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(child);
+
+    expect(cellFromPoint(10, 20)).toEqual({
+      trackId: 'sd',
+      stepIndex: 7,
+    });
+  });
+
+  it('walks up to find data-track when step and track are on different elements', () => {
+    const trackEl = document.createElement('div');
+    trackEl.dataset.track = 'ch';
+    const stepEl = document.createElement('div');
+    stepEl.dataset.step = '2';
+    trackEl.appendChild(stepEl);
+    const inner = document.createElement('span');
+    stepEl.appendChild(inner);
+
+    vi.spyOn(document, 'elementFromPoint')
+      .mockReturnValue(inner);
+
+    expect(cellFromPoint(10, 20)).toEqual({
+      trackId: 'ch',
+      stepIndex: 2,
+    });
+  });
+});

--- a/src/app/gridUtils.ts
+++ b/src/app/gridUtils.ts
@@ -1,0 +1,74 @@
+import type { TrackId } from './types';
+
+export interface CellHit {
+  trackId: TrackId;
+  stepIndex: number;
+}
+
+/**
+ * Find the track and step under a point using
+ * data-track and data-step attributes. Walks up
+ * from the element at the point to find both.
+ *
+ * Returns null if the point is outside all cells.
+ */
+export function cellFromPoint(
+  clientX: number,
+  clientY: number
+): CellHit | null {
+  const el = document.elementFromPoint(
+    clientX, clientY
+  );
+  if (!el) return null;
+
+  let node: Element | null = el;
+  while (
+    node
+    && !('step' in (node as HTMLElement).dataset)
+  ) {
+    node = node.parentElement;
+  }
+  if (!node) return null;
+  const stepIndex = Number(
+    (node as HTMLElement).dataset.step
+  );
+
+  while (
+    node
+    && !('track' in (node as HTMLElement).dataset)
+  ) {
+    node = node.parentElement;
+  }
+  if (!node) return null;
+  const trackId = (
+    node as HTMLElement
+  ).dataset.track as TrackId;
+
+  return { trackId, stepIndex };
+}
+
+/**
+ * Bresenham's line algorithm yielding all (col, row)
+ * cells between two grid coordinates, inclusive of
+ * both endpoints.
+ */
+export function* bresenham(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+): Generator<[number, number]> {
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
+  const sx = x0 < x1 ? 1 : -1;
+  const sy = y0 < y1 ? 1 : -1;
+  let err = dx - dy;
+
+  while (true) {
+    yield [x0, y0];
+    if (x0 === x1 && y0 === y1) break;
+    const e2 = 2 * err;
+    if (e2 > -dy) { err -= dy; x0 += sx; }
+    if (e2 < dx) { err += dx; y0 += sy; }
+  }
+}

--- a/src/app/useDragPaint.ts
+++ b/src/app/useDragPaint.ts
@@ -8,6 +8,8 @@ import {
   CYCLE_THRESHOLD_TOUCH_PX,
   CYCLE_PX_PER_STEP,
 } from './constants';
+import { cellFromPoint, bresenham } from './gridUtils';
+import type { CellHit } from './gridUtils';
 
 interface UseDragPaintOptions {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -32,11 +34,6 @@ interface UseDragPaintOptions {
   onClearSelection?: () => void;
 }
 
-interface CellHit {
-  trackId: TrackId;
-  stepIndex: number;
-}
-
 interface DragState {
   active: boolean;
   dragged: boolean;
@@ -59,74 +56,6 @@ interface DragState {
 // Local aliases for brevity in gesture logic
 const DRAG_THRESHOLD = DRAG_THRESHOLD_PX;
 const CYCLE_THRESHOLD_TOUCH = CYCLE_THRESHOLD_TOUCH_PX;
-
-/**
- * Find the track and step under a point using
- * data-track and data-step attributes. Walks up
- * from the element at the point to find both.
- *
- * Returns null if the point is outside all cells.
- */
-function cellFromPoint(
-  clientX: number,
-  clientY: number
-): CellHit | null {
-  const el = document.elementFromPoint(
-    clientX, clientY
-  );
-  if (!el) return null;
-
-  let node: Element | null = el;
-  while (
-    node
-    && !('step' in (node as HTMLElement).dataset)
-  ) {
-    node = node.parentElement;
-  }
-  if (!node) return null;
-  const stepIndex = Number(
-    (node as HTMLElement).dataset.step
-  );
-
-  while (
-    node
-    && !('track' in (node as HTMLElement).dataset)
-  ) {
-    node = node.parentElement;
-  }
-  if (!node) return null;
-  const trackId = (
-    node as HTMLElement
-  ).dataset.track as TrackId;
-
-  return { trackId, stepIndex };
-}
-
-/**
- * Bresenham's line algorithm yielding all (col, row)
- * cells between two grid coordinates, inclusive of
- * both endpoints.
- */
-function* bresenham(
-  x0: number,
-  y0: number,
-  x1: number,
-  y1: number
-): Generator<[number, number]> {
-  const dx = Math.abs(x1 - x0);
-  const dy = Math.abs(y1 - y0);
-  const sx = x0 < x1 ? 1 : -1;
-  const sy = y0 < y1 ? 1 : -1;
-  let err = dx - dy;
-
-  while (true) {
-    yield [x0, y0];
-    if (x0 === x1 && y0 === y1) break;
-    const e2 = 2 * err;
-    if (e2 > -dy) { err -= dy; x0 += sx; }
-    if (e2 < dx) { err += dx; y0 += sy; }
-  }
-}
 
 /**
  * Hook for click-drag painting/erasing of sequencer


### PR DESCRIPTION
## Summary

- Extract Bresenham line algorithm, `cellFromPoint` lookup, and `CellHit` interface from `useDragPaint.ts` into new `src/app/gridUtils.ts`
- `useDragPaint.ts` drops from 659 to 588 lines
- Add 13 unit tests for the extracted pure functions

Part of the architecture audit (Phase 2 of 11).

## Test plan

- [x] `npm test` — 464 tests pass
- [x] `npm run lint` — zero errors
- [x] Existing `useDragPaint.test.tsx` passes unchanged
