### PR TITLE
Split TrackRow and DRY AccentRow

### DIFF
--- a/src/__tests__/trackUtils.test.ts
+++ b/src/__tests__/trackUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeEffectiveStep,
+  formatPan,
+} from '../app/trackUtils';
+
+describe('computeEffectiveStep', () => {
+  it('returns -1 when currentStep < 0', () => {
+    expect(computeEffectiveStep(-1, 0, false, 16))
+      .toBe(-1);
+  });
+
+  it('uses currentStep when not free-run', () => {
+    expect(computeEffectiveStep(5, 100, false, 16))
+      .toBe(5);
+  });
+
+  it('wraps currentStep by trackLength', () => {
+    expect(computeEffectiveStep(20, 100, false, 16))
+      .toBe(4);
+  });
+
+  it('uses totalSteps when free-run', () => {
+    expect(computeEffectiveStep(5, 100, true, 16))
+      .toBe(4); // 100 % 16 = 4
+  });
+
+  it('handles short tracks', () => {
+    expect(computeEffectiveStep(7, 0, false, 4))
+      .toBe(3); // 7 % 4 = 3
+  });
+});
+
+describe('formatPan', () => {
+  it('center returns "C"', () => {
+    expect(formatPan(0.5)).toBe('C');
+  });
+
+  it('full left returns "L100"', () => {
+    expect(formatPan(0)).toBe('L100');
+  });
+
+  it('full right returns "R100"', () => {
+    expect(formatPan(1)).toBe('R100');
+  });
+
+  it('quarter left returns "L50"', () => {
+    expect(formatPan(0.25)).toBe('L50');
+  });
+
+  it('quarter right returns "R50"', () => {
+    expect(formatPan(0.75)).toBe('R50');
+  });
+});

--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import {
-  memo, useCallback, useRef, useState,
-} from 'react';
-import {
-  LongPressEventType, useLongPress,
-} from 'use-long-press';
+import { memo, useCallback } from 'react';
 import type { TrackId } from './types';
-import {
-  LONG_PRESS_MS, ENDBAR_LONG_PRESS_CANCEL_PX,
-} from './constants';
+import { computeEffectiveStep } from './trackUtils';
+import TrackEndBar from './TrackEndBar';
 import StepButton from './StepButton';
 import Knob from './Knob';
 import Tooltip from './Tooltip';
