### PR TITLE
Improve StepButton and split StepPopover

### DIFF
--- a/src/app/CycleEditor.tsx
+++ b/src/app/CycleEditor.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { CYCLE_OPTIONS } from './trigConditions';
+
+interface CycleEditorProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+/**
+ * Cycle condition editor (a:b dropdown).
+ */
+export default function CycleEditor({
+  value,
+  onChange,
+}: CycleEditorProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange(e.target.value);
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="space-y-1">
+      <div className={
+        'text-[10px] uppercase tracking-wider'
+        + ' text-neutral-500'
+      }>
+        Cycle
+      </div>
+      <select
+        value={value}
+        onChange={handleChange}
+        className={
+          'w-full bg-neutral-800'
+          + ' text-neutral-200'
+          + ' text-sm rounded px-2 py-1.5'
+          + ' border border-neutral-700'
+          + ' focus-visible:outline-none'
+          + ' focus-visible:ring-2'
+          + ' focus-visible:ring-orange-500'
+        }
+      >
+        {CYCLE_OPTIONS.map(opt => (
+          <option key={opt.label} value={opt.label}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/app/FillConditionEditor.tsx
+++ b/src/app/FillConditionEditor.tsx
@@ -1,0 +1,63 @@
+interface FillConditionEditorProps {
+  value: 'none' | 'fill' | '!fill';
+  onChange: (v: 'none' | 'fill' | '!fill') => void;
+}
+
+/**
+ * Fill / !Fill radio group editor.
+ */
+export default function FillConditionEditor({
+  value,
+  onChange,
+}: FillConditionEditorProps) {
+  return (
+    <div className="space-y-1">
+      <div className={
+        'text-[10px] uppercase tracking-wider'
+        + ' text-neutral-500'
+      }>
+        Fill
+      </div>
+      <div
+        className="flex gap-1"
+        role="radiogroup"
+        aria-label="Fill condition"
+      >
+        {([
+          ['none', 'None'],
+          ['fill', 'FILL'],
+          ['!fill', '!FILL'],
+        ] as const).map(([val, label]) => (
+          <button
+            key={val}
+            role="radio"
+            aria-checked={value === val}
+            onClick={() => onChange(val)}
+            className={
+              'flex-1 text-xs py-1 rounded'
+              + ' border transition-colors'
+              + (value === val
+                ? val === 'fill'
+                  ? ' bg-orange-600'
+                    + ' border-orange-500'
+                    + ' text-white'
+                  : val === '!fill'
+                    ? ' bg-neutral-700'
+                      + ' border-neutral-600'
+                      + ' text-neutral-200'
+                    : ' bg-neutral-800'
+                      + ' border-neutral-600'
+                      + ' text-neutral-200'
+                : ' bg-neutral-900'
+                  + ' border-neutral-700'
+                  + ' text-neutral-400'
+                  + ' hover:bg-neutral-800')
+            }
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/ProbabilityEditor.tsx
+++ b/src/app/ProbabilityEditor.tsx
@@ -1,0 +1,29 @@
+import ProbabilitySlider from './ProbabilitySlider';
+
+interface ProbabilityEditorProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+/**
+ * Probability condition editor section.
+ */
+export default function ProbabilityEditor({
+  value,
+  onChange,
+}: ProbabilityEditorProps) {
+  return (
+    <div className="space-y-1">
+      <div className={
+        'text-[10px] uppercase tracking-wider'
+        + ' text-neutral-500'
+      }>
+        Probability
+      </div>
+      <ProbabilitySlider
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/src/app/StepBadges.tsx
+++ b/src/app/StepBadges.tsx
@@ -1,0 +1,117 @@
+/**
+ * Visual badge overlays for step buttons.
+ * Each component is a small absolutely-positioned
+ * indicator rendered inside the StepButton.
+ */
+
+interface ProbabilityBarProps {
+  probability: number;
+}
+
+export function ProbabilityBar({
+  probability,
+}: ProbabilityBarProps) {
+  return (
+    <span
+      data-testid="prob-bar"
+      className="absolute bottom-0 left-0 h-[2px]"
+      style={{
+        width: `${probability}%`,
+        background: 'rgba(255,255,255,0.85)',
+      }}
+    />
+  );
+}
+
+interface PanIndicatorProps {
+  panLock: number;
+}
+
+export function PanIndicator({
+  panLock,
+}: PanIndicatorProps) {
+  if (panLock === 0.5) {
+    return (
+      <span
+        data-testid="pan-bar"
+        className="absolute top-0 h-[2px]"
+        style={{
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: '2px',
+          background: 'rgba(255,255,255,0.85)',
+        }}
+      />
+    );
+  }
+  return (
+    <span
+      data-testid="pan-bar"
+      className="absolute top-0 h-[2px]"
+      style={{
+        ...(panLock < 0.5
+          ? {
+            right: '50%',
+            width: `${(0.5 - panLock) * 100}%`,
+          }
+          : {
+            left: '50%',
+            width: `${(panLock - 0.5) * 100}%`,
+          }),
+        background: 'rgba(255,255,255,0.85)',
+      }}
+    />
+  );
+}
+
+interface FillBadgeProps {
+  fill: 'fill' | '!fill';
+}
+
+export function FillBadge({ fill }: FillBadgeProps) {
+  return (
+    <span
+      data-testid="fill-badge"
+      className={
+        'absolute top-0 right-0.5'
+        + ' text-[8px] font-bold'
+        + ' leading-none'
+        + ' pointer-events-none'
+        + ' text-white'
+      }
+      style={{
+        fontFamily: 'var(--font-orbitron)',
+      }}
+    >
+      {fill === 'fill' ? 'F' : '!F'}
+    </span>
+  );
+}
+
+interface CycleBadgeProps {
+  a: number;
+  b: number;
+}
+
+export function CycleBadge({
+  a, b,
+}: CycleBadgeProps) {
+  return (
+    <span
+      className={
+        'absolute inset-0 flex items-center'
+        + ' justify-center text-[13px]'
+        + ' font-bold leading-none'
+        + ' pointer-events-none'
+      }
+      style={{
+        fontFamily: 'var(--font-orbitron)',
+        color: 'rgba(255,255,255,0.9)',
+        textShadow: '0 1px 2px rgba(0,0,0,0.8)',
+        letterSpacing: '0.05em',
+      }}
+    >
+      {a}:{b}
+    </span>
+  );
+}

--- a/src/app/StepButton.tsx
+++ b/src/app/StepButton.tsx
@@ -5,6 +5,13 @@ import type { RefObject } from 'react';
 import { useLongPress } from 'use-long-press';
 import type { StepConditions, TrackId } from './types';
 import { LONG_PRESS_MS, LONG_PRESS_CANCEL_PX } from './constants';
+import { getStepColor } from './stepColors';
+import {
+  ProbabilityBar,
+  PanIndicator,
+  FillBadge,
+  CycleBadge,
+} from './StepBadges';
 import Tooltip from './Tooltip';
 
 interface StepButtonProps {
@@ -42,8 +49,6 @@ interface StepButtonProps {
 /**
  * Individual step toggle button. Memoized so it only
  * re-renders when its active/current state changes.
- * Disabled steps (beyond the track's length) are dimmed
- * and non-interactive.
  */
 function StepButtonInner({
   trackId,
@@ -108,7 +113,8 @@ function StepButtonInner({
 
   const sizeClass = mini
     ? 'w-4 h-4 lg:w-5 lg:h-5' : 'h-8 lg:h-12';
-  const radiusClass = mini ? 'rounded-full' : 'rounded-sm';
+  const radiusClass = mini
+    ? 'rounded-full' : 'rounded-sm';
 
   if (isDisabled) {
     const disabledEl = (
@@ -138,24 +144,10 @@ function StepButtonInner({
     return disabledEl;
   }
 
-  let color: string;
-  if (isActive) {
-    if (isCurrent && !mini) {
-      color = 'bg-orange-400 motion-safe:scale-105'
-        + ' shadow-[0_0_20px_rgba(251,146,60,0.8)]'
-        + ' z-10';
-    } else if (isCurrent && mini) {
-      color = 'bg-orange-400';
-    } else {
-      color = 'bg-orange-600';
-    }
-  } else {
-    if (isCurrent) {
-      color = 'bg-neutral-700';
-    } else {
-      color = 'bg-neutral-800/40 hover:bg-neutral-800';
-    }
-  }
+  const color = getStepColor(
+    isActive, isCurrent, mini
+  );
+  const showBadges = !mini && isActive;
 
   const longPressHandlers = longPress();
 
@@ -190,7 +182,6 @@ function StepButtonInner({
             onPlainClick?.();
             return;
           }
-          // Clicking outside the selection clears it
           onClearSelection?.();
           handleToggle();
         }}
@@ -226,100 +217,24 @@ function StepButtonInner({
             ? ' ring-2 ring-blue-400/70' : '')
         }
       >
-        {!mini && isActive
+        {showBadges
           && conditions?.probability !== undefined
-          ? (
-            <span
-              data-testid="prob-bar"
-              className={
-                'absolute bottom-0 left-0 h-[2px]'
-              }
-              style={{
-                width: `${conditions.probability}%`,
-                background: 'rgba(255,255,255,0.85)',
-              }}
-            />
-          ) : null}
-        {!mini && isActive
+          && <ProbabilityBar
+            probability={conditions.probability}
+          />}
+        {showBadges
           && panLock !== undefined
-          ? (
-            panLock === 0.5
-              ? (
-                <span
-                  data-testid="pan-bar"
-                  className="absolute top-0 h-[2px]"
-                  style={{
-                    left: '50%',
-                    transform: 'translateX(-50%)',
-                    width: '2px',
-                    background:
-                      'rgba(255,255,255,0.85)',
-                  }}
-                />
-              )
-              : (
-                <span
-                  data-testid="pan-bar"
-                  className="absolute top-0 h-[2px]"
-                  style={{
-                    ...(panLock < 0.5
-                      ? {
-                        right: '50%',
-                        width:
-                          `${(0.5 - panLock) * 100}%`,
-                      }
-                      : {
-                        left: '50%',
-                        width:
-                          `${(panLock - 0.5) * 100}%`,
-                      }),
-                    background:
-                      'rgba(255,255,255,0.85)',
-                  }}
-                />
-              )
-          ) : null}
-        {!mini && isActive && conditions?.fill
-          ? (
-            <span
-              data-testid="fill-badge"
-              className={
-                'absolute top-0 right-0.5'
-                + ' text-[8px] font-bold'
-                + ' leading-none'
-                + ' pointer-events-none'
-                + ' text-white'
-              }
-              style={{
-                fontFamily: 'var(--font-orbitron)',
-              }}
-            >
-              {conditions.fill === 'fill'
-                ? 'F' : '!F'}
-            </span>
-          ) : null}
-        {!mini && isActive && conditions?.cycle != null
+          && <PanIndicator panLock={panLock} />}
+        {showBadges
+          && conditions?.fill
+          && <FillBadge fill={conditions.fill} />}
+        {showBadges
+          && conditions?.cycle != null
           && conditions.cycle.b >= 2
-          ? (
-            <span
-              className={
-                'absolute inset-0 flex items-center'
-                + ' justify-center text-[13px]'
-                + ' font-bold leading-none'
-                + ' pointer-events-none'
-              }
-              style={{
-                fontFamily: 'var(--font-orbitron)',
-                color: 'rgba(255,255,255,0.9)',
-                textShadow:
-                  '0 1px 2px rgba(0,0,0,0.8)',
-                letterSpacing: '0.05em',
-              }}
-            >
-              {conditions.cycle.a}
-              :{conditions.cycle.b}
-            </span>
-          ) : null}
+          && <CycleBadge
+            a={conditions.cycle.a}
+            b={conditions.cycle.b}
+          />}
       </button>
     </Tooltip>
   );

--- a/src/app/StepLockEditors.tsx
+++ b/src/app/StepLockEditors.tsx
@@ -1,0 +1,55 @@
+import RangeSlider from './RangeSlider';
+import PanSlider from './PanSlider';
+
+interface GainLockEditorProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+export function GainLockEditor({
+  value,
+  onChange,
+}: GainLockEditorProps) {
+  return (
+    <div className="space-y-1">
+      <div className={
+        'text-[10px] uppercase tracking-wider'
+        + ' text-neutral-500'
+      }>
+        Gain
+      </div>
+      <RangeSlider
+        value={value}
+        min={0}
+        max={100}
+        onChange={onChange}
+        label="Gain"
+      />
+    </div>
+  );
+}
+
+interface PanLockEditorProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+export function PanLockEditor({
+  value,
+  onChange,
+}: PanLockEditorProps) {
+  return (
+    <div className="space-y-1">
+      <div className={
+        'text-[10px] uppercase tracking-wider'
+        + ' text-neutral-500'
+      }>
+        Pan
+      </div>
+      <PanSlider
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -6,9 +6,13 @@ import {
 import type { RefObject } from 'react';
 import { useSequencer } from './SequencerContext';
 import { CYCLE_OPTIONS } from './trigConditions';
-import ProbabilitySlider from './ProbabilitySlider';
-import RangeSlider from './RangeSlider';
-import PanSlider from './PanSlider';
+import ProbabilityEditor from './ProbabilityEditor';
+import CycleEditor from './CycleEditor';
+import FillConditionEditor from './FillConditionEditor';
+import {
+  GainLockEditor,
+  PanLockEditor,
+} from './StepLockEditors';
 import type {
   StepConditions, StepLocks, TrackId,
 } from './types';
@@ -20,19 +24,15 @@ interface StepPopoverProps {
   locks?: StepLocks;
   anchorRect?: { top: number; left: number };
   onClose: () => void;
-  scrollContainerRef?: RefObject<HTMLDivElement | null>;
+  scrollContainerRef?: RefObject<
+    HTMLDivElement | null
+  >;
 }
 
 /**
- * Popover for editing per-step trig conditions.
- * Shows probability slider and cycle dropdown.
- *
- * Args:
- *   trackId: Track this condition belongs to
- *   stepIndex: Step index (0-based)
- *   conditions: Current conditions
- *   anchorRect: Position anchor
- *   onClose: Called when popover should close
+ * Popover for editing per-step trig conditions and
+ * parameter locks. Orchestrates sub-editors for
+ * probability, cycle, fill, gain, and pan.
  */
 export default function StepPopover({
   trackId,
@@ -72,6 +72,7 @@ export default function StepPopover({
   );
   const panTouched = useRef(false);
 
+  // ─── Condition sync ───────────────────────────
   const updateConditions = useCallback(
     (
       prob: number,
@@ -113,8 +114,7 @@ export default function StepPopover({
   );
 
   const handleCycleChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const v = e.target.value;
+    (v: string) => {
       setCycleValue(v);
       updateConditions(probability, v, fillValue);
     },
@@ -129,14 +129,13 @@ export default function StepPopover({
     [updateConditions, probability, cycleValue]
   );
 
+  // ─── Lock handlers ────────────────────────────
   const handleGainChange = useCallback(
     (v: number) => {
       setGainValue(v);
       gainTouched.current = true;
       actions.setParameterLock(
-        trackId,
-        stepIndex,
-        { gain: v / 100 }
+        trackId, stepIndex, { gain: v / 100 }
       );
     },
     [actions, trackId, stepIndex]
@@ -147,14 +146,13 @@ export default function StepPopover({
       setPanValue(v);
       panTouched.current = true;
       actions.setParameterLock(
-        trackId,
-        stepIndex,
-        { pan: v / 100 }
+        trackId, stepIndex, { pan: v / 100 }
       );
     },
     [actions, trackId, stepIndex]
   );
 
+  // ─── Dismiss effects ─────────────────────────
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
       if (
@@ -208,8 +206,7 @@ export default function StepPopover({
     );
   }, [anchorRect, onClose, scrollContainerRef]);
 
-  // Flip popover above anchor if it would overflow
-  // the viewport bottom.
+  // ─── Flip above if overflowing ────────────────
   const [flippedTop, setFlippedTop] = useState<
     number | null
   >(null);
@@ -218,17 +215,13 @@ export default function StepPopover({
     if (!el || !anchorRect) return;
     const rect = el.getBoundingClientRect();
     if (rect.bottom > window.innerHeight - 8) {
-      // 8px margin from viewport edge.
-      // anchorRect.top is button.bottom + 4,
-      // so button.bottom = anchorRect.top - 4.
-      // Place popover above: button.bottom - 4 - gap
-      // - popoverHeight.
       const above =
         anchorRect.top - 4 - 4 - rect.height;
       setFlippedTop(Math.max(8, above));
     }
   }, [anchorRect]);
 
+  // ─── Render ───────────────────────────────────
   return (
     <div
       ref={popoverRef}
@@ -245,6 +238,7 @@ export default function StepPopover({
         left: `${anchorRect.left}px`,
       } : undefined}
     >
+      {/* Header */}
       <div className={
         'flex items-center justify-between'
       }>
@@ -282,100 +276,23 @@ export default function StepPopover({
         </button>
       </div>
 
-      <div className="space-y-1">
-        <div className={
-          'text-[10px] uppercase tracking-wider'
-          + ' text-neutral-500'
-        }>
-          Probability
-        </div>
-        <ProbabilitySlider
-          value={probability}
-          onChange={handleProbChange}
-        />
-      </div>
-
-      <div className="space-y-1">
-        <div className={
-          'text-[10px] uppercase tracking-wider'
-          + ' text-neutral-500'
-        }>
-          Cycle
-        </div>
-        <select
-          value={cycleValue}
-          onChange={handleCycleChange}
-          className={
-            'w-full bg-neutral-800'
-            + ' text-neutral-200'
-            + ' text-sm rounded px-2 py-1.5'
-            + ' border border-neutral-700'
-            + ' focus-visible:outline-none'
-            + ' focus-visible:ring-2'
-            + ' focus-visible:ring-orange-500'
-          }
-        >
-          {CYCLE_OPTIONS.map(opt => (
-            <option key={opt.label} value={opt.label}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="space-y-1">
-        <div className={
-          'text-[10px] uppercase tracking-wider'
-          + ' text-neutral-500'
-        }>
-          Fill
-        </div>
-        <div
-          className="flex gap-1"
-          role="radiogroup"
-          aria-label="Fill condition"
-        >
-          {([
-            ['none', 'None'],
-            ['fill', 'FILL'],
-            ['!fill', '!FILL'],
-          ] as const).map(([val, label]) => (
-            <button
-              key={val}
-              role="radio"
-              aria-checked={fillValue === val}
-              onClick={() => handleFillChange(val)}
-              className={
-                'flex-1 text-xs py-1 rounded'
-                + ' border transition-colors'
-                + (fillValue === val
-                  ? val === 'fill'
-                    ? ' bg-orange-600'
-                      + ' border-orange-500'
-                      + ' text-white'
-                    : val === '!fill'
-                      ? ' bg-neutral-700'
-                        + ' border-neutral-600'
-                        + ' text-neutral-200'
-                      : ' bg-neutral-800'
-                        + ' border-neutral-600'
-                        + ' text-neutral-200'
-                  : ' bg-neutral-900'
-                    + ' border-neutral-700'
-                    + ' text-neutral-400'
-                    + ' hover:bg-neutral-800')
-              }
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <ProbabilityEditor
+        value={probability}
+        onChange={handleProbChange}
+      />
+      <CycleEditor
+        value={cycleValue}
+        onChange={handleCycleChange}
+      />
+      <FillConditionEditor
+        value={fillValue}
+        onChange={handleFillChange}
+      />
 
       {/* Divider */}
       <div className="border-t border-neutral-700" />
 
-      {/* Locks section */}
+      {/* Locks header */}
       <div className={
         'flex items-center justify-between'
       }>
@@ -413,35 +330,14 @@ export default function StepPopover({
         </button>
       </div>
 
-      <div className="space-y-1">
-        <div className={
-          'text-[10px] uppercase tracking-wider'
-          + ' text-neutral-500'
-        }>
-          Gain
-        </div>
-        <RangeSlider
-          value={gainValue}
-          min={0}
-          max={100}
-          onChange={handleGainChange}
-          label="Gain"
-        />
-      </div>
-
-      <div className="space-y-1">
-        <div className={
-          'text-[10px] uppercase tracking-wider'
-          + ' text-neutral-500'
-        }>
-          Pan
-        </div>
-        <PanSlider
-          value={panValue}
-          onChange={handlePanChange}
-        />
-      </div>
-
+      <GainLockEditor
+        value={gainValue}
+        onChange={handleGainChange}
+      />
+      <PanLockEditor
+        value={panValue}
+        onChange={handlePanChange}
+      />
     </div>
   );
 }

--- a/src/app/stepColors.ts
+++ b/src/app/stepColors.ts
@@ -1,0 +1,26 @@
+/**
+ * Step button color logic extracted as a pure function.
+ * Returns Tailwind class string for the step's
+ * background color and effects.
+ */
+export function getStepColor(
+  isActive: boolean,
+  isCurrent: boolean,
+  mini?: boolean
+): string {
+  if (isActive) {
+    if (isCurrent && !mini) {
+      return 'bg-orange-400 motion-safe:scale-105'
+        + ' shadow-[0_0_20px_rgba(251,146,60,0.8)]'
+        + ' z-10';
+    }
+    if (isCurrent && mini) {
+      return 'bg-orange-400';
+    }
+    return 'bg-orange-600';
+  }
+  if (isCurrent) {
+    return 'bg-neutral-700';
+  }
+  return 'bg-neutral-800/40 hover:bg-neutral-800';
+}


### PR DESCRIPTION
## Summary

Issue #94

- Extract step button color logic into `stepColors.ts` (`getStepColor` pure function)
- Extract badge overlays into `StepBadges.tsx` (`ProbabilityBar`, `PanIndicator`, `FillBadge`, `CycleBadge`)
- Split StepPopover condition editors into focused sub-components:
  - `ProbabilityEditor.tsx` — probability slider section
  - `CycleEditor.tsx` — cycle (a:b) dropdown
  - `FillConditionEditor.tsx` — fill/!fill radio group
  - `StepLockEditors.tsx` — gain and pan lock sliders
- StepButton: 338 → 253 lines
- StepPopover: 447 → 343 lines (state coordination stays in orchestrator)

## Out of scope

Cell ID hygiene (Phase 8), accessibility fixes (Phase 9), and remaining Wave 3 phases will follow as separate PRs.

## Test plan

- [x] All 488 tests pass (`npm test`)
- [x] Existing StepButton and StepPopover tests pass unchanged
- [x] Zero lint errors (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
