### PR TITLE
Arch audit: error boundaries + error state

### DIFF
--- a/src/__tests__/ErrorBoundary.test.tsx
+++ b/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '../app/ErrorBoundary';
+
+function BombComponent(): JSX.Element {
+  throw new Error('Boom!');
+}
+
+function SafeComponent() {
+  return <p>All good</p>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <SafeComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('All good'))
+      .toBeInTheDocument();
+  });
+
+  it('renders default fallback when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <BombComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong.'))
+      .toBeInTheDocument();
+    expect(screen.getByText('Try again'))
+      .toBeInTheDocument();
+  });
+
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={<p>Custom error</p>}>
+        <BombComponent />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Custom error'))
+      .toBeInTheDocument();
+  });
+
+  it('calls onError callback with error and info', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <BombComponent />
+      </ErrorBoundary>
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message)
+      .toBe('Boom!');
+  });
+
+  it('resets and re-renders children on retry', () => {
+    let shouldThrow = true;
+
+    function MaybeBomb() {
+      if (shouldThrow) throw new Error('Boom!');
+      return <p>Recovered</p>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <MaybeBomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong.'))
+      .toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText('Try again'));
+    expect(screen.getByText('Recovered'))
+      .toBeInTheDocument();
+  });
+});

--- a/src/__tests__/StatusBanner.test.tsx
+++ b/src/__tests__/StatusBanner.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import StatusBanner from '../app/StatusBanner';
+
+describe('StatusBanner', () => {
+  it('is collapsed when message is null', () => {
+    const { container } = render(
+      <StatusBanner message={null} onDismiss={() => {}} />
+    );
+    const banner = container.firstElementChild!;
+    expect(banner.className).toContain('max-h-0');
+    expect(banner.className).toContain('border-transparent');
+  });
+
+  it('is expanded when message is set', () => {
+    const { container } = render(
+      <StatusBanner
+        message="Kit failed to load"
+        onDismiss={() => {}}
+      />
+    );
+    const banner = container.firstElementChild!;
+    expect(banner.className).toContain('max-h-[60px]');
+    expect(banner.className).toContain('border-amber-700');
+    expect(screen.getByText('Kit failed to load'))
+      .toBeInTheDocument();
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(
+      <StatusBanner
+        message="Error"
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('has role="alert" for accessibility', () => {
+    render(
+      <StatusBanner message="Oops" onDismiss={() => {}} />
+    );
+    expect(screen.getByRole('alert'))
+      .toBeInTheDocument();
+  });
+});

--- a/src/app/AudioEngine.ts
+++ b/src/app/AudioEngine.ts
@@ -47,6 +47,7 @@ class AudioEngine {
    * Useful for syncing UI visuals or triggering sounds in the React component.
    */
   public onStep: (step: number, time: number) => void = () => {};
+  public onLoadError: (message: string) => void = () => {};
 
   constructor() {}
 
@@ -121,6 +122,9 @@ class AudioEngine {
         this.buffers.set(id, audioBuffer);
       } catch (e) {
         console.error(`Failed to load ${id} for kit ${kitFolder}`, e);
+        this.onLoadError(
+          `Failed to load ${id} sample for kit "${kitFolder}"`
+        );
       }
     });
 

--- a/src/app/ErrorBoundary.tsx
+++ b/src/app/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(
+    error: Error
+  ): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+      return (
+        <div className="bg-neutral-900 text-neutral-200 p-4 rounded-lg border border-neutral-700 text-center">
+          <p className="text-sm mb-2">
+            Something went wrong.
+          </p>
+          <button
+            onClick={this.handleReset}
+            className="px-3 py-1 text-sm bg-orange-600 hover:bg-orange-700 text-white rounded transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -9,6 +9,8 @@ import { TooltipProvider } from './TooltipContext';
 import { MidiProvider } from './MidiContext';
 import TransportControls from './TransportControls';
 import StepGrid from './StepGrid';
+import ErrorBoundary from './ErrorBoundary';
+import StatusBanner from './StatusBanner';
 import PageIndicator from './PageIndicator';
 import { getPatternLength } from './types';
 import PatternPicker from './PatternPicker';
@@ -70,6 +72,10 @@ function SequencerInner() {
             </>
           )}
         </PatternPicker>
+        <StatusBanner
+          message={state.loadError}
+          onDismiss={actions.dismissError}
+        />
         <div
           ref={scrollRef}
           className="flex-1 overflow-y-auto mt-3 lg:mt-4 pb-3 lg:pb-4 track-scroll-region"
@@ -102,12 +108,14 @@ function SequencerInner() {
 
 export default function Sequencer() {
   return (
-    <SequencerProvider>
-      <MidiProvider>
-        <TooltipProvider>
-          <SequencerInner />
-        </TooltipProvider>
-      </MidiProvider>
-    </SequencerProvider>
+    <ErrorBoundary>
+      <SequencerProvider>
+        <MidiProvider>
+          <TooltipProvider>
+            <SequencerInner />
+          </TooltipProvider>
+        </MidiProvider>
+      </SequencerProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/app/SequencerContext.tsx
+++ b/src/app/SequencerContext.tsx
@@ -77,6 +77,7 @@ interface SequencerState {
   currentKit: Kit;
   trackStates: Record<TrackId, TrackState>;
   isLoaded: boolean;
+  loadError: string | null;
   swing: number;
   isFillActive: boolean;
   fillMode: 'off' | 'latched' | 'momentary';
@@ -136,6 +137,7 @@ interface SequencerActions {
   setPatternMode: (mode: PatternMode) => void;
   toggleTemp: () => void;
   playPreview: (trackId: TrackId) => void;
+  dismissError: () => void;
 }
 
 interface SequencerMeta {
@@ -221,6 +223,8 @@ export function SequencerProvider({
   // ─── Transient state ──────────────────────────────
   const [isPlaying, setIsPlaying] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [loadError, setLoadError] =
+    useState<string | null>(null);
   const stepRef = useRef<number>(-1);
   const totalStepsRef = useRef<number>(0);
   const triggeredTracksRef = useRef<Set<TrackId>>(
@@ -327,8 +331,17 @@ export function SequencerProvider({
   // ─── Effects ──────────────────────────────────────
 
   useEffect(() => {
+    audioEngine.onLoadError = (msg) =>
+      setLoadError(msg);
+    return () => {
+      audioEngine.onLoadError = () => {};
+    };
+  }, []);
+
+  useEffect(() => {
     const load = async () => {
       setIsLoaded(false);
+      setLoadError(null);
       await audioEngine.preloadKit(currentKit.folder);
       setIsLoaded(true);
     };
@@ -1193,6 +1206,10 @@ export function SequencerProvider({
     []
   );
 
+  const dismissError = useCallback(() => {
+    setLoadError(null);
+  }, []);
+
   // ─── Context value ────────────────────────────────
 
   const value: SequencerContextValue = {
@@ -1202,6 +1219,7 @@ export function SequencerProvider({
       currentKit,
       trackStates,
       isLoaded,
+      loadError,
       swing: config.swing,
       isFillActive,
       fillMode,
@@ -1236,6 +1254,7 @@ export function SequencerProvider({
       setPatternMode,
       toggleTemp,
       playPreview,
+      dismissError,
     },
     meta: {
       stepRef, totalStepsRef,

--- a/src/app/StatusBanner.tsx
+++ b/src/app/StatusBanner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+interface StatusBannerProps {
+  message: string | null;
+  onDismiss: () => void;
+}
+
+export default function StatusBanner({
+  message,
+  onDismiss,
+}: StatusBannerProps) {
+  return (
+    <div
+      className={`overflow-hidden transition-all duration-300 border ${
+        message
+          ? 'max-h-[60px] border-amber-700 bg-amber-900/80 text-amber-200 rounded-lg mt-2 lg:mt-3'
+          : 'max-h-0 border-transparent'
+      }`}
+      role="alert"
+    >
+      <div className="flex items-center justify-between px-3 py-2">
+        <span className="text-sm truncate">
+          {message}
+        </span>
+        <button
+          onClick={onDismiss}
+          className="ml-2 shrink-0 text-amber-400 hover:text-amber-200 transition-colors"
+          aria-label="Dismiss"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -8,6 +8,7 @@ import { TRACKS, useSequencer } from './SequencerContext';
 import TrackRow from './TrackRow';
 import AccentRow from './AccentRow';
 import StepPopover from './StepPopover';
+import ErrorBoundary from './ErrorBoundary';
 import { useDragPaint } from './useDragPaint';
 import { useSelection } from './useSelection';
 import type { TrackId, TrackPattern } from './types';
@@ -278,6 +279,9 @@ export default function StepGrid({
         />
       </div>
       {openPopover !== null ? (
+        <ErrorBoundary
+          onError={() => setOpenPopover(null)}
+        >
         <StepPopover
           trackId={openPopover.trackId}
           stepIndex={openPopover.stepIndex}
@@ -295,6 +299,7 @@ export default function StepGrid({
           onClose={() => setOpenPopover(null)}
           scrollContainerRef={scrollContainerRef}
         />
+        </ErrorBoundary>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

- Create `ErrorBoundary` component (class component with retry button, custom fallback support)
- Create `StatusBanner` component (collapsible inline banner with dismiss, `role="alert"`)
- Add `loadError` state and `dismissError` action to SequencerContext
- Surface AudioEngine kit load errors via `onLoadError` callback
- Place boundaries: top-level around SequencerProvider, grid-level around StepPopover
- Render StatusBanner between transport controls and step grid

Part of the architecture audit (Phase 3 of 11).

## Test plan

- [x] `npm test` — 460 tests pass
- [x] `npm run lint` — zero errors
- [x] ErrorBoundary: renders children, catches throws, retry resets, calls onError
- [x] StatusBanner: collapsed when null, expanded with message, dismiss works, has role="alert"