@@ -57,9 +51,6 @@ function AccentRowInner({
   onSetGain,
   onClearTrack,
 }: AccentRowProps) {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [isDragging, setIsDragging] = useState(false);
-
   const handleFreeRun = useCallback(
     () => onToggleFreeRun('ac'),
     [onToggleFreeRun]
@@ -81,80 +72,14 @@ function AccentRowInner({
     [onToggleStep, pageOffset]
   );
 
-  // ─── Drag handle logic ──────────────────────────
-  const endBarLongPress = useLongPress(
-    () => {
-      navigator.vibrate?.(10);
-      handleFreeRun();
-    },
-    {
-      detect: LongPressEventType.Touch,
-      threshold: LONG_PRESS_MS,
-      cancelOnMovement: ENDBAR_LONG_PRESS_CANCEL_PX,
-    }
+  const handleSetLength = useCallback(
+    (len: number) => onSetTrackLength('ac', len),
+    [onSetTrackLength]
   );
 
-  const effectiveStep =
-    currentStep >= 0
-      ? (isFreeRun ? totalSteps : currentStep)
-        % trackLength
-      : -1;
-
-  const lengthFromPointer = useCallback(
-    (clientX: number): number => {
-      const grid = gridRef.current;
-      if (!grid) return trackLength;
-      const rect = grid.getBoundingClientRect();
-      const x = clientX - rect.left;
-      const stepWidth = rect.width / 16;
-      const raw = Math.round(x / stepWidth);
-      return Math.max(
-        1,
-        Math.min(patternLength, raw + pageOffset)
-      );
-    },
-    [patternLength, trackLength, pageOffset]
+  const effectiveStep = computeEffectiveStep(
+    currentStep, totalSteps, isFreeRun, trackLength
   );
-
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      if (e.button !== 0) return;
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault();
-        handleFreeRun();
-        return;
-      }
-      e.preventDefault();
-      (e.target as HTMLElement).setPointerCapture(
-        e.pointerId
-      );
-      setIsDragging(true);
-    },
-    [handleFreeRun]
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isDragging) return;
-      const len = lengthFromPointer(e.clientX);
-      if (len !== trackLength) {
-        onSetTrackLength('ac', len);
-      }
-    },
-    [isDragging, lengthFromPointer, trackLength,
-      onSetTrackLength]
-  );
-
-  const handlePointerUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  const handleOnPage =
-    trackLength > pageOffset
-    && trackLength <= pageOffset + 16;
-  const handlePct = handleOnPage
-    ? ((trackLength - pageOffset) / 16) * 100
-    : 0;
 
   return (
     <div>
@@ -179,7 +104,10 @@ function AccentRowInner({
           AC
         </button>
         <div className="ml-auto">
-          <Tooltip tooltipKey="accentIntensity" position="bottom">
+          <Tooltip
+            tooltipKey="accentIntensity"
+            position="bottom"
+          >
             <Knob
               value={gain}
               onChange={handleGain}
@@ -213,13 +141,16 @@ function AccentRowInner({
           >
             AC
           </button>
-          {/* Spacer matching mute + solo toggle widths */}
+          {/* Spacer matching mute + solo widths */}
           <div className="flex gap-1">
             <div className="w-6 h-6" />
             <div className="w-6 h-6" />
           </div>
           <div className="flex gap-1 ml-1">
-            <Tooltip tooltipKey="accentIntensity" position="bottom">
+            <Tooltip
+              tooltipKey="accentIntensity"
+              position="bottom"
+            >
               <Knob
                 value={gain}
                 onChange={handleGain}
@@ -233,7 +164,6 @@ function AccentRowInner({
         {/* Step grid with drag handle */}
         <div className="flex-1 relative">
           <div
-            ref={gridRef}
             data-track="ac"
             className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
           >
@@ -268,71 +198,16 @@ function AccentRowInner({
             )}
           </div>
 
-          {/* Draggable length handle */}
-          {handleOnPage && (
-            <div
-              role="slider"
-              aria-label="accent length"
-              aria-valuemin={1}
-              aria-valuemax={patternLength}
-              aria-valuenow={trackLength}
-              tabIndex={0}
-              onPointerDown={handlePointerDown}
-              onPointerMove={handlePointerMove}
-              onPointerUp={handlePointerUp}
-              onPointerCancel={handlePointerUp}
-              {...endBarLongPress()}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                if (!isDragging) handleFreeRun();
-              }}
-              style={{
-                left: `${handlePct}%`,
-                touchAction: 'none',
-              }}
-              className={
-                'absolute top-0 h-full w-4'
-                + ' -translate-x-1/2 z-20'
-                + (isDragging
-                  ? ' cursor-col-resize'
-                  : ' cursor-default')
-                + ' before:absolute before:inset-y-0'
-                + ' before:left-1/2'
-                + ' before:-translate-x-1/2'
-                + ' before:w-1.5 before:rounded-full'
-                + ' before:transition-colors'
-                + (isDragging
-                  ? ' before:bg-neutral-300'
-                  : ' before:bg-neutral-500/60'
-                    + ' hover:before:bg-neutral-300')
-              }
-            />
-          )}
-
-          {/* Free-run indicator */}
-          {isFreeRun && handleOnPage && (
-            <span
-              aria-label="free run"
-              style={{
-                left: `${handlePct}%`,
-                fontFamily: 'var(--font-orbitron)',
-              }}
-              className={
-                'absolute top-1/2 -translate-x-1/2'
-                + ' -translate-y-1/2 z-30'
-                + ' pointer-events-none select-none'
-                + ' flex items-center'
-                + ' justify-center'
-                + ' w-3.5 h-3.5 rounded-full'
-                + ' bg-orange-500'
-                + ' text-[10px] font-bold'
-                + ' text-white'
-                + ' shadow-[0_0_6px_rgba(251,146,60,0.6)]'
-              }
-            >
-              F
-            </span>
-          )}
+          <TrackEndBar
+            trackName="accent"
+            trackLength={trackLength}
+            patternLength={patternLength}
+            pageOffset={pageOffset}
+            isFreeRun={isFreeRun}
+            onSetTrackLength={handleSetLength}
+            onToggleFreeRun={handleFreeRun}
+            showTooltip={false}
+          />
         </div>
       </div>
     </div>

--- a/src/app/TrackEndBar.tsx
+++ b/src/app/TrackEndBar.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { memo, useCallback, useRef, useState } from 'react';
+import {
+  LongPressEventType, useLongPress,
+} from 'use-long-press';
+import {
+  LONG_PRESS_MS, ENDBAR_LONG_PRESS_CANCEL_PX,
+} from './constants';
+import Tooltip from './Tooltip';
+
+interface TrackEndBarProps {
+  trackName: string;
+  trackLength: number;
+  patternLength: number;
+  pageOffset: number;
+  isFreeRun: boolean;
+  onSetTrackLength: (length: number) => void;
+  onToggleFreeRun: () => void;
+  /** Show tooltip around handle (default true). */
+  showTooltip?: boolean;
+}
+
+/**
+ * Draggable length handle + free-run indicator.
+ * Shared by TrackRow and AccentRow.
+ *
+ * Renders as an absolutely-positioned overlay inside
+ * the parent's step grid container. The parent must
+ * set `position: relative` on the grid wrapper.
+ */
+function TrackEndBarInner({
+  trackName,
+  trackLength,
+  patternLength,
+  pageOffset,
+  isFreeRun,
+  onSetTrackLength,
+  onToggleFreeRun,
+  showTooltip = true,
+}: TrackEndBarProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const endBarLongPress = useLongPress(
+    () => {
+      navigator.vibrate?.(10);
+      onToggleFreeRun();
+    },
+    {
+      detect: LongPressEventType.Touch,
+      threshold: LONG_PRESS_MS,
+      cancelOnMovement: ENDBAR_LONG_PRESS_CANCEL_PX,
+    }
+  );
+
+  const handleOnPage =
+    trackLength > pageOffset
+    && trackLength <= pageOffset + 16;
+  const handlePct = handleOnPage
+    ? ((trackLength - pageOffset) / 16) * 100
+    : 0;
+
+  const lengthFromPointer = useCallback(
+    (clientX: number): number => {
+      const grid = gridRef.current;
+      if (!grid) return trackLength;
+      const rect = grid.getBoundingClientRect();
+      const x = clientX - rect.left;
+      const stepWidth = rect.width / 16;
+      const raw = Math.round(x / stepWidth);
+      return Math.max(
+        1,
+        Math.min(patternLength, raw + pageOffset)
+      );
+    },
+    [patternLength, trackLength, pageOffset]
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        onToggleFreeRun();
+        return;
+      }
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(
+        e.pointerId
+      );
+      setIsDragging(true);
+    },
+    [onToggleFreeRun]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging) return;
+      const len = lengthFromPointer(e.clientX);
+      if (len !== trackLength) {
+        onSetTrackLength(len);
+      }
+    },
+    [isDragging, lengthFromPointer, trackLength,
+      onSetTrackLength]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  if (!handleOnPage) return null;
+
+  const handle = (
+    <div
+      ref={gridRef}
+      role="slider"
+      aria-label={`${trackName} length`}
+      aria-valuemin={1}
+      aria-valuemax={patternLength}
+      aria-valuenow={trackLength}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      {...endBarLongPress()}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        if (!isDragging) onToggleFreeRun();
+      }}
+      style={{
+        left: `${handlePct}%`,
+        touchAction: 'none',
+      }}
+      className={
+        'absolute top-0 h-full w-4'
+        + ' -translate-x-1/2 z-20'
+        + (isDragging
+          ? ' cursor-col-resize'
+          : ' cursor-default')
+        + ' before:absolute before:inset-y-0'
+        + ' before:left-1/2'
+        + ' before:-translate-x-1/2'
+        + ' before:w-1.5 before:rounded-full'
+        + ' before:transition-colors'
+        + (isDragging
+          ? ' before:bg-neutral-300'
+          : ' before:bg-neutral-500/60'
+            + ' hover:before:bg-neutral-300')
+      }
+    />
+  );
+
+  return (
+    <>
+      {showTooltip ? (
+        <Tooltip
+          tooltipKey="lengthHandle"
+          align="right"
+        >
+          {handle}
+        </Tooltip>
+      ) : handle}
+
+      {isFreeRun && (
+        <span
+          aria-label="free run"
+          style={{
+            left: `${handlePct}%`,
+            fontFamily: 'var(--font-orbitron)',
+          }}
+          className={
+            'absolute top-1/2 -translate-x-1/2'
+            + ' -translate-y-1/2 z-30'
+            + ' pointer-events-none select-none'
+            + ' flex items-center'
+            + ' justify-center'
+            + ' w-3.5 h-3.5 rounded-full'
+            + ' bg-orange-500'
+            + ' text-[10px] font-bold'
+            + ' text-white'
+            + ' shadow-[0_0_6px_rgba(251,146,60,0.6)]'
+          }
+        >
+          F
+        </span>
+      )}
+    </>
+  );
+}
+
+const TrackEndBar = memo(TrackEndBarInner);
+export default TrackEndBar;

