### PR TITLE
Add keyboard shortcuts for selected cells

### DIFF
--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  useCallback, useEffect, useRef, useState,
+  useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import type { RefObject } from 'react';
 import { TRACKS, useSequencer } from './SequencerContext';
@@ -12,7 +12,7 @@ import ErrorBoundary from './ErrorBoundary';
 import { useDragPaint } from './hooks/useDragPaint';
 import { useSelection } from './hooks/useSelection';
 import type { TrackId, TrackPattern } from './types';
-import { getPatternLength } from './types';
+import { cellKey, getPatternLength, parseCellKey } from './types';
 import { TRIGGER_FLASH_MS } from './constants';
 import trackPatternData from './data/trackPatterns.json';
 
@@ -55,6 +55,7 @@ export default function StepGrid({
     setGain, setPan, setTrackLength, toggleFreeRun,
     clearTrack, playPreview,
     clearTrigCondition, clearParameterLock,
+    setTrigCondition,
   } = actions;
   const {
     stepRef, totalStepsRef,
@@ -65,7 +66,48 @@ export default function StepGrid({
   const longPressActiveRef = useRef<boolean>(false);
   const popoverOpenRef = useRef<boolean>(false);
 
+  const [openPopover, setOpenPopover] = useState<{
+    trackId: TrackId;
+    stepIndex: number;
+    anchorRect: { top: number; left: number };
+    focusSection?: 'probability' | 'cycle';
+  } | null>(null);
+
+  useEffect(() => {
+    popoverOpenRef.current = openPopover !== null;
+  }, [openPopover]);
+
+  // Stable ref for openBulkPopover to read selection
+  const selectionRef = useRef<Set<string>>(new Set());
+
+  const openBulkPopover = useCallback(
+    (focusSection?: 'probability' | 'cycle') => {
+      const sel = selectionRef.current;
+      if (sel.size === 0) return;
+      const first = parseCellKey(
+        sel.values().next().value!
+      );
+      // Find the step button inside its track row
+      const el = document.querySelector<HTMLElement>(
+        `[data-track="${first.trackId}"]`
+        + ` [data-step="${first.step}"]`
+      );
+      const r = el?.getBoundingClientRect();
+      setOpenPopover({
+        trackId: first.trackId,
+        stepIndex: first.step,
+        anchorRect: {
+          top: (r?.bottom ?? 200) + 4,
+          left: r?.left ?? 100,
+        },
+        focusSection,
+      });
+    },
+    []
+  );
+
   const {
+    selected,
     selectedByTrack,
     ctrlClickCell,
     shiftClickCell,
@@ -81,7 +123,13 @@ export default function StepGrid({
     clearTrigCondition,
     clearParameterLock,
     toggleStep,
+    setTrigCondition,
+    openBulkPopover,
   });
+
+  useEffect(() => {
+    selectionRef.current = selected;
+  }, [selected]);
 
   // Clear selection on page change
   const prevPageRef = useRef(pageOffset);
@@ -108,15 +156,19 @@ export default function StepGrid({
     onClearSelection: clearSelection,
   });
 
-  const [openPopover, setOpenPopover] = useState<{
-    trackId: TrackId;
-    stepIndex: number;
-    anchorRect: { top: number; left: number };
-  } | null>(null);
-
-  useEffect(() => {
-    popoverOpenRef.current = openPopover !== null;
-  }, [openPopover]);
+  // When the popover's anchor cell is in the selection,
+  // apply edits to all selected cells.
+  const bulkTargets = useMemo(() => {
+    if (!openPopover) return undefined;
+    const key = cellKey(
+      openPopover.trackId, openPopover.stepIndex
+    );
+    if (!selected.has(key)) return undefined;
+    return [...selected].map(k => {
+      const { trackId, step } = parseCellKey(k);
+      return { trackId, stepIndex: step };
+    });
+  }, [openPopover, selected]);
 
   // Local state driven by rAF, isolated from the
   // context provider so only StepGrid and its children
@@ -298,6 +350,8 @@ export default function StepGrid({
           anchorRect={openPopover.anchorRect}
           onClose={() => setOpenPopover(null)}
           scrollContainerRef={scrollContainerRef}
+          bulkTargets={bulkTargets}
+          focusSection={openPopover.focusSection}
         />
         </ErrorBoundary>
       ) : null}

--- a/src/app/StepPopover.tsx
+++ b/src/app/StepPopover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  useState, useRef, useEffect, useCallback,
+  useState, useRef, useEffect, useCallback, useMemo,
 } from 'react';
 import type { RefObject } from 'react';
 import { useSequencer } from './SequencerContext';
@@ -27,6 +27,12 @@ interface StepPopoverProps {
   scrollContainerRef?: RefObject<
     HTMLDivElement | null
   >;
+  /** When set, edits apply to all targets. */
+  bulkTargets?: Array<{
+    trackId: TrackId; stepIndex: number;
+  }>;
+  /** Auto-focus this section on mount. */
+  focusSection?: 'probability' | 'cycle';
 }
 
 /**
@@ -42,9 +48,20 @@ export default function StepPopover({
   anchorRect,
   onClose,
   scrollContainerRef,
+  bulkTargets,
+  focusSection,
 }: StepPopoverProps) {
   const { actions } = useSequencer();
   const popoverRef = useRef<HTMLDivElement>(null);
+  const probRef = useRef<HTMLDivElement>(null);
+  const cycleRef = useRef<HTMLDivElement>(null);
+
+  const targets = useMemo(
+    () => bulkTargets ?? [{ trackId, stepIndex }],
+    [bulkTargets, trackId, stepIndex]
+  );
+  const isBulk = bulkTargets
+    && bulkTargets.length > 1;
 
   const [probability, setProbability] = useState(
     conditions?.probability ?? 100
@@ -92,17 +109,20 @@ export default function StepPopover({
       if (fill !== 'none') {
         sc.fill = fill;
       }
-      if (Object.keys(sc).length === 0) {
-        actions.clearTrigCondition(
-          trackId, stepIndex
-        );
-      } else {
-        actions.setTrigCondition(
-          trackId, stepIndex, sc
-        );
+      const empty = Object.keys(sc).length === 0;
+      for (const t of targets) {
+        if (empty) {
+          actions.clearTrigCondition(
+            t.trackId, t.stepIndex
+          );
+        } else {
+          actions.setTrigCondition(
+            t.trackId, t.stepIndex, sc
+          );
+        }
       }
     },
-    [actions, trackId, stepIndex]
+    [actions, targets]
   );
 
   const handleProbChange = useCallback(
@@ -134,38 +154,54 @@ export default function StepPopover({
     (v: number) => {
       setGainValue(v);
       gainTouched.current = true;
-      actions.setParameterLock(
-        trackId, stepIndex, { gain: v / 100 }
-      );
+      for (const t of targets) {
+        actions.setParameterLock(
+          t.trackId, t.stepIndex, { gain: v / 100 }
+        );
+      }
     },
-    [actions, trackId, stepIndex]
+    [actions, targets]
   );
 
   const handlePanChange = useCallback(
     (v: number) => {
       setPanValue(v);
       panTouched.current = true;
-      actions.setParameterLock(
-        trackId, stepIndex, { pan: v / 100 }
-      );
+      for (const t of targets) {
+        actions.setParameterLock(
+          t.trackId, t.stepIndex, { pan: v / 100 }
+        );
+      }
     },
-    [actions, trackId, stepIndex]
+    [actions, targets]
   );
 
   // ─── Focus management ──────────────────────────
   const triggerRef = useRef<Element | null>(null);
 
-  // Capture triggering element and auto-focus first
-  // focusable control on mount
+  // Capture triggering element and auto-focus
+  // focusSection target or first focusable control
   useEffect(() => {
     triggerRef.current = document.activeElement;
+    const sectionRef =
+      focusSection === 'probability' ? probRef
+        : focusSection === 'cycle' ? cycleRef
+          : null;
+    if (sectionRef?.current) {
+      const input =
+        sectionRef.current.querySelector<HTMLElement>(
+          'input, select, button'
+        );
+      input?.focus();
+      return;
+    }
     const el = popoverRef.current;
     if (!el) return;
     const first = el.querySelector<HTMLElement>(
       'button, input, select, [tabindex]'
     );
     first?.focus();
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Restore focus to trigger on unmount
   useEffect(() => {
@@ -298,23 +334,31 @@ export default function StepPopover({
           'text-xs font-bold uppercase'
           + ' tracking-wider text-neutral-400'
         }>
-          Step {stepIndex + 1}{' '}
-          <span className="text-neutral-500">
-            {'\u00B7'} {trackId.toUpperCase()}
-          </span>
+          {isBulk ? (
+            `${bulkTargets!.length} cells selected`
+          ) : (
+            <>
+              Step {stepIndex + 1}{' '}
+              <span className="text-neutral-500">
+                {'\u00B7'} {trackId.toUpperCase()}
+              </span>
+            </>
+          )}
         </div>
         <button
           onClick={() => {
-            actions.clearTrigCondition(
-              trackId, stepIndex
-            );
+            for (const t of targets) {
+              actions.clearTrigCondition(
+                t.trackId, t.stepIndex
+              );
+            }
             onClose();
           }}
-          disabled={conditions === undefined}
+          disabled={!isBulk && conditions === undefined}
           className={
             'text-[11px] px-1.5 py-0.5 rounded'
             + ' border transition-colors'
-            + (conditions !== undefined
+            + ((isBulk || conditions !== undefined)
               ? ' text-neutral-400'
                 + ' hover:text-neutral-200'
                 + ' border-neutral-700'
@@ -328,14 +372,18 @@ export default function StepPopover({
         </button>
       </div>
 
-      <ProbabilityEditor
-        value={probability}
-        onChange={handleProbChange}
-      />
-      <CycleEditor
-        value={cycleValue}
-        onChange={handleCycleChange}
-      />
+      <div ref={probRef}>
+        <ProbabilityEditor
+          value={probability}
+          onChange={handleProbChange}
+        />
+      </div>
+      <div ref={cycleRef}>
+        <CycleEditor
+          value={cycleValue}
+          onChange={handleCycleChange}
+        />
+      </div>
       <FillConditionEditor
         value={fillValue}
         onChange={handleFillChange}
@@ -356,19 +404,21 @@ export default function StepPopover({
         </div>
         <button
           onClick={() => {
-            actions.clearParameterLock(
-              trackId, stepIndex
-            );
+            for (const t of targets) {
+              actions.clearParameterLock(
+                t.trackId, t.stepIndex
+              );
+            }
             setGainValue(100);
             gainTouched.current = false;
             setPanValue(50);
             panTouched.current = false;
           }}
-          disabled={locks === undefined}
+          disabled={!isBulk && locks === undefined}
           className={
             'text-[11px] px-1.5 py-0.5 rounded'
             + ' border transition-colors'
-            + (locks !== undefined
+            + ((isBulk || locks !== undefined)
               ? ' text-neutral-400'
                 + ' hover:text-neutral-200'
                 + ' border-neutral-700'

--- a/src/app/hooks/useSelection.ts
+++ b/src/app/hooks/useSelection.ts
@@ -7,7 +7,9 @@ import type { RefObject } from 'react';
 import {
   cellKey, parseCellKey,
 } from '../types';
-import type { TrackConfig, TrackId } from '../types';
+import type {
+  StepConditions, TrackConfig, TrackId,
+} from '../types';
 
 interface SelectionAnchor {
   trackId: TrackId;
@@ -37,6 +39,15 @@ interface UseSelectionOptions {
   /** Toggle a single step (flip 0↔1). */
   toggleStep: (
     trackId: TrackId, stepIndex: number
+  ) => void;
+  /** Set trig conditions for a step. */
+  setTrigCondition: (
+    trackId: TrackId, stepIndex: number,
+    conditions: StepConditions
+  ) => void;
+  /** Open popover in bulk mode for selected cells. */
+  openBulkPopover: (
+    focusSection?: 'probability' | 'cycle'
   ) => void;
 }
 
@@ -82,12 +93,16 @@ export function useSelection({
   clearTrigCondition,
   clearParameterLock,
   toggleStep,
+  setTrigCondition,
+  openBulkPopover,
 }: UseSelectionOptions) {
   const [selected, setSelected] = useState<Set<string>>(
     () => new Set()
   );
   const anchorRef = useRef<SelectionAnchor | null>(null);
   const dragOriginRef = useRef<SelectionAnchor | null>(null);
+  // Uniform fill cycle: 0=none, 1=fill, 2=!fill
+  const fillCycleRef = useRef(0);
 
   // Stable refs for keyboard handler and callbacks
   const tracksRef = useRef(tracks);
@@ -107,6 +122,7 @@ export function useSelection({
     setSelected(new Set());
     anchorRef.current = null;
     dragOriginRef.current = null;
+    fillCycleRef.current = 0;
   }, []);
 
   const ctrlClickCell = useCallback(
@@ -122,6 +138,7 @@ export function useSelection({
         return next;
       });
       anchorRef.current = { trackId, step };
+      fillCycleRef.current = 0;
     },
     []
   );
@@ -144,6 +161,7 @@ export function useSelection({
         tracksRef.current,
       );
       setSelected(rect);
+      fillCycleRef.current = 0;
     },
     []
   );
@@ -155,6 +173,7 @@ export function useSelection({
       setSelected(
         new Set([cellKey(trackId, step)])
       );
+      fillCycleRef.current = 0;
     },
     []
   );
@@ -174,6 +193,7 @@ export function useSelection({
         tracksRef.current,
       );
       setSelected(rect);
+      fillCycleRef.current = 0;
     },
     []
   );
@@ -206,7 +226,45 @@ export function useSelection({
     return true;
   }, [toggleStep]);
 
-  // Keyboard listener for Escape and Delete/Backspace
+  /** Apply a fill value to all selected cells,
+   *  merging with existing conditions. */
+  const applyFillToSelected = useCallback(
+    (fill: 'fill' | '!fill' | undefined) => {
+      const cur = selectedRef.current;
+      for (const key of cur) {
+        const { trackId: tid, step } =
+          parseCellKey(key);
+        const existing =
+          tracksRef.current[tid]
+            .trigConditions?.[step];
+        if (fill === undefined) {
+          // Remove fill from conditions
+          if (!existing) continue;
+          const rest: StepConditions = {};
+          if (existing.probability !== undefined) {
+            rest.probability = existing.probability;
+          }
+          if (existing.cycle !== undefined) {
+            rest.cycle = existing.cycle;
+          }
+          if (Object.keys(rest).length === 0) {
+            clearTrigCondition(tid, step);
+          } else {
+            setTrigCondition(tid, step, rest);
+          }
+        } else {
+          setTrigCondition(tid, step, {
+            ...existing, fill,
+          });
+        }
+      }
+    },
+    [clearTrigCondition, setTrigCondition]
+  );
+
+  // Keyboard shortcuts for selection
+  // Registered in capture phase so F key can be
+  // intercepted before SequencerContext's fill handler.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -229,13 +287,101 @@ export function useSelection({
         deleteSelected();
         (document.activeElement as HTMLElement)
           ?.blur();
+        return;
+      }
+
+      // All remaining shortcuts require selection
+      if (selectedRef.current.size === 0) return;
+      if (popoverOpenRef.current) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT'
+      ) return;
+
+      // F: uniform fill cycle (none -> fill -> !fill)
+      if (
+        e.code === 'KeyF'
+        && !e.ctrlKey && !e.metaKey
+        && !e.shiftKey && !e.repeat
+      ) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        fillCycleRef.current =
+          (fillCycleRef.current + 1) % 3;
+        const fills: Array<'fill' | '!fill' | undefined> =
+          [undefined, 'fill', '!fill'];
+        applyFillToSelected(
+          fills[fillCycleRef.current]
+        );
+        return;
+      }
+
+      // Shift+F: directly set !fill
+      if (
+        e.code === 'KeyF'
+        && e.shiftKey
+        && !e.ctrlKey && !e.metaKey
+      ) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        fillCycleRef.current = 2;
+        applyFillToSelected('!fill');
+        return;
+      }
+
+      // R: clear all trig conditions + parameter locks
+      if (
+        e.code === 'KeyR'
+        && !e.ctrlKey && !e.metaKey
+        && !e.shiftKey && !e.repeat
+      ) {
+        e.preventDefault();
+        for (const key of selectedRef.current) {
+          const { trackId: tid, step } =
+            parseCellKey(key);
+          clearTrigCondition(tid, step);
+          clearParameterLock(tid, step);
+        }
+        return;
+      }
+
+      // P: open bulk popover on probability
+      if (
+        e.code === 'KeyP'
+        && !e.ctrlKey && !e.metaKey
+        && !e.shiftKey && !e.repeat
+      ) {
+        e.preventDefault();
+        openBulkPopover('probability');
+        return;
+      }
+
+      // C: open bulk popover on cycle
+      if (
+        e.code === 'KeyC'
+        && !e.ctrlKey && !e.metaKey
+        && !e.shiftKey && !e.repeat
+      ) {
+        e.preventDefault();
+        openBulkPopover('cycle');
+        return;
       }
     };
