### PR TITLE
Add accessibility fixes across components

### DIFF
--- a/src/app/Sequencer.tsx
+++ b/src/app/Sequencer.tsx
@@ -48,6 +48,10 @@ function SequencerInner() {
     />
   );
 
+  const liveMessage = state.isPlaying
+    ? `Playing at ${state.bpm} BPM`
+    : 'Stopped';
+
   return (
     <div className="h-dvh overflow-hidden flex flex-col bg-neutral-950 text-neutral-100 font-sans">
       <a
@@ -56,6 +60,13 @@ function SequencerInner() {
       >
         Skip to main content
       </a>
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {liveMessage}
+      </div>
       <div className="max-w-none lg:max-w-4xl w-full mx-auto px-3 lg:px-8 pt-3 lg:pt-4 flex flex-col flex-1 min-h-0">
         <PatternPicker
           categories={categories}

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -152,7 +152,31 @@ export default function StepPopover({
     [actions, trackId, stepIndex]
   );
 
-  // ─── Dismiss effects ─────────────────────────
+  // ─── Focus management ──────────────────────────
+  const triggerRef = useRef<Element | null>(null);
+
+  // Capture triggering element and auto-focus first
+  // focusable control on mount
+  useEffect(() => {
+    triggerRef.current = document.activeElement;
+    const el = popoverRef.current;
+    if (!el) return;
+    const first = el.querySelector<HTMLElement>(
+      'button, input, select, [tabindex]'
+    );
+    first?.focus();
+  }, []);
+
+  // Restore focus to trigger on unmount
+  useEffect(() => {
+    return () => {
+      if (triggerRef.current instanceof HTMLElement) {
+        triggerRef.current.focus();
+      }
+    };
+  }, []);
+
+  // ─── Dismiss + focus trap ─────────────────────
   useEffect(() => {
     const handleMouseDown = (e: MouseEvent) => {
       if (
@@ -182,7 +206,34 @@ export default function StepPopover({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // Focus trap: cycle Tab within popover
+      if (e.key === 'Tab') {
+        const el = popoverRef.current;
+        if (!el) return;
+        const focusable = el.querySelectorAll<
+          HTMLElement
+        >(
+          'button, input, select, [tabindex]'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
     };
     document.addEventListener(
       'keydown', handleKeyDown
@@ -226,6 +277,7 @@ export default function StepPopover({
     <div
       ref={popoverRef}
       role="dialog"
+      aria-modal="true"
       aria-label="Step editor"
       className={
         'fixed z-30'

--- a/src/app/TrackNameButton.tsx
+++ b/src/app/TrackNameButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  memo, useEffect, useRef, useState,
+  memo, useCallback, useEffect, useRef, useState,
 } from 'react';
 import type { TrackId } from './types';
 import Tooltip from './Tooltip';
@@ -36,6 +36,12 @@ function TrackNameButtonInner({
   const menuRef = useRef<HTMLDivElement>(null);
   const nameRef = useRef<HTMLButtonElement>(null);
 
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+    nameRef.current?.focus();
+  }, []);
+
+  // Click-outside dismiss
   useEffect(() => {
     if (!menuOpen) return;
     const handleClick = (e: MouseEvent) => {
@@ -49,7 +55,7 @@ function TrackNameButtonInner({
           e.target as Node
         )
       ) {
-        setMenuOpen(false);
+        closeMenu();
       }
     };
     document.addEventListener(
@@ -59,13 +65,43 @@ function TrackNameButtonInner({
       document.removeEventListener(
         'mousedown', handleClick
       );
-  }, [menuOpen]);
+  }, [menuOpen, closeMenu]);
+
+  // Escape key dismiss + auto-focus first item
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        closeMenu();
+      }
+    };
+    document.addEventListener(
+      'keydown', handleKeyDown
+    );
+    // Auto-focus first menu item
+    const firstItem =
+      menuRef.current?.querySelector<HTMLElement>(
+        '[role="menuitem"]'
+      );
+    firstItem?.focus();
+    return () =>
+      document.removeEventListener(
+        'keydown', handleKeyDown
+      );
+  }, [menuOpen, closeMenu]);
 
   return (
     <div className="relative">
       <Tooltip tooltipKey={`track-${trackId}`}>
         <button
           ref={size === 'lg' ? nameRef : undefined}
+          aria-haspopup={
+            size === 'lg' ? 'menu' : undefined
+          }
+          aria-expanded={
+            size === 'lg' ? menuOpen : undefined
+          }
           onMouseDown={(e: React.MouseEvent) => {
             if (e.button !== 0) return;
             if (e.shiftKey) {
@@ -104,12 +140,15 @@ function TrackNameButtonInner({
       {menuOpen && size === 'lg' && (
         <div
           ref={menuRef}
+          role="menu"
+          aria-label={`${trackName} options`}
           className="absolute left-0 top-full mt-1 w-36 bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl z-30 overflow-hidden"
         >
           <button
+            role="menuitem"
             onClick={() => {
               onToggleFreeRun();
-              setMenuOpen(false);
+              closeMenu();
             }}
             className="w-full text-left px-3 py-2 text-xs text-neutral-200 hover:bg-neutral-800 transition-colors flex items-center justify-between"
           >

--- a/src/app/TransportControls.tsx
+++ b/src/app/TransportControls.tsx
@@ -46,6 +46,8 @@ function TransportControlsInner({
             <button
               onClick={togglePlay}
               disabled={!isLoaded}
+              aria-label={isPlaying ? 'Stop playback' : 'Start playback'}
+              aria-pressed={isPlaying}
               className={`w-20 lg:w-28 py-2 rounded-full font-bold text-sm lg:text-base text-center font-[family-name:var(--font-orbitron)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 ${isPlaying
                 ? 'bg-red-600 hover:bg-red-700 shadow-[0_0_20px_rgba(220,38,38,0.4)]'
                 : 'bg-orange-600 hover:bg-orange-700 shadow-[0_0_20px_rgba(234,88,12,0.4)]'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,15 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   animation: tap-pulse 200ms ease-out;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .animate-temp-blink {
+    animation: none;
+  }
+  .tap-flash {
+    animation: none;
+  }
+}
+
 /* Hide scrollbar but keep scroll functionality */
 @layer base {
   .hide-scrollbar {


### PR DESCRIPTION
## Summary

Issue #96

Accessibility fixes across the sequencer:

- **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables `temp-blink` and `tap-pulse` animations in `globals.css`
- **TransportControls**: Play/stop button gains `aria-label` ("Start/Stop playback") and `aria-pressed` toggle state
- **TrackNameButton**: Menu popover gains `role="menu"`, `role="menuitem"`, `aria-haspopup`, `aria-expanded`, Escape key dismiss, auto-focus first item on open, focus restore on close
- **StepPopover**: Gains `aria-modal="true"`, manual focus trap (Tab/Shift+Tab cycling within popover), auto-focus first control on open, focus restore to triggering step button on close
- **Sequencer**: Adds visually-hidden `aria-live="polite"` region announcing transport state changes (e.g., "Playing at 110 BPM", "Stopped")
- **StatusBanner**: Already had `role="alert"` (implicit `aria-live="assertive"`) — unchanged

## Test plan

- [x] All 492 tests pass (`npm test`)
- [x] Zero lint errors (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: keyboard-only navigation through all controls
- [ ] Manual: `prefers-reduced-motion` browser override check