--- a/src/app/TrackMixer.tsx
+++ b/src/app/TrackMixer.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { memo } from 'react';
+import TrackToggle from './TrackToggle';
+import Knob from './Knob';
+import Tooltip from './Tooltip';
+import { formatPan } from './trackUtils';
+
+interface TrackMixerProps {
+  trackName: string;
+  isMuted: boolean;
+  isSolo: boolean;
+  gain: number;
+  pan: number;
+  size: 'sm' | 'lg';
+  onToggleMute: () => void;
+  onToggleSolo: () => void;
+  onSetGain: (value: number) => void;
+  onSetPan: (value: number) => void;
+}
+
+/**
+ * Mute/Solo toggle buttons + gain/pan knobs.
+ * Renders in two sizes: 'sm' (mobile) and 'lg'
+ * (desktop sidebar).
+ */
+function TrackMixerInner({
+  trackName,
+  isMuted,
+  isSolo,
+  gain,
+  pan,
+  size,
+  onToggleMute,
+  onToggleSolo,
+  onSetGain,
+  onSetPan,
+}: TrackMixerProps) {
+  const knobSize = size === 'sm' ? 20 : undefined;
+
+  return (
+    <>
+      <div className="flex gap-1">
+        <TrackToggle
+          variant="mute"
+          active={isMuted}
+          trackName={trackName}
+          size={size === 'sm' ? 'lg' : 'md'}
+          onToggle={onToggleMute}
+        />
+        <TrackToggle
+          variant="solo"
+          active={isSolo}
+          trackName={trackName}
+          size={size === 'sm' ? 'lg' : 'md'}
+          onToggle={onToggleSolo}
+        />
+      </div>
+      <div
+        className={
+          'flex gap-1'
+          + (size === 'lg' ? ' ml-1' : '')
+        }
+      >
+        <Knob
+          value={gain}
+          onChange={onSetGain}
+          trackName={trackName}
+          size={knobSize}
+        />
+        <Tooltip tooltipKey="pan">
+          <Knob
+            value={pan}
+            onChange={onSetPan}
+            trackName={trackName}
+            size={knobSize}
+            defaultValue={0.5}
+            ariaPrefix="Pan"
+            formatValue={formatPan}
+          />
+        </Tooltip>
+      </div>
+    </>
+  );
+}
+
+const TrackMixer = memo(TrackMixerInner);
+export default TrackMixer;

