### PR TITLE
Fix TrackEndBar drag using wrong element ref

### DIFF
--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useRef } from 'react';
 import type { TrackId } from './types';
 import { computeEffectiveStep } from './trackUtils';
 import TrackEndBar from './TrackEndBar';
@@ -51,6 +51,7 @@ function AccentRowInner({
   onSetGain,
   onClearTrack,
 }: AccentRowProps) {
+  const stepGridRef = useRef<HTMLDivElement>(null);
   const handleFreeRun = useCallback(
     () => onToggleFreeRun('ac'),
     [onToggleFreeRun]
@@ -164,6 +165,7 @@ function AccentRowInner({
         {/* Step grid with drag handle */}
         <div className="flex-1 relative">
           <div
+            ref={stepGridRef}
             data-track="ac"
             className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
           >
@@ -204,6 +206,7 @@ function AccentRowInner({
             patternLength={patternLength}
             pageOffset={pageOffset}
             isFreeRun={isFreeRun}
+            gridRef={stepGridRef}
             onSetTrackLength={handleSetLength}
             onToggleFreeRun={handleFreeRun}
             showTooltip={false}

--- a/src/app/TrackEndBar.tsx
+++ b/src/app/TrackEndBar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { memo, useCallback, useRef, useState } from 'react';
+import {
+  memo, useCallback, useState, type RefObject,
+} from 'react';
 import {
   LongPressEventType, useLongPress,
 } from 'use-long-press';
@@ -17,6 +19,8 @@ interface TrackEndBarProps {
   isFreeRun: boolean;
   onSetTrackLength: (length: number) => void;
   onToggleFreeRun: () => void;
+  /** Ref to the parent step-grid container. */
+  gridRef: RefObject<HTMLDivElement | null>;
   /** Show tooltip around handle (default true). */
   showTooltip?: boolean;
 }
@@ -36,10 +40,10 @@ function TrackEndBarInner({
   pageOffset,
   isFreeRun,
   onSetTrackLength,
+  gridRef,
   onToggleFreeRun,
   showTooltip = true,
 }: TrackEndBarProps) {
-  const gridRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   const endBarLongPress = useLongPress(
@@ -64,7 +68,7 @@ function TrackEndBarInner({
   const lengthFromPointer = useCallback(
     (clientX: number): number => {
       const grid = gridRef.current;
-      if (!grid) return trackLength;
+      if (!grid) return pageOffset + 1;
       const rect = grid.getBoundingClientRect();
       const x = clientX - rect.left;
       const stepWidth = rect.width / 16;
@@ -74,7 +78,7 @@ function TrackEndBarInner({
         Math.min(patternLength, raw + pageOffset)
       );
     },
-    [patternLength, trackLength, pageOffset]
+    [patternLength, pageOffset, gridRef]
   );
 
   const handlePointerDown = useCallback(
@@ -114,7 +118,6 @@ function TrackEndBarInner({
 
   const handle = (
     <div
-      ref={gridRef}
       role="slider"
       aria-label={`${trackName} length`}
       aria-valuemin={1}

--- a/src/app/TrackRow.tsx
+++ b/src/app/TrackRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
 import type {
   StepConditions, StepLocks, TrackId,
@@ -100,6 +100,7 @@ function TrackRowInner({
   onPlainClick,
   onClearSelection,
 }: TrackRowProps) {
+  const stepGridRef = useRef<HTMLDivElement>(null);
   // ─── Bound callbacks ──────────────────────────
   const handleMute = useCallback(
     () => onToggleMute(trackId),
@@ -228,6 +229,7 @@ function TrackRowInner({
         {/* Step grid with drag handle */}
         <div className="flex-1 relative">
           <div
+            ref={stepGridRef}
             data-track={trackId}
             className="grid grid-cols-8 lg:grid-cols-16 gap-[3px] lg:gap-1.5"
           >
@@ -292,6 +294,7 @@ function TrackRowInner({
             patternLength={patternLength}
             pageOffset={pageOffset}
             isFreeRun={isFreeRun}
+            gridRef={stepGridRef}
             onSetTrackLength={handleSetLength}
             onToggleFreeRun={handleFreeRun}
           />


### PR DESCRIPTION
## Summary

- When `TrackEndBar` was extracted from `TrackRow` (35ef07c), `gridRef` was
  recreated locally and attached to the drag handle itself (a 16px-wide `div`)
  instead of the parent step grid container
- `lengthFromPointer` used this ref to convert mouse position to step index, so
  it was computing against the handle's tiny bounding rect — causing the handle
  to oscillate wildly when dragged left
- `TrackEndBar` now accepts `gridRef` as a prop; both `TrackRow` and
  `AccentRow` pass their step grid container ref through

## Test plan

- [x] `npm test` — 531 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: drag a track length handle left and verify it tracks the cursor smoothly
- [ ] Manual: verify AccentRow length handle also drags correctly
