### PR TITLE
Fix track name tooltips not rendering

### DIFF
--- a/src/app/AccentRow.tsx
+++ b/src/app/AccentRow.tsx
@@ -86,24 +86,25 @@ function AccentRowInner({
     <div>
       {/* Mobile: label + knob above grid */}
       <div className="flex items-center gap-2 mb-1 lg:hidden">
-        <button
-          type="button"
-          title="Accent"
-          onClick={(e) => {
-            if (e.shiftKey) handleClear();
-          }}
-          className={
-            'text-lg font-bold uppercase'
-            + ' tracking-wider rounded px-1 py-0.5'
-            + ' transition-colors cursor-pointer'
-            + ' font-[family-name:var(--font-orbitron)]'
-            + (isFreeRun
-              ? ' text-orange-400'
-              : ' text-neutral-400')
-          }
-        >
-          AC
-        </button>
+        <Tooltip tooltipKey="track-ac">
+          <button
+            type="button"
+            onClick={(e) => {
+              if (e.shiftKey) handleClear();
+            }}
+            className={
+              'text-lg font-bold uppercase'
+              + ' tracking-wider rounded px-1 py-0.5'
+              + ' transition-colors cursor-pointer'
+              + ' font-[family-name:var(--font-orbitron)]'
+              + (isFreeRun
+                ? ' text-orange-400'
+                : ' text-neutral-400')
+            }
+          >
+            AC
+          </button>
+        </Tooltip>
         <div className="ml-auto">
           <Tooltip
             tooltipKey="accentIntensity"
@@ -123,25 +124,28 @@ function AccentRowInner({
       <div className="flex gap-4 items-center">
         {/* Desktop: sidebar with label + knob */}
         <div className="hidden lg:flex w-56 items-center gap-2">
-          <button
-            type="button"
-            title="Accent"
-            onClick={(e) => {
-              if (e.shiftKey) handleClear();
-            }}
-            className={
-              'w-12 truncate text-xl text-left'
-              + ' font-bold uppercase tracking-wider'
-              + ' rounded px-1 py-0.5 transition-colors'
-              + ' cursor-pointer'
-              + ' font-[family-name:var(--font-orbitron)]'
-              + (isFreeRun
-                ? ' text-orange-400'
-                : ' text-neutral-400')
-            }
-          >
-            AC
-          </button>
+          <Tooltip tooltipKey="track-ac">
+            <div>
+              <button
+                type="button"
+                onClick={(e) => {
+                  if (e.shiftKey) handleClear();
+                }}
+                className={
+                  'w-12 truncate text-xl text-left'
+                  + ' font-bold uppercase tracking-wider'
+                  + ' rounded px-1 py-0.5 transition-colors'
+                  + ' cursor-pointer'
+                  + ' font-[family-name:var(--font-orbitron)]'
+                  + (isFreeRun
+                    ? ' text-orange-400'
+                    : ' text-neutral-400')
+                }
+              >
+                AC
+              </button>
+            </div>
+          </Tooltip>
           {/* Spacer matching mute + solo widths */}
           <div className="flex gap-1">
             <div className="w-6 h-6" />

--- a/src/app/TrackNameButton.tsx
+++ b/src/app/TrackNameButton.tsx
@@ -92,8 +92,8 @@ function TrackNameButtonInner({
   }, [menuOpen, closeMenu]);
 
   return (
-    <div className="relative">
-      <Tooltip tooltipKey={`track-${trackId}`}>
+    <Tooltip tooltipKey={`track-${trackId}`}>
+      <div className="relative">
         <button
           ref={size === 'lg' ? nameRef : undefined}
           aria-haspopup={
@@ -136,7 +136,6 @@ function TrackNameButtonInner({
         >
           {trackName}
         </button>
-      </Tooltip>
       {menuOpen && size === 'lg' && (
         <div
           ref={menuRef}
@@ -164,7 +163,8 @@ function TrackNameButtonInner({
           </button>
         </div>
       )}
-    </div>
+      </div>
+    </Tooltip>
   );
 }
 

--- a/src/app/data/tooltips.json
+++ b/src/app/data/tooltips.json
@@ -22,6 +22,7 @@
   "track-lt": "Low Tom",
   "track-rs": "Rimshot",
   "track-cp": "Clap",
+  "track-ac": "Accent",
   "track-cb": "Cowbell",
   "lengthHandle": "Drag to set track length",
   "follow": "Auto-follow playhead during playback",


### PR DESCRIPTION
## Summary

- Fix track name tooltips being clipped by `overflow: hidden` from Tailwind's `truncate` class — move `<Tooltip>` wrapper from the `<button>` to its parent `<div>` so the absolutely-positioned tooltip span isn't clipped
- Wire up the accent row's AC label with the `<Tooltip>` component (previously used a bare `title` attribute)
- Add missing `track-ac` entry to `tooltips.json`

## Test plan

- [x] Lint passes
- [x] All 537 tests pass
- [x] Production build succeeds
- [ ] Hover over any track name (BD, SD, CH, etc.) — tooltip appears above after ~1s delay
- [ ] Hover over AC label — tooltip appears above, consistent with other tracks