--- a/src/app/TrackNameButton.tsx
+++ b/src/app/TrackNameButton.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+  memo, useEffect, useRef, useState,
+} from 'react';
+import type { TrackId } from './types';
+import Tooltip from './Tooltip';
+
+interface TrackNameButtonProps {
+  size: 'sm' | 'lg';
+  trackId: TrackId;
+  trackName: string;
+  isFreeRun: boolean;
+  isTriggered: boolean;
+  onToggleFreeRun: () => void;
+  onClearTrack: () => void;
+  onPlayPreview: () => void;
+}
+
+/**
+ * Track name button with optional popover menu.
+ * The popover (with free-run toggle) only renders
+ * at 'lg' size. Owns its own menu state and refs.
+ */
+function TrackNameButtonInner({
+  size,
+  trackId,
+  trackName,
+  isFreeRun,
+  isTriggered,
+  onToggleFreeRun,
+  onClearTrack,
+  onPlayPreview,
+}: TrackNameButtonProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        menuRef.current
+        && !menuRef.current.contains(
+          e.target as Node
+        )
+        && nameRef.current
+        && !nameRef.current.contains(
+          e.target as Node
+        )
+      ) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener(
+      'mousedown', handleClick
+    );
+    return () =>
+      document.removeEventListener(
+        'mousedown', handleClick
+      );
+  }, [menuOpen]);
+
+  return (
+    <div className="relative">
+      <Tooltip tooltipKey={`track-${trackId}`}>
+        <button
+          ref={size === 'lg' ? nameRef : undefined}
+          onMouseDown={(e: React.MouseEvent) => {
+            if (e.button !== 0) return;
+            if (e.shiftKey) {
+              onClearTrack();
+              return;
+            }
+            if (e.metaKey || e.ctrlKey) {
+              setMenuOpen(v => !v);
+              return;
+            }
+            onPlayPreview();
+          }}
+          onTouchStart={() => onPlayPreview()}
+          onContextMenu={(e: React.MouseEvent) => {
+            e.preventDefault();
+            setMenuOpen(v => !v);
+          }}
+          className={
+            (size === 'sm'
+              ? 'text-lg'
+              : 'w-12 truncate text-xl text-left')
+            + ' font-bold uppercase tracking-wider font-[family-name:var(--font-orbitron)]'
+            + ' rounded px-1 py-0.5 transition-colors'
+            + (isTriggered
+              ? ' text-orange-300 bg-orange-400/25'
+              : isFreeRun
+                ? ' text-orange-400 bg-orange-400/10'
+                : ' text-neutral-400'
+                  + ' hover:text-neutral-200'
+                  + ' hover:bg-neutral-800/50')
+          }
+        >
+          {trackName}
+        </button>
+      </Tooltip>
+      {menuOpen && size === 'lg' && (
+        <div
+          ref={menuRef}
+          className="absolute left-0 top-full mt-1 w-36 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl z-30 overflow-hidden"
+        >
+          <button
+            onClick={() => {
+              onToggleFreeRun();
+              setMenuOpen(false);
+            }}
+            className="w-full text-left px-3 py-2 text-xs text-neutral-200 hover:bg-neutral-800 transition-colors flex items-center justify-between"
+          >
+            <span>Free-run</span>
+            <span
+              className={
+                'inline-block w-2 h-2 rounded-full '
+                + (isFreeRun
+                  ? 'bg-orange-400'
+                  : 'bg-neutral-600')
+              }
+            />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const TrackNameButton = memo(TrackNameButtonInner);
+export default TrackNameButton;

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -1,155 +1,17 @@
 "use client";
 
-import {
-  memo, useCallback, useEffect, useRef, useState,
-} from 'react';
+import { memo, useCallback } from 'react';
 import type { RefObject } from 'react';
-import {
-  LongPressEventType, useLongPress,
-} from 'use-long-press';
 import type {
   StepConditions, StepLocks, TrackId,
 } from './types';
-import {
-  LONG_PRESS_MS, ENDBAR_LONG_PRESS_CANCEL_PX,
-} from './constants';
-import TrackToggle from './TrackToggle';
+import { computeEffectiveStep } from './trackUtils';
+import TrackNameButton from './TrackNameButton';
+import TrackMixer from './TrackMixer';
+import TrackEndBar from './TrackEndBar';
 import StepButton from './StepButton';
-import Knob from './Knob';
-import Tooltip from './Tooltip';
 
-function formatPan(v: number): string {
-  const pct = Math.round((v - 0.5) * 200);
-  if (pct === 0) return 'C';
-  return pct < 0 ? `L${-pct}` : `R${pct}`;
-}
-
-interface TrackNameButtonProps {
-  size: 'sm' | 'lg';
-  trackId: TrackId;
-  trackName: string;
-  isFreeRun: boolean;
-  isTriggered: boolean;
-  onToggleFreeRun: () => void;
-  onClearTrack: () => void;
-  onPlayPreview: () => void;
-}
-
-/**
- * Track name button with optional popover menu.
- * The popover (with free-run toggle) only renders
- * at 'lg' size. Owns its own menu state and refs.
- */
-function TrackNameButtonInner({
-  size,
-  trackId,
-  trackName,
-  isFreeRun,
-  isTriggered,
-  onToggleFreeRun,
-  onClearTrack,
-  onPlayPreview,
-}: TrackNameButtonProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const nameRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (
-        menuRef.current
-        && !menuRef.current.contains(
-          e.target as Node
-        )
-        && nameRef.current
-        && !nameRef.current.contains(
-          e.target as Node
-        )
-      ) {
-        setMenuOpen(false);
-      }
-    };
-    document.addEventListener(
-      'mousedown', handleClick
-    );
-    return () =>
-      document.removeEventListener(
-        'mousedown', handleClick
-      );
-  }, [menuOpen]);
-
-  return (
-    <div className="relative">
-      <Tooltip tooltipKey={`track-${trackId}`}>
-        <button
-          ref={size === 'lg' ? nameRef : undefined}
-          onMouseDown={(e: React.MouseEvent) => {
-            if (e.button !== 0) return;
-            if (e.shiftKey) {
-              onClearTrack();
-              return;
-            }
-            if (e.metaKey || e.ctrlKey) {
-              setMenuOpen(v => !v);
-              return;
-            }
-            onPlayPreview();
-          }}
-          onTouchStart={() => onPlayPreview()}
-          onContextMenu={(e: React.MouseEvent) => {
-            e.preventDefault();
-            setMenuOpen(v => !v);
-          }}
-          className={
-            (size === 'sm'
-              ? 'text-lg'
-              : 'w-12 truncate text-xl text-left')
-            + ' font-bold uppercase tracking-wider font-[family-name:var(--font-orbitron)]'
-            + ' rounded px-1 py-0.5 transition-colors'
-            + (isTriggered
-              ? ' text-orange-300 bg-orange-400/25'
-              : isFreeRun
-                ? ' text-orange-400 bg-orange-400/10'
-                : ' text-neutral-400'
-                  + ' hover:text-neutral-200'
-                  + ' hover:bg-neutral-800/50')
-          }
-        >
-          {trackName}
-        </button>
-      </Tooltip>
-      {menuOpen && size === 'lg' && (
-        <div
-          ref={menuRef}
-          className="absolute left-0 top-full mt-1 w-36 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl z-30 overflow-hidden"
-        >
-          <button
-            onClick={() => {
-              onToggleFreeRun();
-              setMenuOpen(false);
-            }}
-            className="w-full text-left px-3 py-2 text-xs text-neutral-200 hover:bg-neutral-800 transition-colors flex items-center justify-between"
-          >
-            <span>Free-run</span>
-            <span
-              className={
-                'inline-block w-2 h-2 rounded-full '
-                + (isFreeRun
-                  ? 'bg-orange-400'
-                  : 'bg-neutral-600')
-              }
-            />
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-const TrackNameButton = memo(TrackNameButtonInner);
-
-interface TrackRowProps {
+export interface TrackRowProps {
   trackId: TrackId;
   trackName: string;
   steps: string;
@@ -201,12 +63,8 @@ interface TrackRowProps {
 }
 
 /**
- * Single track row: name, mute/solo, knob, and step
- * buttons with a draggable length handle. Steps beyond
- * the track's length are dimmed and non-interactive.
- * Each track computes its own effective running-light
- * position for polyrhythms. Clicking the track name
- * opens a popover with per-track settings.
+ * Single track row: name, mute/solo, knobs, and step
+ * buttons with a draggable length handle.
  */
 function TrackRowInner({
   trackId,
@@ -242,6 +100,7 @@ function TrackRowInner({
   onPlainClick,
   onClearSelection,
 }: TrackRowProps) {
+  // ─── Bound callbacks ──────────────────────────
   const handleMute = useCallback(
     () => onToggleMute(trackId),
     [onToggleMute, trackId]
@@ -270,88 +129,16 @@ function TrackRowInner({
     () => onPlayPreview(trackId),
     [onPlayPreview, trackId]
   );
-
-  // ─── Drag handle state ─────────────────────────
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [isDragging, setIsDragging] = useState(false);
-
-  const endBarLongPress = useLongPress(
-    () => {
-      navigator.vibrate?.(10);
-      handleFreeRun();
-    },
-    {
-      detect: LongPressEventType.Touch,
-      threshold: LONG_PRESS_MS,
-      cancelOnMovement: ENDBAR_LONG_PRESS_CANCEL_PX,
-    }
+  const handleSetLength = useCallback(
+    (len: number) => onSetTrackLength(trackId, len),
+    [onSetTrackLength, trackId]
   );
 
-  const effectiveStep =
-    currentStep >= 0
-      ? (isFreeRun ? totalSteps : currentStep)
-        % trackLength
-      : -1;
-
-  // ─── Drag handle logic ──────────────────────────
-  const lengthFromPointer = useCallback(
-    (clientX: number): number => {
-      const grid = gridRef.current;
-      if (!grid) return trackLength;
-      const rect = grid.getBoundingClientRect();
-      const x = clientX - rect.left;
-      const stepWidth = rect.width / 16;
-      const raw = Math.round(x / stepWidth);
-      return Math.max(
-        1,
-        Math.min(
-          patternLength, raw + pageOffset
-        )
-      );
-    },
-    [patternLength, trackLength, pageOffset]
+  const effectiveStep = computeEffectiveStep(
+    currentStep, totalSteps, isFreeRun, trackLength
   );
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      if (e.button !== 0) return;
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault();
-        handleFreeRun();
-        return;
-      }
-      e.preventDefault();
-      (e.target as HTMLElement).setPointerCapture(
-        e.pointerId
-      );
-      setIsDragging(true);
-    },
-    [handleFreeRun]
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isDragging) return;
-      const len = lengthFromPointer(e.clientX);
-      if (len !== trackLength) {
-        onSetTrackLength(trackId, len);
-      }
-    },
-    [isDragging, lengthFromPointer, trackLength,
-      onSetTrackLength, trackId]
-  );
-
-  const handlePointerUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  const handleOnPage =
-    trackLength > pageOffset
-    && trackLength <= pageOffset + 16;
-  const handlePct = handleOnPage
-    ? ((trackLength - pageOffset) / 16) * 100
-    : 0;
-
+  // ─── Page-offset wrappers ─────────────────────
   const handleToggleStep = useCallback(
     (tid: TrackId, localStep: number) =>
       onToggleStep(tid, localStep + pageOffset),
@@ -396,37 +183,18 @@ function TrackRowInner({
           onPlayPreview={handlePlayPreview}
         />
         <div className="flex gap-1 ml-auto items-center">
-          <TrackToggle
-            variant="mute"
-            active={isMuted}
+          <TrackMixer
             trackName={trackName}
-            size="lg"
-            onToggle={handleMute}
+            isMuted={isMuted}
+            isSolo={isSolo}
+            gain={gain}
+            pan={pan}
+            size="sm"
+            onToggleMute={handleMute}
+            onToggleSolo={handleSolo}
+            onSetGain={handleGain}
+            onSetPan={handlePan}
           />
-          <TrackToggle
-            variant="solo"
-            active={isSolo}
-            trackName={trackName}
-            size="lg"
-            onToggle={handleSolo}
-          />
-          <Knob
-            value={gain}
-            onChange={handleGain}
-            trackName={trackName}
-            size={20}
-          />
-          <Tooltip tooltipKey="pan">
-            <Knob
-              value={pan}
-              onChange={handlePan}
-              trackName={trackName}
-              size={20}
-              defaultValue={0.5}
-              ariaPrefix="Pan"
-              formatValue={formatPan}
-            />
-          </Tooltip>
         </div>
       </div>
 
@@ -443,45 +211,23 @@ function TrackRowInner({
             onClearTrack={handleClearTrack}
             onPlayPreview={handlePlayPreview}
           />
-          <div className="flex gap-1">
-            <TrackToggle
-              variant="mute"
-              active={isMuted}
-              trackName={trackName}
-              size="md"
-              onToggle={handleMute}
-            />
-            <TrackToggle
-              variant="solo"
-              active={isSolo}
-              trackName={trackName}
-              size="md"
-              onToggle={handleSolo}
-            />
-          </div>
-          <div className="flex gap-1 ml-1">
-            <Knob
-              value={gain}
-              onChange={handleGain}
-              trackName={trackName}
-            />
-            <Tooltip tooltipKey="pan">
-              <Knob
-                value={pan}
-                onChange={handlePan}
-                trackName={trackName}
-                defaultValue={0.5}
-                ariaPrefix="Pan"
-                formatValue={formatPan}
-              />
-            </Tooltip>
-          </div>
+          <TrackMixer
+            trackName={trackName}
+            isMuted={isMuted}
+            isSolo={isSolo}
+            gain={gain}
+            pan={pan}
+            size="lg"
+            onToggleMute={handleMute}
+            onToggleSolo={handleSolo}
+            onSetGain={handleGain}
+            onSetPan={handlePan}
+          />
         </div>
 
         {/* Step grid with drag handle */}
         <div className="flex-1 relative">
           <div
-            ref={gridRef}
             data-track={trackId}
             className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
           >
@@ -540,73 +286,15 @@ function TrackRowInner({
             )}
           </div>
 
-          {/* Draggable length handle */}
-          {handleOnPage && (
-            <Tooltip tooltipKey="lengthHandle" align="right">
-              <div
-                role="slider"
-                aria-label={`${trackName} length`}
-              aria-valuemin={1}
-              aria-valuemax={patternLength}
-              aria-valuenow={trackLength}
-              tabIndex={0}
-              onPointerDown={handlePointerDown}
-              onPointerMove={handlePointerMove}
-              onPointerUp={handlePointerUp}
-              onPointerCancel={handlePointerUp}
-              {...endBarLongPress()}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                if (!isDragging) handleFreeRun();
-              }}
-              style={{
-                left: `${handlePct}%`,
-                touchAction: 'none',
-              }}
-              className={
-                'absolute top-0 h-full w-4'
-                + ' -translate-x-1/2 z-20'
-                + (isDragging
-                  ? ' cursor-col-resize'
-                  : ' cursor-default')
-                + ' before:absolute before:inset-y-0'
-                + ' before:left-1/2'
-                + ' before:-translate-x-1/2'
-                + ' before:w-1.5 before:rounded-full'
-                + ' before:transition-colors'
-                + (isDragging
-                  ? ' before:bg-neutral-300'
-                  : ' before:bg-neutral-500/60'
-                    + ' hover:before:bg-neutral-300')
-              }
-              />
-            </Tooltip>
-          )}
-
-          {/* Free-run indicator */}
-          {isFreeRun && handleOnPage && (
-            <span
-              aria-label="free run"
-              style={{
-                left: `${handlePct}%`,
-                fontFamily: 'var(--font-orbitron)',
-              }}
-              className={
-                'absolute top-1/2 -translate-x-1/2'
-                + ' -translate-y-1/2 z-30'
-                + ' pointer-events-none select-none'
-                + ' flex items-center'
-                + ' justify-center'
-                + ' w-3.5 h-3.5 rounded-full'
-                + ' bg-orange-500'
-                + ' text-[10px] font-bold'
-                + ' text-white'
-                + ' shadow-[0_0_6px_rgba(251,146,60,0.6)]'
-              }
-            >
-              F
-            </span>
-          )}
+          <TrackEndBar
+            trackName={trackName}
+            trackLength={trackLength}
+            patternLength={patternLength}
+            pageOffset={pageOffset}
+            isFreeRun={isFreeRun}
+            onSetTrackLength={handleSetLength}
+            onToggleFreeRun={handleFreeRun}
+          />
         </div>
       </div>
     </div>

--- a/src/app/trackUtils.ts
+++ b/src/app/trackUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared utilities for TrackRow and AccentRow.
+ */
+
+/**
+ * Compute the effective running-light step position,
+ * accounting for free-run mode and per-track length.
+ */
+export function computeEffectiveStep(
+  currentStep: number,
+  totalSteps: number,
+  isFreeRun: boolean,
+  trackLength: number
+): number {
+  if (currentStep < 0) return -1;
+  return (isFreeRun ? totalSteps : currentStep)
+    % trackLength;
+}
+
+/**
+ * Format a pan value (0.0–1.0) as a display string.
+ * 0.5 = "C", <0.5 = "L{pct}", >0.5 = "R{pct}".
+ */
+export function formatPan(v: number): string {
+  const pct = Math.round((v - 0.5) * 200);
+  if (pct === 0) return 'C';
+  return pct < 0 ? `L${-pct}` : `R${pct}`;
+}


### PR DESCRIPTION
## Summary

Issue #93

- Extract shared components and utilities from the 617-line `TrackRow` and 343-line `AccentRow`:
  - `TrackEndBar.tsx` (195 lines) — draggable length handle + free-run indicator, shared by both rows
  - `TrackNameButton.tsx` (133 lines) — name button with popover menu, extracted from TrackRow
  - `TrackMixer.tsx` (88 lines) — M/S toggle buttons + gain/pan knobs
  - `trackUtils.ts` (28 lines) — `computeEffectiveStep` and `formatPan` pure functions
- TrackRow shrinks from 617 to 305 lines
- AccentRow shrinks from 343 to 218 lines
- Duplicated drag handle, effectiveStep, and free-run indicator code is now shared via `TrackEndBar` and `trackUtils`

## Out of scope

StepButton/StepPopover decomposition (Phase 7) and remaining Wave 2 phases will follow as separate PRs.

## Test plan

- [x] All 488 tests pass (10 new trackUtils tests)
- [x] Existing TrackRow, AccentRow, TrackEndBar tests pass unchanged
- [x] Zero lint errors
- [x] Production build succeeds
