### PR TITLE
Add gap-drag cell selection

### DIFF
--- a/src/__tests__/__snapshots__/constants.test.ts.snap
+++ b/src/__tests__/__snapshots__/constants.test.ts.snap
@@ -17,6 +17,7 @@ exports[`constants snapshot 1`] = `
   "LONG_PRESS_MS": 500,
   "LOOKAHEAD_MS": 25,
   "MAX_PATTERN_LENGTH": 64,
+  "NEAREST_CELL_MAX_DISTANCE_PX": 30,
   "SCHEDULE_AHEAD_S": 0.1,
   "SWING_MAX": 100,
   "TRIGGER_FLASH_MS": 150,

--- a/src/__tests__/gridUtils.test.ts
+++ b/src/__tests__/gridUtils.test.ts
@@ -1,4 +1,6 @@
-import { bresenham, cellFromPoint } from '../app/gridUtils';
+import {
+  bresenham, cellFromPoint, nearestCellFromPoint,
+} from '../app/gridUtils';
 
 describe('bresenham', () => {
   it('yields a single point when start equals end', () => {
@@ -127,5 +129,98 @@ describe('cellFromPoint', () => {
       trackId: 'ch',
       stepIndex: 2,
     });
+  });
+});
+
+describe('nearestCellFromPoint', () => {
+  /**
+   * Helper: create a container with step elements that
+   * have mocked bounding rects nested under a data-track
+   * parent.
+   */
+  function makeGrid(
+    cells: {
+      trackId: string;
+      step: number;
+      rect: { left: number; right: number; top: number; bottom: number };
+    }[]
+  ): HTMLElement {
+    const container = document.createElement('div');
+    const trackGroups = new Map<string, HTMLElement>();
+
+    for (const c of cells) {
+      let trackEl = trackGroups.get(c.trackId);
+      if (!trackEl) {
+        trackEl = document.createElement('div');
+        trackEl.dataset.track = c.trackId;
+        container.appendChild(trackEl);
+        trackGroups.set(c.trackId, trackEl);
+      }
+      const btn = document.createElement('button');
+      btn.dataset.step = String(c.step);
+      btn.getBoundingClientRect = () => ({
+        left: c.rect.left,
+        right: c.rect.right,
+        top: c.rect.top,
+        bottom: c.rect.bottom,
+        width: c.rect.right - c.rect.left,
+        height: c.rect.bottom - c.rect.top,
+        x: c.rect.left,
+        y: c.rect.top,
+        toJSON: () => ({}),
+      });
+      trackEl.appendChild(btn);
+    }
+    return container;
+  }
+
+  it('returns nearest cell when pointer is in a gap', () => {
+    const container = makeGrid([
+      { trackId: 'bd', step: 0, rect: { left: 0, right: 40, top: 0, bottom: 32 } },
+      { trackId: 'bd', step: 1, rect: { left: 46, right: 86, top: 0, bottom: 32 } },
+    ]);
+    // Point in the 6px gap between step 0 and step 1
+    const result = nearestCellFromPoint(42, 16, container, 30);
+    expect(result).toEqual({ trackId: 'bd', stepIndex: 0 });
+  });
+
+  it('returns null when pointer is beyond max distance', () => {
+    const container = makeGrid([
+      { trackId: 'bd', step: 0, rect: { left: 0, right: 40, top: 0, bottom: 32 } },
+    ]);
+    const result = nearestCellFromPoint(200, 200, container, 30);
+    expect(result).toBeNull();
+  });
+
+  it('returns cell when pointer is inside its rect', () => {
+    const container = makeGrid([
+      { trackId: 'sd', step: 3, rect: { left: 100, right: 140, top: 0, bottom: 32 } },
+    ]);
+    const result = nearestCellFromPoint(120, 16, container, 30);
+    expect(result).toEqual({ trackId: 'sd', stepIndex: 3 });
+  });
+
+  it('walks up to find data-track from step element', () => {
+    const container = makeGrid([
+      { trackId: 'ch', step: 5, rect: { left: 0, right: 40, top: 0, bottom: 32 } },
+    ]);
+    const result = nearestCellFromPoint(20, 16, container, 30);
+    expect(result).toEqual({ trackId: 'ch', stepIndex: 5 });
+  });
+
+  it('returns nearest cell across multiple tracks', () => {
+    const container = makeGrid([
+      { trackId: 'bd', step: 0, rect: { left: 0, right: 40, top: 0, bottom: 32 } },
+      { trackId: 'sd', step: 0, rect: { left: 0, right: 40, top: 48, bottom: 80 } },
+    ]);
+    // Point in the 16px gap between rows, closer to sd
+    const result = nearestCellFromPoint(20, 44, container, 30);
+    expect(result).toEqual({ trackId: 'sd', stepIndex: 0 });
+  });
+
+  it('returns null when container has no step elements', () => {
+    const container = document.createElement('div');
+    const result = nearestCellFromPoint(20, 20, container, 30);
+    expect(result).toBeNull();
   });
 });

--- a/src/app/StepGrid.tsx
+++ b/src/app/StepGrid.tsx
@@ -254,12 +254,12 @@ export default function StepGrid({
   }, [stepRef, totalStepsRef, triggeredTracksRef, flashTriggered, setPage]);
 
   return (
-    <div className="space-y-2 lg:space-y-4 bg-neutral-900/30 p-3 lg:p-6 rounded-xl lg:rounded-2xl border border-neutral-800/50">
+    <div className="space-y-2 lg:space-y-4 bg-neutral-900/30 p-1 lg:p-2 rounded-xl lg:rounded-2xl border border-neutral-800/50">
       <div
         ref={dragContainerRef}
         style={{ touchAction: 'none' }}
         {...dragPaint}
-        className="space-y-2 lg:space-y-4 select-none"
+        className="space-y-2 lg:space-y-4 select-none p-2 lg:p-4"
       >
         {TRACKS.map(track => (
           <TrackRow

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -20,6 +20,8 @@ export const LONG_PRESS_CANCEL_PX = 5;
 export const ENDBAR_LONG_PRESS_CANCEL_PX = 1;
 /** Minimum pointer movement before starting a drag (px). */
 export const DRAG_THRESHOLD_PX = 5;
+/** Max edge-distance for nearest-cell lookup in gaps (px). */
+export const NEAREST_CELL_MAX_DISTANCE_PX = 30;
 /** Touch distance to start cycle mode (px). */
 export const CYCLE_THRESHOLD_TOUCH_PX = 10;
 /** Vertical px per step when cycling patterns. */

--- a/src/app/gridUtils.ts
+++ b/src/app/gridUtils.ts
@@ -48,6 +48,55 @@ export function cellFromPoint(
 }
 
 /**
+ * Find the nearest step button to a point by querying
+ * all [data-step] elements within a container and
+ * computing edge distance.
+ *
+ * Returns null if no cell is within maxDistance.
+ */
+export function nearestCellFromPoint(
+  clientX: number,
+  clientY: number,
+  container: HTMLElement,
+  maxDistance: number,
+): CellHit | null {
+  const steps = container.querySelectorAll<HTMLElement>(
+    '[data-step]'
+  );
+  let bestDist = Infinity;
+  let bestEl: HTMLElement | null = null;
+
+  for (const el of steps) {
+    const r = el.getBoundingClientRect();
+    const dx = Math.max(r.left - clientX, 0, clientX - r.right);
+    const dy = Math.max(r.top - clientY, 0, clientY - r.bottom);
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestEl = el;
+    }
+  }
+
+  if (!bestEl || bestDist > maxDistance) return null;
+
+  const stepIndex = Number(bestEl.dataset.step);
+
+  let node: Element | null = bestEl;
+  while (
+    node
+    && !('track' in (node as HTMLElement).dataset)
+  ) {
+    node = node.parentElement;
+  }
+  if (!node) return null;
+  const trackId = (
+    node as HTMLElement
+  ).dataset.track as TrackId;
+
+  return { trackId, stepIndex };
+}
+
+/**
  * Bresenham's line algorithm yielding all (col, row)
  * cells between two grid coordinates, inclusive of
  * both endpoints.

--- a/src/app/hooks/useDragPaint.ts
+++ b/src/app/hooks/useDragPaint.ts
@@ -7,8 +7,11 @@ import {
   DRAG_THRESHOLD_PX,
   CYCLE_THRESHOLD_TOUCH_PX,
   CYCLE_PX_PER_STEP,
+  NEAREST_CELL_MAX_DISTANCE_PX,
 } from '../constants';
-import { cellFromPoint, bresenham } from '../gridUtils';
+import {
+  cellFromPoint, nearestCellFromPoint, bresenham,
+} from '../gridUtils';
 import type { CellHit } from '../gridUtils';
 
 interface UseDragPaintOptions {
@@ -247,6 +250,48 @@ export function useDragPaint({
         return;
       }
 
+      // Gap-selection: mouse click on empty space
+      // (no cell hit, no modifiers, not touch)
+      if (
+        !hit
+        && e.pointerType === 'mouse'
+        && !e.shiftKey
+        && !popoverOpenRef?.current
+      ) {
+        // Always clear existing selection on gap click
+        onClearSelection?.();
+
+        const cont = containerRef.current;
+        const nearest = cont
+          ? nearestCellFromPoint(
+              e.clientX, e.clientY,
+              cont,
+              NEAREST_CELL_MAX_DISTANCE_PX,
+            )
+          : null;
+        if (
+          !nearest
+          || trackOrder.indexOf(nearest.trackId) === -1
+        ) {
+          return;
+        }
+
+        const drag = dragRef.current;
+        drag.active = true;
+        drag.dragged = false;
+        drag.startX = e.clientX;
+        drag.startY = e.clientY;
+        drag.pointerId = e.pointerId;
+        drag.lastTrackIdx = -1;
+        drag.lastStep = -1;
+        drag.escapeHandler = null;
+        drag.selectionMode = true;
+        drag.cyclingMode = false;
+        drag.selectionHit = null;
+        e.preventDefault();
+        return;
+      }
+
       if (!hit) return;
 
       const { trackId, stepIndex } = hit;
@@ -310,6 +355,8 @@ export function useDragPaint({
           ? '0' : '1';
     },
     [
+      containerRef,
+      trackOrder,
       tracks,
       patterns,
       onSetTrackSteps,
@@ -317,6 +364,7 @@ export function useDragPaint({
       popoverOpenRef,
       pageOffset,
       onSelectionStart,
+      onClearSelection,
     ]
   );
 
@@ -361,14 +409,24 @@ export function useDragPaint({
         const hit = cellFromPoint(
           e.clientX, e.clientY
         );
-        if (hit) {
+        const resolved = hit
+          ?? (container
+            ? nearestCellFromPoint(
+                e.clientX, e.clientY,
+                container,
+                NEAREST_CELL_MAX_DISTANCE_PX,
+              )
+            : null);
+        if (
+          resolved
+          && trackOrder.indexOf(resolved.trackId) !== -1
+          && onSelectionUpdate
+        ) {
           const globalStep =
-            hit.stepIndex + (pageOffset ?? 0);
-          if (onSelectionUpdate) {
-            onSelectionUpdate(
-              hit.trackId, globalStep
-            );
-          }
+            resolved.stepIndex + (pageOffset ?? 0);
+          onSelectionUpdate(
+            resolved.trackId, globalStep
+          );
         }
         return;
       }
@@ -483,7 +541,7 @@ export function useDragPaint({
       if (hit) paintTo(hit, drag);
     },
     [containerRef, paintTo, applyPatternAtIndex,
-      patterns, onSetTrackSteps,
+      patterns, onSetTrackSteps, trackOrder,
       onSelectionStart, onSelectionUpdate, pageOffset,
       onClearSelection]
   );


### PR DESCRIPTION
## Summary

- Add a new gesture: click+drag from gaps between cells (or slightly outside the grid) to start rectangle selection, no modifier key needed
- Add `nearestCellFromPoint()` utility that finds the closest step button by edge distance when the pointer lands in a gap
- Fall back to nearest-cell lookup during selection drag so moving through gaps updates the selection rectangle smoothly
- Redistribute padding from outer to inner drag container to expand the clickable capture area
- Mouse-only — touch devices are unaffected to avoid accidental triggers on small mobile gaps
- Clicking empty space also clears any existing selection

## Test plan

- [ ] Click+drag from gap between cells starts selection
- [ ] Click+drag from gap between rows starts selection
- [ ] Click+drag from padding outside grid starts selection
- [ ] Click+drag from sidebar-to-grid gap starts selection
- [ ] Dragging through gaps updates rectangle smoothly
- [ ] Click on a cell still toggles (paint mode)
- [ ] Ctrl/Cmd+drag still works for selection
- [ ] Shift+click range select still works
- [ ] Click on gap without dragging clears selection, does nothing else
- [ ] Touch tap/drag in gap does nothing (mouse-only)
- [ ] Gap near accent row does not select accent cells
- [ ] `npm test` passes (537 tests)
- [ ] `npm run lint` clean
- [ ] `npm run build` clean