-    document.addEventListener('keydown', handler);
+    document.addEventListener(
+      'keydown', handler, true
+    );
     return () => {
-      document.removeEventListener('keydown', handler);
+      document.removeEventListener(
+        'keydown', handler, true
+      );
     };
-  }, [clearSelection, deleteSelected, popoverOpenRef]);
+  }, [
+    clearSelection, deleteSelected, popoverOpenRef,
+    applyFillToSelected, clearTrigCondition,
+    clearParameterLock, openBulkPopover,
+  ]);
 
   // Pre-compute per-track selected step sets
   const selectedByTrack = useMemo(() => {


### PR DESCRIPTION
## Summary

- Add keyboard shortcuts for bulk-editing trig conditions
  on selected cells: F (fill cycle), Shift+F (!fill),
  R (reset conditions + locks), P (probability popover),
  C (cycle popover)
- Make StepPopover selection-aware: right-clicking a
  selected cell opens the popover in bulk mode, applying
  all edits to the entire selection
- F key is context-sensitive: sets fill trig condition when
  cells are selected, acts as fill button otherwise

## Test plan

- [x] All 531 tests pass
- [x] Production build succeeds
- [x] ESLint passes with zero errors
- [ ] Select cells with Ctrl+click, press F — all show
  "F" badge
- [ ] Press F again — all show "!F" badge
- [ ] Press F again — badges cleared
- [ ] Shift+F — all show "!F" directly
- [ ] R — all trig conditions and parameter locks cleared
- [ ] P — bulk popover opens with probability focused
- [ ] C — bulk popover opens with cycle focused
- [ ] Right-click a selected cell — popover shows
  "{N} cells selected", changes apply to all
- [ ] Right-click an unselected cell — normal single-cell
  popover
- [ ] With no selection, F still works as fill button
  (momentary and Ctrl+F latch)
