### PR TITLE
Fix track length handle freezing mid-drag (#116)

### DIFF
--- a/src/__tests__/TrackEndBar.test.tsx
+++ b/src/__tests__/TrackEndBar.test.tsx
@@ -139,4 +139,24 @@ describe('TrackEndBar', () => {
       ).toBe('12');
     }
   );
+
+  it(
+    'pointerdown on handle does not bubble to parent'
+    + ' (would otherwise trigger gap-drag selection)',
+    () => {
+      const parentDown = vi.fn();
+      render(
+        <div onPointerDown={parentDown}>
+          <TrackRow {...base} />
+        </div>
+      );
+      const slider = screen.getByRole('slider', {
+        name: 'BD length',
+      });
+      fireEvent.pointerDown(slider, {
+        pointerId: 1, button: 0,
+      });
+      expect(parentDown).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/app/TrackEndBar.tsx
+++ b/src/app/TrackEndBar.tsx
@@ -84,6 +84,10 @@ function TrackEndBarInner({
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       if (e.button !== 0) return;
+      // Stop propagation so the parent grid's
+      // drag-paint / gap-selection handler doesn't
+      // also claim this pointer and steal capture.
+      e.stopPropagation();
       if (e.ctrlKey || e.metaKey) {
         e.preventDefault();
         onToggleFreeRun();


### PR DESCRIPTION
Closes #116

## Summary

The track length adjustment handles froze after the very first
move event of any drag, so cell-by-cell adjustment was
impossible.

The handle's `pointerdown` bubbled to the parent grid, where
the gap-drag selection added in #114 also claimed the gesture
and eventually called `setPointerCapture` on the grid container,
stealing capture from the handle. Subsequent `pointermove`
events fired on the parent only, so the handle's length-update
logic stopped running. (Large single-shot drags worked because
the lone move event landed at its final x before capture was
stolen.)

Fix: stop propagation in `TrackEndBar`'s `pointerdown` so the
parent's drag handler never sees the gesture.

## Out-of-scope context for reviewers

- The issue was introduced by #114 (gap-drag cell selection),
  not by `TrackEndBar` itself — but the handle was already
  riding the parent's pointer-capture quirks, so stopping
  propagation at the handle is the localized fix and avoids
  reshaping the gap-selection logic.
- The handle's right-click toggle for free-run and the touch
  long-press for free-run still work — `contextmenu` and the
  long-press hook are unchanged.

## Test plan

- [x] Unit: new regression test asserts `pointerdown` on the
      handle does not bubble to its parent
- [x] Full vitest: 538 tests pass, 0 failures
- [x] `npm run lint`: clean
- [x] `npm run build`: clean
- [x] Manual (Playwright on local dev server): pixel-by-pixel
      drag of BD length handle decrements length 16 → 15 → 14
      → 9; no leaked rectangle selection
- [x] Manual: drag-paint across cells still works (regression
      check)
- [x] Manual: gap-drag selection still works (regression check
      for the #114 feature)
